### PR TITLE
Radio Field with empty value

### DIFF
--- a/src/Helper/Fields/Field_Radio.php
+++ b/src/Helper/Fields/Field_Radio.php
@@ -95,6 +95,23 @@ class Field_Radio extends Helper_Abstract_Fields {
 	}
 
 	/**
+	 * Check if the value is empty. Optional filter to check both the value and the label
+	 *
+	 * @return bool
+	 *
+	 * @since 6.1
+	 */
+	public function is_empty() {
+		$value = $this->value();
+
+		if ( apply_filters( 'gfpdf_field_is_empty_value_instead_of_label', true, $value, $this->field, $this->entry, $this->form, $this ) ) {
+			return empty( $value['value'] );
+		}
+
+		return parent::is_empty();
+	}
+
+	/**
 	 * Return the HTML form data
 	 *
 	 * @return array

--- a/src/Helper/Fields/Field_Select.php
+++ b/src/Helper/Fields/Field_Select.php
@@ -77,6 +77,23 @@ class Field_Select extends Helper_Abstract_Fields {
 	}
 
 	/**
+	 * Check if the value is empty. Optional filter to check both the value and the label
+	 *
+	 * @return bool
+	 *
+	 * @since 6.1
+	 */
+	public function is_empty() {
+		$value = $this->value();
+
+		if ( apply_filters( 'gfpdf_field_is_empty_value_instead_of_label', true, $value, $this->field, $this->entry, $this->form, $this ) ) {
+			return empty( $value['value'] );
+		}
+
+		return parent::is_empty();
+	}
+
+	/**
 	 * Display the HTML version of this field
 	 *
 	 * @param string $value

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Radio.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Radio.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Fields;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2021, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_FlushCache
+ *
+ * @package GFPDF\Helper\Fonts
+ *
+ * @group   helper
+ * @group   fields
+ */
+class Test_Field_Radio extends WP_UnitTestCase {
+
+	public $form;
+
+	public $gf_field;
+
+	public $pdf_field;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->form = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+
+		foreach ( $this->form['fields'] as $field ) {
+			if ( $field->type === 'radio' ) {
+				$this->gf_field = new \GF_Field_Radio( $field );
+				break;
+			}
+		}
+
+		$entry = [
+			'form_id' => $this->form['id'],
+		];
+
+		$this->pdf_field = new Field_Radio( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+	}
+
+	public function test_is_empty() {
+		$this->assertTrue( $this->pdf_field->is_empty() );
+
+		add_filter( 'gfpdf_field_is_empty_value_instead_of_label', '__return_false' );
+
+		$this->assertFalse( $this->pdf_field->is_empty() );
+
+		remove_filter( 'gfpdf_field_is_empty_value_instead_of_label', '__return_false' );
+	}
+
+	public function test_value_with_empty_value() {
+		$value = $this->pdf_field->value();
+
+		$this->assertEmpty( $value['value'] );
+		$this->assertNotEmpty( $value['label'] );
+	}
+
+	public function test_form_data_with_empty_value() {
+		$form_data = $this->pdf_field->form_data();
+
+		$this->assertSame( '', $form_data['field'][ $this->gf_field->id ] );
+		$this->assertSame( 'Radio Fourth Choice Label', $form_data['field'][ $this->gf_field->id . '_name' ] );
+	}
+}

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Select.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Select.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Fields;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2021, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_FlushCache
+ *
+ * @package GFPDF\Helper\Fonts
+ *
+ * @group   helper
+ * @group   fields
+ */
+class Test_Field_Select extends WP_UnitTestCase {
+
+	public $form;
+
+	public $gf_field;
+
+	public $pdf_field;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->form = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+
+		foreach ( $this->form['fields'] as $field ) {
+			if ( $field->type === 'select' ) {
+				$this->gf_field = new \GF_Field_Select( $field );
+				break;
+			}
+		}
+
+		$entry = [
+			'form_id' => $this->form['id'],
+		];
+
+		$this->pdf_field = new Field_Select( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+	}
+
+	public function test_is_empty() {
+		$this->assertTrue( $this->pdf_field->is_empty() );
+
+		add_filter( 'gfpdf_field_is_empty_value_instead_of_label', '__return_false' );
+
+		$this->assertFalse( $this->pdf_field->is_empty() );
+
+		remove_filter( 'gfpdf_field_is_empty_value_instead_of_label', '__return_false' );
+	}
+
+	public function test_value_with_empty_value() {
+		$value = $this->pdf_field->value();
+
+		$this->assertEmpty( $value['value'] );
+		$this->assertNotEmpty( $value['label'] );
+	}
+
+	public function test_form_data_with_empty_value() {
+		$form_data = $this->pdf_field->form_data();
+
+		$this->assertSame( '', $form_data['field'][ $this->gf_field->id ] );
+		$this->assertSame( 'Option 4', $form_data['field'][ $this->gf_field->id . '_name' ] );
+	}
+}

--- a/tests/phpunit/unit-tests/json/all-form-fields.json
+++ b/tests/phpunit/unit-tests/json/all-form-fields.json
@@ -99,6 +99,12 @@
           "value": "Option 3 Value",
           "isSelected": false,
           "price": ""
+        },
+        {
+          "text": "Option 4",
+          "value": "",
+          "isSelected": false,
+          "price": ""
         }
       ],
       "formId": 58,
@@ -279,6 +285,13 @@
         {
           "text": "Radio Third Choice",
           "value": "Radio Third Choice",
+          "isSelected": false,
+          "price": ""
+        },
+
+        {
+          "text": "Radio Fourth Choice Label",
+          "value": "",
           "isSelected": false,
           "price": ""
         }


### PR DESCRIPTION
## Description
Selected empty radio field should be displayed as empty on the pdf.

<!-- Describe what you have changed or added. -->
Since gravity forms doesn't allow empty values on their `_gf_entry_meta` table. We should be able to fix this by checking if the current `value` is empty or null. If that's the case we should hide the label as well - leaving the GPDF "skipped" the field.
Same principle is applied to radio values with a space(s).
<!-- Link to the support ticket(s) where appropriate. -->
#1204 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
