### PR TITLE
Add PDF URL to Webhook "All Fields" Request Body

### DIFF
--- a/src/Controller/Controller_Form_Settings.php
+++ b/src/Controller/Controller_Form_Settings.php
@@ -169,6 +169,9 @@ class Controller_Form_Settings extends Helper_Abstract_Controller implements Hel
 
 		/* Update our PDF settings before the form gets updated */
 		add_filter( 'gform_form_update_meta', [ $this, 'clear_cached_pdf_settings' ], 10, 2 );
+
+		/* Integrate PDFs into Addon Settings */
+		add_filter( 'gform_webhooks_request_data', [ $this->model, 'webhook_request_data' ], 10, 3 );
 	}
 
 	/**

--- a/src/Model/Model_Form_Settings.php
+++ b/src/Model/Model_Form_Settings.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Model_Welcome_Screen
+ * Model_Form_Settings
  *
  * A general class for About / Intro Screen
  *
@@ -1007,5 +1007,25 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* end AJAX function */
 		wp_die();
+	}
+
+	/**
+	 * Include the Gravity PDF URLs in the "All Fields" Webhook request
+	 *
+	 * @since 6.0
+	 */
+	public function webhook_request_data( array $request_data, array $feed, array $entry ): array {
+		if ( $feed['meta']['requestBodyType'] !== 'all_fields' ) {
+			return $request_data;
+		}
+
+		$model_pdf = \GPDFAPI::get_mvc_class( 'Model_PDF' );
+		$pdfs      = $model_pdf->get_pdf_display_list( $entry );
+
+		foreach ( $pdfs as $pdf ) {
+			$request_data[ 'gpdf_' . $pdf['settings']['id'] ] = $pdf['view'];
+		}
+
+		return $request_data;
 	}
 }

--- a/tests/phpunit/unit-tests/Model/TestWebhook.php
+++ b/tests/phpunit/unit-tests/Model/TestWebhook.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace GFPDF\Model;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class TestWebhook
+ *
+ * @package GFPDF\Model\Model_Form_Settings
+ *
+ * @group   model
+ * @group   form-settings
+ */
+class TestWebhook extends \WP_UnitTestCase {
+
+	/**
+	 * Test we add the PDF URLs to the Webhook request data when the request type is "all_fields"
+	 */
+	public function test_webhook_request_data_all_fields() {
+		$feed         = [ 'meta' => [ 'requestBodyType' => 'all_fields' ] ];
+		$entry        = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$request_data = $entry;
+
+		$request_data = apply_filters( 'gform_webhooks_request_data', $request_data, $feed, $entry );
+
+		$this->assertArrayHasKey( 'gpdf_556690c67856b', $request_data );
+		$this->assertStringContainsString( 'http://example.org/?gpdf=1', $request_data['gpdf_556690c67856b'] );
+
+		$this->assertArrayHasKey( 'gpdf_fawf90c678523b', $request_data );
+		$this->assertStringContainsString( 'http://example.org/?gpdf=1', $request_data['gpdf_fawf90c678523b'] );
+	}
+
+	/**
+	 * Test that we do nothing if the request type isn't "all_fields"
+	 */
+	public function test_webhook_request_data_select_fields() {
+		$feed         = [ 'meta' => [ 'requestBodyType' => 'select_fields' ] ];
+		$entry        = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$request_data = $entry;
+
+		$request_data = apply_filters( 'gform_webhooks_request_data', $request_data, $feed, $entry );
+
+		$this->assertSame( $entry, $request_data );
+		$this->assertArrayNotHasKey( 'gpdf_556690c67856b', $request_data );
+	}
+
+}


### PR DESCRIPTION
## Description

Resolves #1066

## Testing instructions
1. Install the Webhooks plugin
1. Setup a Webhook feed on a Form with PDFs configured and use the "All Fields" option in the "Request Body"
1. Enable Gravity Forms Debug Mode
1. Submit an entry on the form with the new webhook
1. View the Webhook log file and verify the PDF URLs are included in the response.

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
