### PR TITLE
Add gfpdf_current_form_object filter

### DIFF
--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -197,7 +197,7 @@ class Helper_PDF {
 		$this->misc      = $misc;
 		$this->templates = $templates;
 		$this->log       = $log;
-		$this->form      = $this->gform->get_form( $entry['form_id'] );
+		$this->form      = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __METHOD__ );
 
 		$this->set_path();
 	}

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -256,7 +256,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 */
 	public function apply_backwards_compatibility_filters( $settings, $entry ) {
 
-		$form = $this->gform->get_form( $entry['form_id'] );
+		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
 		$settings['filename'] = $this->misc->remove_extension_from_string( apply_filters( 'gfpdfe_pdf_name', $settings['filename'], $form, $entry ) );
 		$settings['template'] = $this->misc->remove_extension_from_string( apply_filters( 'gfpdfe_template', $settings['template'], $form, $entry ), '.php' );
@@ -664,7 +664,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		$args = [];
 
 		/* Check if we have any PDFs */
-		$form = $this->gform->get_form( $entry['form_id'] );
+		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 		$pdfs = ( isset( $form['gfpdf_form_settings'] ) ) ? $this->get_active_pdfs( $form['gfpdf_form_settings'], $entry ) : [];
 
 		if ( ! empty( $pdfs ) ) {
@@ -703,7 +703,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	public function get_active_pdfs( $pdfs, $entry ) {
 
 		$filtered = [];
-		$form     = $this->gform->get_form( $entry['form_id'] );
+		$form     = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
 		foreach ( $pdfs as $pdf ) {
 			if ( $pdf['active'] && ( empty( $pdf['conditionalLogic'] ) || $this->misc->evaluate_conditional_logic( $pdf['conditionalLogic'], $entry ) ) ) {
@@ -731,7 +731,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 */
 	public function get_pdf_name( $settings, $entry ) {
 
-		$form = $this->gform->get_form( $entry['form_id'] );
+		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 		$name = $this->gform->process_tags( $settings['filename'], $form, $entry );
 
 		/* Decode HTML entities */
@@ -1034,7 +1034,7 @@ class Model_PDF extends Helper_Abstract_Model {
 			/* Get required parameters */
 			$entry    = $pdf->get_entry();
 			$settings = $pdf->get_settings();
-			$form     = $this->gform->get_form( $entry['form_id'] );
+			$form     = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
 			do_action( 'gfpdf_pre_pdf_generation', $form, $entry, $settings, $pdf );
 
@@ -1135,7 +1135,7 @@ class Model_PDF extends Helper_Abstract_Model {
 			return [];
 		}
 
-		$form = $this->gform->get_form( $entry['form_id'] );
+		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
 		if ( ! is_array( $form ) ) {
 			return [];
@@ -1259,7 +1259,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 */
 	public function handle_legacy_tier_2_processing( Helper_PDF $pdf, $entry, $settings, $args ) {
 
-		$form = $this->gform->get_form( $entry['form_id'] );
+		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
 		$prevent_main_pdf_loader = apply_filters(
 			'gfpdfe_pre_load_template',
@@ -1770,7 +1770,7 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		if ( is_file( $pdf_path ) ) {
 			/* Add appropriate filters so developers can access the PDF when it is generated */
-			$form     = $this->gform->get_form( $entry['form_id'] );
+			$form     = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 			$filename = basename( $pdf_path );
 
 			do_action( 'gfpdf_post_pdf_save', $form['id'], $entry['id'], $settings, $pdf_path ); /* Backwards compatibility */

--- a/src/View/View_PDF.php
+++ b/src/View/View_PDF.php
@@ -150,7 +150,7 @@ class View_PDF extends Helper_Abstract_View {
 
 		$controller = $this->getController();
 		$model      = $controller->model;
-		$form       = $this->gform->get_form( $entry['form_id'] );
+		$form       = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 		$form       = $this->add_gravity_perk_conditional_logic_date_support( $form );
 
 		/**
@@ -369,7 +369,7 @@ class View_PDF extends Helper_Abstract_View {
 	public function generate_html_structure( $entry, Helper_Abstract_Model $model, $config = [] ) {
 
 		/* Set up required variables */
-		$form        = $this->gform->get_form( $entry['form_id'] );
+		$form        = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 		$products    = new Field_Products( new GF_Field(), $entry, $this->gform, $this->misc );
 		$page_number = 0;
 
@@ -613,7 +613,7 @@ class View_PDF extends Helper_Abstract_View {
 	 * @since 4.0
 	 */
 	public function get_core_template_styles( $settings, $entry ) {
-		$form = $this->gform->get_form( $entry['form_id'] );
+		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
 		$html = $this->load_core_template_styles( $settings );
 


### PR DESCRIPTION
## Description

This allows developers to modify the form object specifically when processing PDFs

## Testing instructions
1. Change the order of fields using the `gfpdf_current_form_object` hook and then view a PDF to verify it worked

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
