### PR TITLE
Filter Notification messages exclusively to Gravity PDF pages.

### DIFF
--- a/src/View/html/Settings/help.php
+++ b/src/View/html/Settings/help.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** @var $args array */
 
+GFCommon::display_admin_message();
+
 ?>
 
 <div id="pdfextended-settings" class="gpdf-help">

--- a/src/View/html/Settings/licence.php
+++ b/src/View/html/Settings/licence.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** @var $args array */
 
+GFCommon::display_admin_message();
+
 ?>
 
 <div id="pdfextended-settings">

--- a/src/View/html/Settings/tools.php
+++ b/src/View/html/Settings/tools.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** @var $args array */
 
+GFCommon::display_admin_message();
+
 ?>
 
 <div id="pdfextended-settings">

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -911,7 +911,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	}
 
 	/**
-	 * Detect any Gravity PDF messages and convert to Gravity Forms message system
+	 * Detect any Gravity PDF messages and add to our notice system
 	 *
 	 * @since 6.0
 	 */
@@ -919,7 +919,11 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$messages = get_settings_errors( 'gfpdf-notices' );
 
 		foreach ( $messages as $message ) {
-			GFCommon::add_message( $message['message'], $message['type'] !== 'updated' );
+			if ( $message['type'] !== 'updated' ) {
+				$this->notices->add_error( $message['message'] );
+			} else {
+				$this->notices->add_notice( $message['message'] );
+			}
 		}
 	}
 

--- a/tests/phpunit/unit-tests/test-notices.php
+++ b/tests/phpunit/unit-tests/test-notices.php
@@ -40,6 +40,7 @@ class Test_Notices extends WP_UnitTestCase {
 		/* run parent method */
 		parent::set_up();
 
+
 		/* Setup our test classes */
 		$this->notices = new Helper_Notices();
 		$this->notices->init();
@@ -158,5 +159,84 @@ class Test_Notices extends WP_UnitTestCase {
 		$html = ob_get_clean();
 
 		$this->assertNotFalse( strpos( $html, $form ) );
+	}
+
+	/**
+	 * Testing hooks form gform_admin_messages and gform_admin_error_messages
+	 **/
+	public function test_gform_admin_messages_hooks() {
+		/* Set up PDF page */
+		remove_all_actions( 'init' );
+		$_GET['page']    = 'gf_entries';
+		$_GET['subview'] = 'PDF';
+		set_current_screen( 'dashboard-user' );
+		$notice = new Helper_Notices();
+		$notice->init();
+		do_action( 'init' );
+
+		$notice->add_notice( 'My First Notice.' );
+		$notice->add_error( 'My First Error.' );
+
+		/* Run this method to initialize the hooks overrides. */
+		$this->assertSame( 'My First Notice.', apply_filters( 'gform_admin_messages', [ 'Global Notice Message.' ] )[0] );
+		$this->assertSame( 'My First Error.', apply_filters( 'gform_admin_error_messages', [ 'Global Error Message.' ] )[0] );
+
+		/* Reset actions and $_GET parameters. */
+		remove_all_actions( 'gform_admin_messages' );
+		remove_all_actions( 'gform_admin_error_messages' );
+		unset( $_GET['page'], $_GET['subview'] );
+
+		/* Re-run this method to make sure that the hooks is skipped. */
+		$notice->maybe_remove_non_pdf_messages();
+		$this->assertSame( 'Global Notice Message.', apply_filters( 'gform_admin_messages', [ 'Global Notice Message.' ] )[0] );
+		$this->assertSame( 'Global Error Message.', apply_filters( 'gform_admin_error_messages', [ 'Global Error Message.' ] )[0] );
+	}
+
+	public function test_empty_set_gravitypdf_errors() {
+		$this->notices->clear( 'errors' );
+		$this->assertCount( 0, $this->notices->set_gravitypdf_errors( [] ) );
+	}
+
+	public function test_empty_set_gravitypdf_notices() {
+		$this->notices->clear( 'notices' );
+		$this->assertCount( 0, $this->notices->set_gravitypdf_notices( [] ) );
+	}
+
+	/* Test if reset_gravityforms_messages always return empty. */
+	public function test_reset_gravityforms_messages() {
+		$this->assertCount( 0, $this->notices->reset_gravityforms_messages( [ 'test' ] ) );
+	}
+
+	/* Non Filter tests, make sure that errors and messages were properly merged and return. */
+	public function test_set_gravitypdf_notices() {
+		$this->notices->add_notice( 'My Third Notice.' );
+		$this->notices->add_notice( 'My Fourth Notice.' );
+
+		$messages = $this->notices->set_gravitypdf_notices( [ 'My First Notice.', 'My Second Notice.' ] );
+
+		$this->assertCount( 4, $messages );
+		/* Test merge positions. */
+		$this->assertSame( 'My First Notice.', $messages[0] );
+		$this->assertSame( 'My Third Notice.', $messages[2] );
+
+		$this->notices->clear( 'notices' );
+		$this->assertCount( 2, $this->notices->set_gravitypdf_notices( [ 'My First Error.', 'My Second Error.' ] ) );
+		$this->assertEmpty( $this->notices->set_gravitypdf_notices( [] ) );
+	}
+
+	public function test_set_gravitypdf_error() {
+		$this->notices->add_error( 'My Third Error.' );
+		$this->notices->add_error( 'My Fourth Error.' );
+
+		$messages = $this->notices->set_gravitypdf_errors( [ 'My First Error.', 'My Second Error.' ] );
+
+		$this->assertCount( 4, $messages );
+		/* Test merge positions. */
+		$this->assertSame( 'My First Error.', $messages[0] );
+		$this->assertSame( 'My Third Error.', $messages[2] );
+
+		$this->notices->clear( 'errors' );
+		$this->assertCount( 2, $this->notices->set_gravitypdf_errors( [ 'My First Error.', 'My Second Error.' ] ) );
+		$this->assertEmpty( $this->notices->set_gravitypdf_errors( [] ) );
 	}
 }


### PR DESCRIPTION
Create a separate method that returns our `errors` and `notices`  messages exclusively to Gravity PDF pages.

NOTE: This may need some improvements on how to properly initialize the Helper_Notice class exclusively to Gravity PDF pages as well.
## Description

<!-- Describe what you have changed or added. -->
<!-- Link to the support ticket(s) where appropriate. -->

## Testing instructions
Install Gravity Forms Akismet Add-On. Its default error message should not display on PDF settings.
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
