### PR TITLE
Add Export Entry PDF Support

### DIFF
--- a/src/Controller/Controller_Export_Entries.php
+++ b/src/Controller/Controller_Export_Entries.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace GFPDF\Controller;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Controller_Export_Entries
+ *
+ * @package GFPDF\Controller
+ */
+class Controller_Export_Entries {
+
+	/**
+	 * @since 6.0
+	 */
+	public function init(): void {
+		add_filter( 'gform_export_fields', [ $this, 'add_pdfs_to_export_fields' ] );
+		add_filter( 'gform_export_field_value', [ $this, 'get_export_field_value' ], 10, 4 );
+	}
+
+	/**
+	 * Include active PDFs for the form in the Entry Export list
+	 *
+	 * @since 6.0
+	 */
+	public function add_pdfs_to_export_fields( array $form ): array {
+		$pdfs = \GPDFAPI::get_form_pdfs( $form['id'] );
+
+		if ( is_wp_error( $pdfs ) ) {
+			return $form;
+		}
+
+		foreach ( $pdfs as $pdf ) {
+			$form['fields'][] = [
+				'id'    => 'gpdf_' . $pdf['id'],
+				'label' => sprintf( __( 'PDF: %s', 'gravity-forms-pdf-extended' ), $pdf['name'] ),
+			];
+		}
+
+		return $form;
+	}
+
+	/**
+	 * If exporting a PDF, get the URL for the entry (if valid)
+	 *
+	 * @param string           $value
+	 * @param int              $form_id
+	 * @param string|int|float $field_id
+	 *
+	 * @return string The URL, or an empty string
+	 *
+	 * @since 6.0
+	 */
+	public function get_export_field_value( $value, int $form_id, $field_id, array $entry ) {
+		if ( substr( $field_id, 0, 5 ) !== 'gpdf_' ) {
+			return $value;
+		}
+
+		$pdf_id = substr( $field_id, 5 );
+
+		$shortcode = apply_filters(
+			'gfpdf_export_pdf_shortcode',
+			sprintf(
+				'[gravitypdf id="%1$s" entry="%2$d" raw="1" type="%3$s"]',
+				$pdf_id,
+				$entry['id'] ?? '',
+				'view'
+			),
+			$pdf_id,
+			$entry
+		);
+
+		return do_shortcode( $shortcode );
+	}
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -222,6 +222,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$this->load_custom_font_handler();
 		$this->load_debug();
 		$this->check_system_status();
+		$this->export();
 
 		/* Add localisation support */
 		$this->add_localization_support();
@@ -851,6 +852,16 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 */
 	public function check_system_status() {
 		$class = new Controller\Controller_System_Report( $this->data->allow_url_fopen );
+		$class->init();
+
+		$this->singleton->add_class( $class );
+	}
+
+	/**
+	 * @since 6.0
+	 */
+	public function export(): void {
+		$class = new Controller\Controller_Export_Entries();
 		$class->init();
 
 		$this->singleton->add_class( $class );

--- a/tests/phpunit/unit-tests/Controller/TestControllerExportEntries.php
+++ b/tests/phpunit/unit-tests/Controller/TestControllerExportEntries.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class TestControllerSystemReport
+ *
+ * @package GFPDF\Controller
+ *
+ * @group   controller
+ * @group   export
+ */
+class TestControllerExportEntries extends WP_UnitTestCase {
+	public function test_add_pdfs_to_export_fields() {
+		$form = apply_filters( 'gform_export_fields', $GLOBALS['GFPDF_Test']->form['all-form-fields'] );
+
+		$field_ids = array_column( $form['fields'], 'id' );
+
+		$this->assertContains( 'gpdf_555ad84787d7e', $field_ids );
+		$this->assertContains( 'gpdf_556690c67856b', $field_ids );
+		$this->assertContains( 'gpdf_fawf90c678523b', $field_ids );
+		$this->assertContains( 'gpdf_556690c8d7f82', $field_ids );
+	}
+
+	public function test_no_add_pdfs_to_export_fields() {
+		$form = [ 'id' => 0 ];
+
+		$this->assertSame( $form, apply_filters( 'gform_export_fields', $form ) );
+	}
+
+	public function test_get_export_field_unrelated_value() {
+		$value = 'item';
+		$this->assertSame( $value, apply_filters( 'gform_export_field_value', $value, 1, '', [] ) );
+	}
+
+	public function test_get_export_field_empty_pdf_value_if_failed_conditional_logic() {
+		$form_id  = $GLOBALS['GFPDF_Test']->form['all-form-fields']['id'];
+		$entry    = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$field_id = 'gpdf_555ad84787d7e';
+		$this->assertEmpty( apply_filters( 'gform_export_field_value', 'item', $form_id, $field_id, $entry ) );
+	}
+
+	public function test_get_export_field_pdf_value() {
+		$form_id  = $GLOBALS['GFPDF_Test']->form['all-form-fields']['id'];
+		$entry    = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$field_id = 'gpdf_556690c67856b';
+		$this->assertStringContainsString( 'http://example.org/?gpdf=1', apply_filters( 'gform_export_field_value', 'item', $form_id, $field_id, $entry ) );
+	}
+
+	public function test_get_export_field_empty_value() {
+		$form_id  = $GLOBALS['GFPDF_Test']->form['all-form-fields']['id'];
+		$field_id = 'gpdf_555ad84787d7e';
+		$this->assertEmpty( apply_filters( 'gform_export_field_value', 'item', $form_id, $field_id, [] ) );
+	}
+}


### PR DESCRIPTION
## Description

This code adds any active PDFs to the Forms -> Export -> Export Entries page when you select a supported Gravity Form, and then converts that to the appropriate URL in the exported CSV file.

Resolves #961

## Testing instructions
1. Navigate to /wp-admin/admin.php?page=gf_export 
1. Select a form with PDFs setup on it
1. Select the PDF(s) in the field list
1. View CSV and see it includes the PDF URL(s)

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
