### PR TITLE
Add a custom class on #gfpdf_pdf_form to get the current GF version a…

### DIFF
--- a/src/Model/Model_Form_Settings.php
+++ b/src/Model/Model_Form_Settings.php
@@ -3,6 +3,7 @@
 namespace GFPDF\Model;
 
 use GFFormsModel;
+use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Abstract_Model;
 use GFPDF\Helper\Helper_Abstract_Options;
@@ -222,6 +223,12 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			}
 		}
 
+		/* add custom classes to form */
+		$form_classes = '';
+		if ( version_compare( '2.6-rc-1', GFCommon::$version, '>=' ) ) {
+			$form_classes .= 'gfpdf-gf-2-6';
+		}
+
 		$entry_meta = GFFormsModel::get_entry_meta( $form_id );
 		$entry_meta = apply_filters( 'gform_entry_meta_conditional_logic_confirmations', $entry_meta, $form, '' );
 
@@ -253,6 +260,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 				'form'         => $form,
 				'entry_meta'   => $entry_meta,
 				'pdf'          => $pdf,
+				'form_classes' => $form_classes,
 			]
 		);
 	}

--- a/src/View/html/FormSettings/add_edit.php
+++ b/src/View/html/FormSettings/add_edit.php
@@ -17,7 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** @var $args array */
 
 global $wp_settings_fields;
-
 ?>
 
 <!-- Merge tag functionality requires a global form object -->
@@ -34,7 +33,8 @@ global $wp_settings_fields;
 <?php GFFormSettings::page_header( $args['title'] ); ?>
 
 <!-- Prevent Firefox auto-filling fields on refresh. @see https://stackoverflow.com/a/44504822/1614565 -->
-<form name="gfpdf-settings-form-<?= rand() ?>" method="post" id="gfpdf_pdf_form" class="gform_settings_form">
+<form name="gfpdf-settings-form-<?= rand() ?>" method="post" id="gfpdf_pdf_form"
+	  class="gform_settings_form <?= $args['form_classes'] ?>">
 
 	<?php wp_nonce_field( 'gfpdf_save_pdf', 'gfpdf_save_pdf' ); ?>
 

--- a/src/assets/scss/Pages/_pdf-settings.scss
+++ b/src/assets/scss/Pages/_pdf-settings.scss
@@ -40,4 +40,23 @@
       }
     }
   }
+
+  /* GF 2.6 UI updates */
+  .gfpdf-gf-2-6 {
+    .gfpdf-settings-field-wrapper {
+      .wp-editor-wrap {
+        margin-right: 0rem;
+      }
+    }
+
+    .wp-media-buttons {
+      .all-merge-tags {
+        top: -0.15rem;
+      }
+
+      .gform-icon--merge-tag {
+        font-size: 2.25rem;
+      }
+    }
+  }
 }

--- a/src/assets/scss/RTL/Pages/_rtl-pdf-settings.scss
+++ b/src/assets/scss/RTL/Pages/_rtl-pdf-settings.scss
@@ -73,4 +73,14 @@ html[dir="rtl"] {
       }
     }
   }
+
+  /* GF 2.6 UI updates */
+  .gfpdf-gf-2-6 {
+    .gfpdf-settings-field-wrapper {
+      .wp-editor-wrap {
+        margin-left: 0rem;
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
…nd apply the request style for 2.6.beta.

## Description
On add-edit.php on FormSettings View. I have added a class which reflects the current version GravityForms. I have prepared that value into a viable class name, then apply the requested styles for the merge tag selector icon and RTE width.
<!-- Link to the support ticket(s) where appropriate. -->
#1308 
## Testing instructions
Make sure your on GF 2.6.beta and WP 5.9, go to Forms->Settings->PDF. The larger merge tag icon and the RTE updated width should be applied.
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
