### PR TITLE
Harden Signed URL Secret Key Creation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -118,6 +118,7 @@ If you aren't able to meet the v6 minimum requirements [you can download v5 whic
 * Security (Hardening): Prevent directory traversal when loading the various Gravity PDF UI components
 * Security (Hardening): Change PDF Form Settings capability check from `gravityforms_edit_settings` to `gravityforms_edit_forms`
 * Security (Hardening): Change Font Manager CRUD capability check from `gravityforms_view_entries` to `gravityforms_edit_forms`
+* Security (Hardening): Switch to sodium_crypto_secretbox_keygen() function with modified fallback to wp_generate_password() when generating new PDF URL signing secret key
 * Developer: Added \GFPDF\Statics\Kses::output( $html ) and \GFPDF\Statics\Kses::parse( $html ) methods for use with escaping/sanitizing HTML in PDFs (as an alternative to wp_kses_post()).
 * Performance: Register JavaScript in the footer on Gravity PDF admin pages
 * Privacy: Added "Get more info" link in the Core Font Installer instructions, and disclaimer to plugin's README.txt installation section

--- a/tests/phpunit/unit-tests/test-url-signer.php
+++ b/tests/phpunit/unit-tests/test-url-signer.php
@@ -33,4 +33,18 @@ class Test_Url_Signer extends WP_UnitTestCase {
 		$this->assertTrue( $signer->verify( $signer->sign( $url, '+ 1 day' ) ) );
 		$this->assertFalse( $signer->verify( $url ) );
 	}
+
+	public function test_random_password_filter_disabled() {
+		/* Delete the existing token (if any) */
+		\GPDFAPI::delete_plugin_option( 'signed_secret_token' );
+
+		/* Sign the URL */
+		$signer = new Helper_Url_Signer();
+		$url    = 'https://test.com';
+		$signer->sign( $url, '+ 1 day' );
+
+		/* Verify the token generated is 64 characters */
+		$secret_token = \GPDFAPI::get_plugin_option( 'signed_secret_token' );
+		$this->assertSame( 64, strlen( $secret_token ) );
+	}
 }


### PR DESCRIPTION
## Description

Replace usage of wp_generate_password() which includes the `random_password` filter, to sodium_crypto_secretbox_keygen() with fallback to modified version of wp_generate_password() which doesn't include the above filter.

## Testing instructions

1. On new installation test the signed PDF URL feature as a logged out user with the [Restrict Owner Access setting enabled
](https://docs.gravitypdf.com/v6/users/setup-pdf#restrict-owner)
2. On an existing installation test the signed PDF URL feature as a logged out user with the [Restrict Owner Access setting enabled
](https://docs.gravitypdf.com/v6/users/setup-pdf#restrict-owner)

In both cases there should be no issues with the user viewing the PDF.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
