### PR TITLE
Add Zapier Support (PDF URLS)

### DIFF
--- a/src/Controller/Controller_Zapier.php
+++ b/src/Controller/Controller_Zapier.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace GFPDF\Controller;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2022, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Controller_Zapier
+ *
+ * @package GFPDF\Controller
+ */
+class Controller_Zapier {
+
+	/**
+	 * @since 6.3
+	 */
+	public function init(): void {
+		add_filter( 'gform_zapier_request_body', [ $this, 'add_zapier_support' ], 10, 3 );
+	}
+
+	/**
+	 * Add PDF URLs to the Zapier body array
+	 *
+	 * @param array $body  An associative array containing the request body that will be sent to Zapier.
+	 * @param array $feed  The Feed Object currently being processed.
+	 * @param array $entry The Entry Object currently being processed.
+	 *
+	 * @return array
+	 *
+	 * @since 6.3
+	 */
+	public function add_zapier_support( $body, $feed, $entry ) {
+		$zapier = \GF_Zapier::get_instance();
+		$pdfs   = \GPDFAPI::get_entry_pdfs( $entry['id'] ?? 0 );
+
+		if ( is_wp_error( $pdfs ) ) {
+			return $body;
+		}
+
+		foreach ( $pdfs as $pdf ) {
+			$body[ $zapier->get_body_key( $body, $pdf['name'] . ' PDF URL' ) ]                  = do_shortcode( sprintf( '[gravitypdf id="%2$s" entry="%1$d" raw="1"]', $entry['id'], $pdf['id'] ) );
+			$body[ $zapier->get_body_key( $body, $pdf['name'] . ' PDF URL - SIGNED 1 WEEK' ) ]  = do_shortcode( sprintf( '[gravitypdf id="%2$s" entry="%1$d" raw="1" signed="1" expires="+1 week"]', $entry['id'], $pdf['id'] ) );
+			$body[ $zapier->get_body_key( $body, $pdf['name'] . ' PDF URL - SIGNED 1 MONTH' ) ] = do_shortcode( sprintf( '[gravitypdf id="%2$s" entry="%1$d" raw="1" signed="1" expires="+1 month"]', $entry['id'], $pdf['id'] ) );
+			$body[ $zapier->get_body_key( $body, $pdf['name'] . ' PDF URL - SIGNED 1 YEAR' ) ]  = do_shortcode( sprintf( '[gravitypdf id="%2$s" entry="%1$d" raw="1" signed="1" expires="+1 year"]', $entry['id'], $pdf['id'] ) );
+		}
+
+		return $body;
+	}
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -226,6 +226,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$this->check_system_status();
 		$this->export();
 		$this->webhooks();
+		$this->zapier();
 
 		/* Add localisation support */
 		$this->add_localization_support();
@@ -894,6 +895,16 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 */
 	public function webhooks(): void {
 		$class = new Controller\Controller_Webhooks();
+		$class->init();
+
+		$this->singleton->add_class( $class );
+	}
+
+	/**
+	 * @since 6.3
+	 */
+	public function zapier(): void {
+		$class = new Controller\Controller_Zapier();
 		$class->init();
 
 		$this->singleton->add_class( $class );

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -69,6 +69,18 @@ class GravityPDF_Unit_Tests_Bootstrap {
 
 		/* load the WP testing environment */
 		require_once( $this->wp_tests_dir . '/includes/bootstrap.php' );
+
+		/* Load Mocks */
+		$this->mocks();
+	}
+
+	/**
+	 * Load Addon Mocks
+	 *
+	 * @since 6.3
+	 */
+	public function mocks(){
+		require_once 'unit-tests/Mocks/zapier-mock.php';
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Zapier.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Zapier.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2022, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_Controller_Zapier
+ *
+ * @package GFPDF\Controller
+ *
+ * @group   controller
+ * @group   zapier
+ */
+class Test_Controller_Zapier extends WP_UnitTestCase {
+
+	/**
+	 * @var Controller_Zapier
+	 */
+	protected $controller;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->controller = new Controller_Zapier();
+	}
+
+	public function test_add_zapier_support_active_pdfs() {
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$body  = $this->controller->add_zapier_support( [], [], $entry );
+
+		$this->assertCount( 8, $body );
+
+		$this->assertArrayHasKey( 'My First PDF Template (copy) PDF URL', $body );
+		$this->assertArrayHasKey( 'My First PDF Template (copy) PDF URL - SIGNED 1 WEEK', $body );
+		$this->assertArrayHasKey( 'My First PDF Template (copy) PDF URL - SIGNED 1 MONTH', $body );
+		$this->assertArrayHasKey( 'My First PDF Template (copy) PDF URL - SIGNED 1 YEAR', $body );
+
+		$this->assertArrayHasKey( 'My First PDF Template (copy) PDF URL - 1', $body );
+		$this->assertArrayHasKey( 'My First PDF Template (copy) PDF URL - SIGNED 1 WEEK - 1', $body );
+		$this->assertArrayHasKey( 'My First PDF Template (copy) PDF URL - SIGNED 1 MONTH - 1', $body );
+		$this->assertArrayHasKey( 'My First PDF Template (copy) PDF URL - SIGNED 1 YEAR - 1', $body );
+
+		$this->assertNotFalse( filter_var( $body['My First PDF Template (copy) PDF URL'], FILTER_VALIDATE_URL ) );
+		$this->assertNotFalse( filter_var( $body['My First PDF Template (copy) PDF URL - SIGNED 1 WEEK'], FILTER_VALIDATE_URL ) );
+		$this->assertNotFalse( filter_var( $body['My First PDF Template (copy) PDF URL - SIGNED 1 MONTH'], FILTER_VALIDATE_URL ) );
+		$this->assertNotFalse( filter_var( $body['My First PDF Template (copy) PDF URL - SIGNED 1 YEAR'], FILTER_VALIDATE_URL ) );
+
+		$this->assertStringNotContainsString( 'signature=', $body['My First PDF Template (copy) PDF URL'] );
+		$this->assertStringContainsString( 'signature=', $body['My First PDF Template (copy) PDF URL - SIGNED 1 WEEK'] );
+		$this->assertStringContainsString( 'signature=', $body['My First PDF Template (copy) PDF URL - SIGNED 1 MONTH'] );
+		$this->assertStringContainsString( 'signature=', $body['My First PDF Template (copy) PDF URL - SIGNED 1 YEAR'] );
+	}
+
+	public function test_add_zapier_support_conditional_logic() {
+		$entry    = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$entry[7] = 'Albania';
+		\GFAPI::update_entry( $entry );
+
+		$body = $this->controller->add_zapier_support( [], [], $entry );
+
+		$this->assertCount( 12, $body );
+
+		$this->assertArrayHasKey( 'My First PDF Template PDF URL', $body );
+		$this->assertArrayHasKey( 'My First PDF Template PDF URL - SIGNED 1 WEEK', $body );
+		$this->assertArrayHasKey( 'My First PDF Template PDF URL - SIGNED 1 MONTH', $body );
+		$this->assertArrayHasKey( 'My First PDF Template PDF URL - SIGNED 1 YEAR', $body );
+	}
+
+	public function test_add_zapier_support_empty() {
+		$body = $this->controller->add_zapier_support( [], [], [ 'id' => 9999 ] );
+
+		$this->assertCount( 0, $body );
+	}
+
+}

--- a/tests/phpunit/unit-tests/Mocks/zapier-mock.php
+++ b/tests/phpunit/unit-tests/Mocks/zapier-mock.php
@@ -1,0 +1,39 @@
+<?php
+
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2022, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GF_Zapier {
+
+	private static $_instance = null;
+
+	public static function get_instance() {
+		if ( self::$_instance === null ) {
+			self::$_instance = new GF_Zapier();
+		}
+
+		return self::$_instance;
+	}
+
+	public function get_body_key( $body, $label ) {
+		$count = 1;
+		$key   = $label;
+
+		while ( array_key_exists( $key, $body ) ) {
+			$key = $label . ' - ' . $count;
+			$count++;
+		}
+
+		return $key;
+	}
+}


### PR DESCRIPTION
## Description
Since the introduction of Zapier filter `gform_zapier_request_body`  (3.2). We will be including the PDF URLs on its returned `$body`. 

Fixes #1287 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
