### PR TITLE
Don't delete top-level directory during cache cleanup

### DIFF
--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -350,12 +350,13 @@ class Helper_Misc {
 	 * equivalent to Bash: rm -r $dir
 	 *
 	 * @param string $dir The path to be deleted
+	 * @param bool   $delete_top_level_dir Add ability to leave the top-level directory as-is. Added in 6.3.1
 	 *
 	 * @return bool|WP_Error
 	 *
 	 * @since 4.0
 	 */
-	public function rmdir( $dir ) {
+	public function rmdir( $dir, bool $delete_top_level_dir = true ) {
 
 		$this->log->notice( sprintf( 'Begin deleting directory recursively: %s', $dir ) );
 
@@ -385,9 +386,12 @@ class Helper_Misc {
 			return new WP_Error( 'recursion_delete_problem', $e );
 		}
 
-		$results = rmdir( $dir );
-		if ( ! $results ) {
-			$this->log->error( sprintf( 'Could not delete the top-level directory: %s', $dir ) );
+		$results = true;
+		if ( $delete_top_level_dir ) {
+			$results = rmdir( $dir );
+			if ( ! $results ) {
+				$this->log->error( sprintf( 'Could not delete the top-level directory: %s', $dir ) );
+			}
 		}
 
 		$this->log->notice( sprintf( 'End deleting directory recursively: %s', $dir ) );
@@ -396,15 +400,16 @@ class Helper_Misc {
 	}
 
 	/**
-	 * Wrapper function for rmdir() which ensures the directory gets automatically recreated after being deleted
+	 * Wrapper function for rmdir() which ensures the top-level directory is not deleted
 	 *
 	 * @param string $path
 	 *
 	 * @since 4.0
+	 *
+	 * @internal Changed behaviour in 6.3.1 so the top-level directory is never deleted
 	 */
 	public function cleanup_dir( $path ) {
-		$this->rmdir( $path );
-		wp_mkdir_p( $path );
+		$this->rmdir( $path, false );
 	}
 
 	/**

--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -368,11 +368,12 @@ class Helper_Misc {
 
 			foreach ( $files as $fileinfo ) {
 				$function = ( $fileinfo->isDir() ) ? 'rmdir' : 'unlink';
-				if ( ! $function( $fileinfo->getRealPath() ) ) {
-					throw new Exception( 'Could not run ' . $function . ' on  ' . $fileinfo->getRealPath() );
+				$real_path = $fileinfo->getRealPath();
+				if ( ! $function( $real_path ) ) {
+					throw new Exception( 'Could not run ' . $function . ' on  ' . $real_path );
 				}
 
-				$this->log->notice( sprintf( 'Successfully ran `%s` on %s', $function, $fileinfo->getRealPath() ) );
+				$this->log->notice( sprintf( 'Successfully ran `%s` on %s', $function, $real_path ) );
 			}
 		} catch ( Exception $e ) {
 			$this->log->error(

--- a/tests/phpunit/unit-tests/test-helper-misc.php
+++ b/tests/phpunit/unit-tests/test-helper-misc.php
@@ -620,7 +620,36 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 
 		/* Check the file was deleted but the directory still exists */
 		$this->assertFileDoesNotExist( $path . 'test' );
-		$this->assertTrue( is_dir( $path ) );
+		$this->assertDirectoryExists( $path );
 
+		rmdir( $path );
+	}
+
+	public function test_rmdir() {
+		/* Create test data */
+		$path = ABSPATH . 'test/';
+		wp_mkdir_p( $path );
+		touch( $path . 'test' );
+
+		/* Ensure it created correctly */
+		$this->assertFileExists( $path . 'test' );
+
+		/* Run our test but don't delete the top-level folder */
+		$this->misc->rmdir( $path, false );
+
+		$this->assertFileDoesNotExist( $path . 'test' );
+		$this->assertDirectoryExists( $path );
+
+		/* Setup and run out test again, but delete the top-level directory as well */
+		touch( $path . 'test' );
+
+		/* Ensure it created correctly */
+		$this->assertFileExists( $path . 'test' );
+
+		/* Run our test and delete the top-level folder */
+		$this->misc->rmdir( $path );
+
+		$this->assertFileDoesNotExist( $path . 'test' );
+		$this->assertDirectoryDoesNotExist( $path );
 	}
 }


### PR DESCRIPTION
## Description

This PR increases performance by running two less I/O operations, and may also fix a race condition between the folder being deleted and getting recreated.

TODO:

- [x] Write unit test to ensure top-level directory is not deleted
- [x] Replicate this bug by writing code that will trigger this race condition. This should be doable by generating a PDF while the PDF cache is flushed repeatedly.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
