### PR TITLE
PDF Form Settings Permissions Change

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -114,6 +114,8 @@ If you aren't able to meet the v6 minimum requirements [you can download v5 whic
 * Security (Hardening): Escape any and all strings from the Gravity Forms form object, in any context (including PDFs)
 * Security (Hardening): The ?html=1 and ?data=1 developer helper parameters now only work in non-production environments, or when Gravity PDF Debug Mode is explicitly enabled
 * Security (Hardening): Prevent directory traversal when loading the various Gravity PDF UI components
+* Security (Hardening): Change PDF Form Settings capability check from `gravityforms_edit_settings` to `gravityforms_edit_forms`
+* Security (Hardening): Change Font Manager CRUD capability check from `gravityforms_view_entries` to `gravityforms_edit_forms`
 * Developers: Added \GFPDF\Statics\Kses::output( $html ) and \GFPDF\Statics\Kses::parse( $html ) methods for use with sanitizing HTML in PDFs (as an alternative to wp_kses_post()).
 * Performance: Register JavaScript in the footer on Gravity PDF admin pages
 * Bug: Fix issue passing PDF URL to Gravity Forms Mailchimp add-on

--- a/src/Controller/Controller_Custom_Fonts.php
+++ b/src/Controller/Controller_Custom_Fonts.php
@@ -517,9 +517,9 @@ class Controller_Custom_Fonts extends Helper_Abstract_Controller {
 	 * @since 6.0
 	 */
 	protected function check_permissions(): bool {
-		$capabilities = $this->gform->has_capability( 'gravityforms_view_entries' );
+		$capabilities = $this->gform->has_capability( 'gravityforms_edit_forms' );
 		if ( ! $capabilities ) {
-			$this->log->warning( 'Permission denied: user does not have "gravityforms_view_entries" capabilities' );
+			$this->log->warning( 'Permission denied: user does not have "gravityforms_edit_forms" capabilities' );
 		}
 
 		return $capabilities;

--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -365,7 +365,7 @@ class Helper_PDF {
 		$template = ( isset( $this->settings['template'] ) ) ? $this->settings['template'] : '';
 
 		/* Allow a user to change the current template if they have the appropriate capabilities */
-		if ( rgget( 'template' ) && is_user_logged_in() && $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( rgget( 'template' ) && is_user_logged_in() && $this->gform->has_capability( 'gravityforms_edit_forms' ) ) {
 			$template = rgget( 'template' );
 
 			/*
@@ -889,7 +889,7 @@ class Helper_PDF {
 		}
 
 		/* Check if user has permission to view info */
-		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_forms' ) ) {
 			return;
 		}
 

--- a/src/Helper/Helper_Templates.php
+++ b/src/Helper/Helper_Templates.php
@@ -518,7 +518,7 @@ class Helper_Templates {
 	public function get_config_class( $template_id ) {
 
 		/* Allow a user to change the current template configuration file if they have the appropriate capabilities */
-		if ( rgget( 'template' ) && is_user_logged_in() && $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( rgget( 'template' ) && is_user_logged_in() && $this->gform->has_capability( 'gravityforms_edit_forms' ) ) {
 			$template_id = rgget( 'template' );
 
 			/* Handle legacy v3 URL structure and strip .php from the end of the template */

--- a/src/Model/Model_Form_Settings.php
+++ b/src/Model/Model_Form_Settings.php
@@ -148,7 +148,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			'label'        => $this->data->short_title,
 			'query'        => [ 'pid' => null ],
 			'icon'         => 'gform-icon--gravity-pdf',
-			'capabilities' => [ 'gravityforms_edit_settings' ],
+			'capabilities' => [ 'gravityforms_edit_forms' ],
 		];
 
 		return $tabs;
@@ -166,7 +166,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	public function process_list_view( $form_id ) {
 
 		/* prevent unauthorized access */
-		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_forms' ) ) {
 			$this->log->warning( 'Lack of User Capabilities.' );
 			wp_die( esc_html__( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );
 		}
@@ -203,7 +203,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	public function show_edit_view( $form_id, $pdf_id ) {
 
 		/* prevent unauthorized access */
-		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_forms' ) ) {
 			$this->log->warning( 'Lack of User Capabilities.' );
 			wp_die( esc_html__( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );
 		}
@@ -310,7 +310,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	public function process_submission( $form_id, $pdf_id ) {
 
 		/* prevent unauthorized access */
-		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_forms' ) ) {
 			$this->log->critical(
 				'Lack of User Capabilities.',
 				[
@@ -791,7 +791,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$nonce_id = "gfpdf_delete_nonce_{$fid}_{$pid}";
 
 		/* User / CORS validation */
-		$this->misc->handle_ajax_authentication( 'Delete PDF Settings', 'gravityforms_edit_settings', $nonce_id );
+		$this->misc->handle_ajax_authentication( 'Delete PDF Settings', 'gravityforms_edit_forms', $nonce_id );
 
 		/* Delete PDF settings */
 		$results = $this->options->delete_pdf( $fid, $pid );
@@ -843,7 +843,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$nonce_id = "gfpdf_duplicate_nonce_{$fid}_{$pid}";
 
 		/* User / CORS validation */
-		$this->misc->handle_ajax_authentication( 'Duplicate PDF Settings', 'gravityforms_edit_settings', $nonce_id );
+		$this->misc->handle_ajax_authentication( 'Duplicate PDF Settings', 'gravityforms_edit_forms', $nonce_id );
 
 		/* Duplicate PDF config */
 		$config = $this->options->get_pdf( $fid, $pid );
@@ -911,7 +911,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$nonce_id = "gfpdf_state_nonce_{$fid}_{$pid}";
 
 		/* User / CORS validation */
-		$this->misc->handle_ajax_authentication( 'Change PDF Settings State', 'gravityforms_edit_settings', $nonce_id );
+		$this->misc->handle_ajax_authentication( 'Change PDF Settings State', 'gravityforms_edit_forms', $nonce_id );
 
 		/* Change the PDF state */
 		$config = $this->options->get_pdf( $fid, $pid );
@@ -962,7 +962,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	public function render_template_fields() {
 
 		/* User / CORS validation */
-		$this->misc->handle_ajax_authentication( 'Render Template Custom Fields', 'gravityforms_edit_settings' );
+		$this->misc->handle_ajax_authentication( 'Render Template Custom Fields', 'gravityforms_edit_forms' );
 
 		/* phpcs:disable WordPress.Security.NonceVerification.Missing */
 		$template = $_POST['template'] ?? '';


### PR DESCRIPTION
## Description

Use correct permission when editing PDF Form Settings

Swaps `gravityforms_edit_settings` to `gravityforms_edit_forms` capability, brining it in line with the correct Gravity Forms capability configuration.

Also changes the permission for the font manager from `gravityforms_view_entries` to `gravityforms_edit_forms`.

Resolves #1342

## Testing instructions
1. Install User Role Manager Plugin
2. Create new role and only enable the `gravityforms_edit_forms` capability
3. Create a new user and give it this role
4. Install the User Switching plugin  
5. Switch to this new user and verify you can now add/edit/delete PDFs configured on Gravity Forms

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->