### PR TITLE
Conditionally clean up PDF after form submission

### DIFF
--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -341,14 +341,23 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller implements Helper_
 		$queue_data = apply_filters( 'gfpdf_queue_pre_pdf_creation', [], $entry, $form );
 
 		foreach ( $pdfs as $pdf ) {
+			$pdf_queue_data = [
+				'id'            => $this->get_queue_id( $form, $entry, $pdf ),
+				'func'          => '\GFPDF\Statics\Queue_Callbacks::create_pdf',
+				'args'          => [ $entry['id'], $pdf['id'] ],
+				'unrecoverable' => true,
+			];
+
+			/* Check if we need to save the PDF due to a filter */
+			if ( $this->model_pdf->maybe_always_save_pdf( $pdf, $form['id'] ) ) {
+				$queue_data[] = $pdf_queue_data;
+				continue;
+			}
+
+			/* If a filter isn't implemented to force the PDF to save, check if it needs to be attached to a notification email */
 			foreach ( $notifications as $notification ) {
-				if ( $this->model_pdf->maybe_always_save_pdf( $pdf, $form['id'] ) || $this->model_pdf->maybe_attach_to_notification( $notification, $pdf, $entry, $form ) ) {
-					$queue_data[] = [
-						'id'            => $this->get_queue_id( $form, $entry, $pdf ),
-						'func'          => '\GFPDF\Statics\Queue_Callbacks::create_pdf',
-						'args'          => [ $entry['id'], $pdf['id'] ],
-						'unrecoverable' => true,
-					];
+				if ( $this->model_pdf->maybe_attach_to_notification( $notification, $pdf, $entry, $form ) ) {
+					$queue_data[] = $pdf_queue_data;
 
 					/* Only queue each PDF once (even if attached to multiple notifications) */
 					break;

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -1843,10 +1843,13 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @internal  In future we may give the option to cache PDFs to save on processing power
 	 *
 	 * @since     4.0
-	 *
-	 * @todo      Add PDF caching support to make software more performant. Need to review correct triggers for a cleanup (API-based, UI actions, 3rd-party add-on compatibility)
 	 */
 	public function cleanup_pdf( $entry, $form ) {
+
+		/* Exit early if background processing is enabled */
+		if ( $this->options->get_option( 'background_processing', 'No' ) === 'Yes' ) {
+			return;
+		}
 
 		$pdfs = ( isset( $form['gfpdf_form_settings'] ) ) ? $this->get_active_pdfs( $form['gfpdf_form_settings'], $entry ) : [];
 


### PR DESCRIPTION
## Description

This resolves a race condition with Background Processing.

Fixes #1320

## Testing instructions
1. Set a breakpoint in Xdebug on line 1850 of /src/Model/Model_PDF.php
2. Do form submission and check `Model_PDF::cleanup_pdf()` runs
3. Enable Background Processing
4. Do form submission and check `Model_PDF::cleanup_pdf()` does not run

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
