### PR TITLE
Add GPDFAPI::get_entry_pdfs() endpoint

### DIFF
--- a/api.php
+++ b/api.php
@@ -237,7 +237,7 @@ final class GPDFAPI {
 	 *
 	 * See https://gravitypdf.com/documentation/v5/api_get_form_pdfs/ for more information about this method
 	 *
-	 * @param  integer $form_id The Gravity Form ID
+	 * @param  int $form_id The Gravity Form ID
 	 *
 	 * @return array|WP_Error Array of PDF settings or WP_Error
 	 *
@@ -247,6 +247,36 @@ final class GPDFAPI {
 		$options = static::get_options_class();
 
 		return $options->get_form_pdfs( $form_id );
+	}
+
+	/**
+	 * Gets a list of current PDFs setup for a particular Entry
+	 * This differs from \GPDFAPI::get_form_pdfs() as it'll filter out any PDFs that don't pass the conditional logic
+	 * for the current entry.
+	 *
+	 * See https://gravitypdf.com/documentation/v5/@TODO/ for more information about this method
+	 *
+	 * @param int $entry_id The Gravity Forms Entry ID
+	 *
+	 * @return array|WP_Error Array of PDFs available to the entry or WP_Error
+	 *
+	 * @since 6.0
+	 */
+	public static function get_entry_pdfs( $entry_id ) {
+		$form_class = static::get_form_class();
+
+		/* Get our entry */
+		$entry = $form_class->get_entry( $entry_id );
+
+		if ( is_wp_error( $entry ) ) {
+			return new WP_Error( 'invalid_entry', esc_html__( 'Make sure to pass in a valid Gravity Forms Entry ID', 'gravity-forms-pdf-extended' ) );
+		}
+
+		/** @var \GFPDF\Model\Model_PDF $model_pdf */
+		$model_pdf = static::get_mvc_class( 'Model_PDF' );
+		$pdfs      = static::get_form_pdfs( $entry['form_id'] );
+
+		return $model_pdf->get_active_pdfs( $pdfs, $entry );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/test-api.php
+++ b/tests/phpunit/unit-tests/test-api.php
@@ -60,6 +60,33 @@ class Test_API extends WP_UnitTestCase {
 	 */
 	public function test_get_form_pdfs() {
 		$this->assertTrue( is_wp_error( GPDFAPI::get_form_pdfs( null ) ) );
+
+		$pdfs = GPDFAPI::get_form_pdfs( $GLOBALS['GFPDF_Test']->form['all-form-fields']['id'] );
+		$this->assertCount( 4, $pdfs );
+
+		$this->assertArrayHasKey( 'id', $pdfs['555ad84787d7e'] );
+		$this->assertArrayHasKey( 'filename', $pdfs['555ad84787d7e'] );
+		$this->assertArrayHasKey( 'template', $pdfs['555ad84787d7e'] );
+		$this->assertArrayHasKey( 'notification', $pdfs['555ad84787d7e'] );
+		$this->assertArrayHasKey( 'conditionalLogic', $pdfs['555ad84787d7e'] );
+	}
+
+	/**
+	 * Check we can get a form's PDF settings
+	 *
+	 * @since 6.0
+	 */
+	public function test_get_entry_pdfs() {
+		$this->assertTrue( is_wp_error( GPDFAPI::get_entry_pdfs( null ) ) );
+
+		$pdfs = GPDFAPI::get_entry_pdfs( $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0]['id'] );
+		$this->assertCount( 2, $pdfs );
+
+		$this->assertArrayHasKey( 'id', $pdfs['fawf90c678523b'] );
+		$this->assertArrayHasKey( 'filename', $pdfs['fawf90c678523b'] );
+		$this->assertArrayHasKey( 'template', $pdfs['fawf90c678523b'] );
+		$this->assertArrayHasKey( 'notification', $pdfs['fawf90c678523b'] );
+		$this->assertArrayHasKey( 'conditionalLogic', $pdfs['fawf90c678523b'] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

It's like GPDFAPI::get_form_pdfs(), but filters out any PDFs that don't pass conditional logic checks for the current entry.

Resolves #1092

## Testing instructions
Usage: `\GPDFAPI::get_entry_pdfs( $entry_id )`

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
