### PR TITLE
Process [gravitypdf] shortcode during merge tag processing

### DIFF
--- a/src/Controller/Controller_Shortcodes.php
+++ b/src/Controller/Controller_Shortcodes.php
@@ -76,14 +76,11 @@ class Controller_Shortcodes extends Helper_Abstract_Controller implements Helper
 	 *
 	 * @return void
 	 * @since 4.0
-	 *
 	 */
 	public function add_filters() {
-
-		add_filter( 'gform_confirmation', [ $this->model, 'gravitypdf_confirmation' ], 100, 3 );
-		add_filter( 'gform_notification', [ $this->model, 'gravitypdf_notification' ], 100, 3 );
 		add_filter( 'gform_admin_pre_render', [ $this->model, 'gravitypdf_redirect_confirmation' ] );
 		add_filter( 'gform_confirmation', [ $this->model, 'gravitypdf_redirect_confirmation_shortcode_processing' ], 10, 3 );
+		add_filter( 'gform_pre_replace_merge_tags', [ $this->model, 'gravitypdf_process_during_merge_tag_replacement' ], 10, 3 );
 
 		/* Basic GravityView Support */
 		add_filter( 'gravityview/fields/custom/content_before', [ $this->model, 'gravitypdf_gravityview_custom' ], 10 );

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -154,6 +154,25 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	}
 
 	/**
+	 * Auto-inject the entry ID into the [gravitypdf] shortcode when merge tags are processed
+	 *
+	 * @param string $html  The text to be processed
+	 * @param array  $form  The Gravity Form array
+	 * @param array  $entry The Gravity Form entry information
+	 *
+	 * @return string
+	 *
+	 * @since 6.3
+	 */
+	public function gravitypdf_process_during_merge_tag_replacement( $html, $form, $entry ) {
+		if ( empty( $entry['id'] ) || ! is_string( $html ) ) {
+			return $html;
+		}
+
+		return $this->add_entry_id_to_shortcode( $html, $entry['id'] );
+	}
+
+	/**
 	 * Update our Gravity Forms "Text" Confirmation Shortcode to include the current entry ID
 	 *
 	 * @param string|array $confirmation The confirmation text
@@ -163,24 +182,11 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 * @return string|array               The confirmation text
 	 *
 	 * @since 4.0
+	 *
+	 * @depecated 6.3. Processing handled automatically when merge tags processed
+	 * @see Helper_Abstract_Pdf_Shortcode::gravitypdf_process_during_merge_tag_replacement()
 	 */
 	public function gravitypdf_confirmation( $confirmation, $form, $entry ) {
-
-		/**
-		 * Do nothing if WP_Error is passed
-		 *
-		 * This resolves a conflict with a third party GF plugin which was passing an error instead of the expected GF confirmation response
-		 *
-		 * @see https://github.com/GravityPDF/gravity-pdf/issues/999
-		 */
-		if ( is_wp_error( $confirmation ) || is_wp_error( $form ) || is_wp_error( $entry ) ) {
-			return $confirmation;
-		}
-
-		if ( isset( $form['confirmation']['type'] ) && $form['confirmation']['type'] === 'message' ) {
-			$confirmation = $this->add_entry_id_to_shortcode( $confirmation, $entry['id'] );
-		}
-
 		return $confirmation;
 	}
 
@@ -194,24 +200,11 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 * @return array               The notification
 	 *
 	 * @since 4.0
+	 *
+	 * @depecated 6.3. Processing handled automatically when merge tags processed
+	 * @see Helper_Abstract_Pdf_Shortcode::gravitypdf_process_during_merge_tag_replacement()
 	 */
 	public function gravitypdf_notification( $notification, $form, $entry ) {
-
-		/**
-		 * Do nothing if WP_Error is passed
-		 *
-		 * This resolves a conflict with a third party GF plugin which was passing an error instead of the expected GF confirmation response
-		 *
-		 * @see https://github.com/GravityPDF/gravity-pdf/issues/999
-		 */
-		if ( is_wp_error( $notification ) || is_wp_error( $entry ) || empty( $entry['id'] ) ) {
-			return $notification;
-		}
-
-		if ( isset( $notification['message'] ) ) {
-			$notification['message'] = $this->add_entry_id_to_shortcode( $notification['message'], $entry['id'] );
-		}
-
 		return $notification;
 	}
 

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -187,7 +187,7 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 * @see Helper_Abstract_Pdf_Shortcode::gravitypdf_process_during_merge_tag_replacement()
 	 */
 	public function gravitypdf_confirmation( $confirmation, $form, $entry ) {
-		return $confirmation;
+		return $this->gravitypdf_process_during_merge_tag_replacement( $confirmation, $form, $entry );
 	}
 
 	/**
@@ -205,6 +205,10 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 * @see Helper_Abstract_Pdf_Shortcode::gravitypdf_process_during_merge_tag_replacement()
 	 */
 	public function gravitypdf_notification( $notification, $form, $entry ) {
+		if ( is_array( $notification ) && isset( $notification['message'] ) ) {
+			$notification['message'] = $this->gravitypdf_process_during_merge_tag_replacement( $notification['message'], $form, $entry );
+		}
+
 		return $notification;
 	}
 

--- a/tests/phpunit/unit-tests/test-shortcodes.php
+++ b/tests/phpunit/unit-tests/test-shortcodes.php
@@ -82,8 +82,6 @@ class Test_Shortcode extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_filters() {
-		$this->assertEquals( 100, has_filter( 'gform_confirmation', [ $this->model, 'gravitypdf_confirmation' ] ) );
-		$this->assertEquals( 100, has_filter( 'gform_notification', [ $this->model, 'gravitypdf_notification' ] ) );
 		$this->assertEquals(
 			10,
 			has_filter(


### PR DESCRIPTION
## Description

This allows for forward compatibility with other plugins, like Gravity Wiz's Entry Block add-on.

Resolves #1325

## Testing instructions
1. Add [gravitypdf] shortcode to Text Confirmation and do submission to test it works
1. Add [gravitypdf] shortcode to Page Confirmation and do submission to test it works
1. Add [gravitypdf] shortcode to Redirect Confirmation and do submission to test it works
1. Add [gravitypdf] shortcode to Notifications and do submission to test it works
1. Add [gravitypdf] shortcode to GravityView Custom Content column and preview the view to test it works
1. Add [gravitypdf] shortcode to Gravity Wiz's Entry Blocks Custom column and test it works

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
