### PR TITLE
Add simplebar markup for multiple pdf to Entry List.

### DIFF
--- a/src/View/html/PDF/entry_list_pdf_multiple.php
+++ b/src/View/html/PDF/entry_list_pdf_multiple.php
@@ -24,17 +24,19 @@ $parent_link_text = $download ? esc_html__( 'Download PDFs', 'gravity-forms-pdf-
 <div class="gfpdf_form_action_has_submenu">
 	| <a href="#" aria-haspopup="true" aria-expanded="false"><?= $parent_link_text ?></a>
 	<div class="gform-form-toolbar__submenu">
-		<ul>
-			<?php foreach ( $args['pdfs'] as $pdf ): ?>
-				<li>
-					<a href="<?= $download ? esc_url( $pdf['download'] ) : esc_url( $pdf['view'] ); ?>"
-						<?= ! $download ? 'target="_blank"' : ''; ?>
-					   data-label="<?= esc_attr( $pdf['name'] ) ?>"
-					>
-						<?= esc_html( $pdf['name'] ); ?>
-					</a>
-				</li>
-			<?php endforeach; ?>
-		</ul>
+		<div data-simplebar>
+			<ul>
+				<?php foreach ( $args['pdfs'] as $pdf ): ?>
+					<li>
+						<a href="<?= $download ? esc_url( $pdf['download'] ) : esc_url( $pdf['view'] ); ?>"
+							<?= ! $download ? 'target="_blank"' : ''; ?>
+						   data-label="<?= esc_attr( $pdf['name'] ) ?>"
+						>
+							<?= esc_html( $pdf['name'] ); ?>
+						</a>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Description
Prior to GravityForms's changes to UI Dropdown or the introduction of SimpleBar (https://www.npmjs.com/package/simplebar) . We are going to implement the same UI in our pages as well.

<!-- Describe what you have changed or added. -->
Add `<div data-simplebar></div>` to line `entry_list_pdf_multiple.php:27`
<!-- Link to the support ticket(s) where appropriate. -->
#1313 

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->

1. Enable multiple PDFs on a single form
2. Go to entry list page
3. Hover over the "View PDF" link

<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
