### PR TITLE
Inject current PDF Settings into the Template Config class

### DIFF
--- a/src/Helper/Helper_Abstract_Config_Settings.php
+++ b/src/Helper/Helper_Abstract_Config_Settings.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace GFPDF\Helper;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Helper_Abstract_Config_Settings
+ *
+ * @package GFPDF\Helper
+ */
+abstract class Helper_Abstract_Config_Settings implements Helper_Interface_Config_Settings {
+
+	/**
+	 * @var array Holds the current PDF settings
+	 * @since 6.0
+	 */
+	protected $settings = [];
+
+	/**
+	 * Setter
+	 *
+	 * @since 6.0
+	 */
+	public function set_settings( array $settings ) {
+		$this->settings = $settings;
+	}
+
+	/**
+	 * Getter
+	 *
+	 * @since 6.0
+	 */
+	public function get_settings(): array {
+		return $this->settings;
+	}
+}

--- a/src/Helper/Helper_Interface_Config_Settings.php
+++ b/src/Helper/Helper_Interface_Config_Settings.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace GFPDF\Helper;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Helper_Interface_Config_Settings
+ *
+ * @package GFPDF\Helper
+ */
+interface Helper_Interface_Config_Settings {
+
+	/**
+	 * Setter
+	 *
+	 * @since 6.0
+	 */
+	public function set_settings( array $settings );
+
+	/**
+	 * Getter
+	 *
+	 * @since 6.0
+	 */
+	public function get_settings(): array;
+}

--- a/src/Helper/Helper_Templates.php
+++ b/src/Helper/Helper_Templates.php
@@ -584,7 +584,7 @@ class Helper_Templates {
 			require_once( $file );
 		}
 
-		/* Insure the class we are trying to load exists and implements our Helper_Interface_Config interface */
+		/* Insure the class we are trying to load exists */
 		if ( class_exists( $fqcn ) ) {
 			return new $fqcn();
 		}
@@ -696,15 +696,20 @@ class Helper_Templates {
 		/* Disable the field encryption checks which can slow down our entry queries */
 		add_filter( 'gform_is_encrypted_field', '__return_false' );
 
+		/* Inject the settings into our config object, if requested */
+		if ( $config instanceof Helper_Interface_Config_Settings ) {
+			$config->set_settings( $settings );
+		}
+
 		/* See https://gravitypdf.com/documentation/v5/gfpdf_template_args/ for more details about this filter */
 
 		return apply_filters(
 			'gfpdf_template_args',
 			[
 
-				'form_id'   => $form['id'], /* backwards compat */
-				'lead_ids'  => $legacy_ids, /* backwards compat */
-				'lead_id'   => apply_filters( 'gfpdfe_lead_id', $entry['id'], $form, $entry, $gfpdf ), /* backwards compat */
+				'form_id'  => $form['id'], /* backwards compat */
+				'lead_ids' => $legacy_ids, /* backwards compat */
+				'lead_id'  => apply_filters( 'gfpdfe_lead_id', $entry['id'], $form, $entry, $gfpdf ), /* backwards compat */
 
 				'form'      => $form,
 				'entry'     => $entry,

--- a/src/templates/config/blank-slate.php
+++ b/src/templates/config/blank-slate.php
@@ -2,6 +2,7 @@
 
 namespace GFPDF\Templates\Config;
 
+use GFPDF\Helper\Helper_Abstract_Config_Settings;
 use GFPDF\Helper\Helper_Interface_Config;
 
 /**
@@ -35,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 4.0
  */
-class Blank_Slate implements Helper_Interface_Config {
+class Blank_Slate extends Helper_Abstract_Config_Settings implements Helper_Interface_Config {
 
 	/**
 	 * Return the templates configuration structure which control what extra fields will be shown in the "Template" tab when configuring a form's PDF.

--- a/src/templates/config/focus-gravity.php
+++ b/src/templates/config/focus-gravity.php
@@ -2,6 +2,7 @@
 
 namespace GFPDF\Templates\Config;
 
+use GFPDF\Helper\Helper_Abstract_Config_Settings;
 use GFPDF\Helper\Helper_Interface_Config;
 
 /**
@@ -35,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 4.0
  */
-class Focus_Gravity implements Helper_Interface_Config {
+class Focus_Gravity extends Helper_Abstract_Config_Settings implements Helper_Interface_Config {
 
 	/**
 	 * Return the templates configuration structure which control what extra fields will be shown in the "Template" tab when configuring a form's PDF.
@@ -69,7 +70,7 @@ class Focus_Gravity implements Helper_Interface_Config {
 
 			/* Create custom fields to control the look and feel of a template */
 			'fields' => [
-				'focusgravity_accent_colour'    => [
+				'focusgravity_accent_colour' => [
 					'id'   => 'focusgravity_accent_colour',
 					'name' => esc_html__( 'Accent Color', 'gravity-forms-pdf-extended' ),
 					'type' => 'color',
@@ -85,7 +86,7 @@ class Focus_Gravity implements Helper_Interface_Config {
 					'std'  => '#eaf2fa',
 				],
 
-				'focusgravity_label_format'     => [
+				'focusgravity_label_format' => [
 					'id'      => 'focusgravity_label_format',
 					'name'    => esc_html__( 'Format', 'gravity-forms-pdf-extended' ),
 					'type'    => 'radio',

--- a/src/templates/config/rubix.php
+++ b/src/templates/config/rubix.php
@@ -2,6 +2,7 @@
 
 namespace GFPDF\Templates\Config;
 
+use GFPDF\Helper\Helper_Abstract_Config_Settings;
 use GFPDF\Helper\Helper_Interface_Config;
 
 /**
@@ -29,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 4.0
  */
-class Rubix implements Helper_Interface_Config {
+class Rubix extends Helper_Abstract_Config_Settings implements Helper_Interface_Config {
 
 	/**
 	 * Return the templates configuration structure which control what extra fields will be shown in the "Template" tab when configuring a form's PDF.

--- a/src/templates/config/zadani.php
+++ b/src/templates/config/zadani.php
@@ -2,6 +2,7 @@
 
 namespace GFPDF\Templates\Config;
 
+use GFPDF\Helper\Helper_Abstract_Config_Settings;
 use GFPDF\Helper\Helper_Interface_Config;
 
 /**
@@ -29,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 4.0
  */
-class Zadani implements Helper_Interface_Config {
+class Zadani extends Helper_Abstract_Config_Settings implements Helper_Interface_Config {
 
 	/**
 	 * Return the templates configuration structure which control what extra fields will be shown in the "Template" tab when configuring a form's PDF.

--- a/tests/phpunit/unit-tests/test-helper-templates.php
+++ b/tests/phpunit/unit-tests/test-helper-templates.php
@@ -498,17 +498,20 @@ class Test_Templates_Helper extends WP_UnitTestCase {
 
 		/* Sniff that our keys have the correct details */
 		$this->assertEquals( $entry['form_id'], $data['form_id'] );
-		$this->assertEquals( $entry['id'], $data['lead_id'] );
-		$this->assertEquals( [ $entry['id'] ], $data['lead_ids'] );
-		$this->assertTrue( is_array( $data['form'] ) );
-		$this->assertTrue( is_array( $data['entry'] ) );
-		$this->assertTrue( is_array( $data['lead'] ) );
-		$this->assertTrue( is_array( $data['form_data'] ) );
-		$this->assertEquals( $data['entry'], $data['lead'] );
-		$this->assertEquals( $pdf, $data['settings'] );
-		$this->assertEquals( 'GFPDF\Router', get_class( $data['gfpdf'] ) );
-		$this->assertTrue( is_array( $data['fields'] ) );
-		$this->assertEquals( 'GF_Field_Checkbox', get_class( $data['fields'][47] ) );
-		$this->assertEquals( 'GFPDF\Templates\Config\Zadani', get_class( $data['config'] ) );
+		$this->assertSame( $entry['id'], $data['lead_id'] );
+		$this->assertSame( [ $entry['id'] ], $data['lead_ids'] );
+		$this->assertIsArray( $data['form'] );
+		$this->assertIsArray( $data['entry'] );
+		$this->assertIsArray( $data['lead'] );
+		$this->assertIsArray( $data['form_data'] );
+		$this->assertSame( $data['entry'], $data['lead'] );
+		$this->assertSame( $pdf, $data['settings'] );
+		$this->assertInstanceOf( 'GFPDF\Router', $data['gfpdf'] );
+		$this->assertIsArray( $data['fields'] );
+		$this->assertInstanceOf( 'GF_Field_Checkbox', $data['fields'][47] );
+		$this->assertInstanceOf( 'GFPDF\Templates\Config\Zadani', $data['config'] );
+
+		/* Check our config class has the settings populated */
+		$this->assertSame( $data['settings'], $data['config']->get_settings() );
 	}
 }


### PR DESCRIPTION
## Description

Config classes that implement `Helper_Abstract_Config_Settings` will have access to `$config->get_settings()` and `$config->set_settings()`, and have the settings auto-injected.

Resolves #658

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
