### PR TITLE
Apply new table single row class exclusively on GF 2.6

### DIFF
--- a/src/Helper/Helper_PDF_List_Table.php
+++ b/src/Helper/Helper_PDF_List_Table.php
@@ -172,8 +172,9 @@ class Helper_PDF_List_Table extends WP_List_Table {
 	 */
 	public function single_row( $item ) {
 		static $row_class = '';
+		$class            = version_compare( '2.6-rc-1', \GFCommon::$version, '>=' ) ? 'gf-locking' : 'alternate';
 
-		$row_class = ( $row_class === '' ? 'class="alternate"' : $row_class );
+		$row_class = ( $row_class === '' ? "class='$class'" : $row_class );
 
 		echo '<tr id="gfpdf-' . $item['id'] . '" ' . $row_class . '>';
 		$this->single_row_columns( $item );


### PR DESCRIPTION
## Description
A simple condition statement check if the current Gravity Form version is 2.6 or above and use the appropriate class on table-listing row.

<!-- Describe what you have changed or added. -->
<!-- Link to the support ticket(s) where appropriate. -->
#1316 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
