### PR TITLE
Fix the incorrect Tab ID for PDF settings 

### DIFF
--- a/src/assets/js/admin/settings/pdf/doFormSettingsEditPage.js
+++ b/src/assets/js/admin/settings/pdf/doFormSettingsEditPage.js
@@ -35,7 +35,7 @@ export function doFormSettingsEditPage () {
   }
 
   /* Move alert inline */
-  $('.gform-settings__wrapper > .alert').detach().prependTo('#tab_pdf')
+  $('.gform-settings__wrapper > .alert').detach().prependTo('#tab_PDF')
 
   /*
    * Workaround for Firefix TinyMCE Editor Bug NS_ERROR_UNEXPECTED (http://www.tinymce.com/develop/bugtracker_view.php?id=3152) when loading wp_editor via AJAX


### PR DESCRIPTION
## Description
A quick update on the PDF tab ID, the incorrect ID causes the error message to disappear (detached and prepend to a wrapper that doesn't exists).
<!-- Describe what you have changed or added. -->
<!-- Link to the support ticket(s) where appropriate. -->
#1319 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
