### PR TITLE
Better Sanitizing and Escaping of PDF URLs

### DIFF
--- a/src/Model/Model_Mergetags.php
+++ b/src/Model/Model_Mergetags.php
@@ -210,7 +210,7 @@ class Model_Mergetags extends Helper_Abstract_Model {
 
 				/* Everything is valid so get the URL and display */
 				$modifiers = explode( ':', $tag[2] ?? '' );
-				$url       = $this->pdf->get_pdf_url( $tag[1], $entry['id'], (bool) in_array( 'download', $modifiers, true ), (bool) in_array( 'print', $modifiers, true ), $url_encode );
+				$url       = $this->pdf->get_pdf_url( $tag[1], $entry['id'], (bool) in_array( 'download', $modifiers, true ), (bool) in_array( 'print', $modifiers, true ) );
 
 				/*
 				 * A URL cannot be modified after signing (becomes invalid), so move the signing option to the bottom
@@ -235,6 +235,10 @@ class Model_Mergetags extends Helper_Abstract_Model {
 						default:
 							$url = apply_filters( 'gfpdf_mergetag_modifiers_url', $url, $modifier, $tag, $form, $entry, $config );
 					}
+				}
+
+				if ( $url_encode ) {
+					$url = esc_url( $url );
 				}
 
 				/* replace the merge tag */

--- a/src/Model/Model_Shortcodes.php
+++ b/src/Model/Model_Shortcodes.php
@@ -100,7 +100,7 @@ class Model_Shortcodes extends Helper_Abstract_Pdf_Shortcode {
 			$download          = $attributes['type'] === 'download';
 			$print             = ! empty( $attributes['print'] );
 			$raw               = ! empty( $attributes['raw'] );
-			$attributes['url'] = $pdf->get_pdf_url( $attributes['id'], $attributes['entry'], $download, $print, ! $raw );
+			$attributes['url'] = $pdf->get_pdf_url( $attributes['id'], $attributes['entry'], $download, $print );
 
 			/* Sign the URL to allow direct access to the PDF until it expires */
 			if ( ! empty( $attributes['signed'] ) ) {

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -328,8 +328,12 @@ class Test_PDF extends WP_UnitTestCase {
 	public function test_middle_public_access() {
 
 		/* Check if error correctly triggered */
-		$settings['public_access'] = 'No';
-		$this->model->middle_public_access( '', [], $settings );
+		$settings = [
+			'id'            => 0,
+			'public_access' => 'No',
+		];
+
+		$this->model->middle_public_access( '', [ 'id' => 0 ], $settings );
 
 		/* Run our Tests */
 		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_active' ] ) );
@@ -341,7 +345,7 @@ class Test_PDF extends WP_UnitTestCase {
 
 		/* Check if setting passes */
 		$settings['public_access'] = 'Yes';
-		$this->model->middle_public_access( '', [], $settings );
+		$this->model->middle_public_access( '', [ 'id' => 0 ], $settings );
 
 		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_active' ] ) );
 		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_conditional' ] ) );
@@ -365,7 +369,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$options          = GPDFAPI::get_options_class();
 
 		/* Test it does nothing by default */
-		$this->model->middle_signed_url_access( '', [], [] );
+		$this->model->middle_signed_url_access( '', [ 'id' => 0 ], [ 'id' => '' ] );
 
 		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_active' ] ) );
 		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_conditional' ] ) );
@@ -381,7 +385,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$_GET['signature']      = '';
 		$_SERVER['REQUEST_URI'] = str_replace( home_url(), '', $url );
 
-		$this->model->middle_signed_url_access( '', [], [] );
+		$this->model->middle_signed_url_access( '', [ 'id' => 0 ], [ 'id' => '' ] );
 
 		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_active' ] ) );
 		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_conditional' ] ) );
@@ -424,7 +428,7 @@ class Test_PDF extends WP_UnitTestCase {
 
 		$_SERVER['REQUEST_URI'] = str_replace( $protocol . $domain, '', $url );
 
-		$this->model->middle_signed_url_access( '', [], [] );
+		$this->model->middle_signed_url_access( '', [ 'id' => 0 ], [ 'id' => '' ] );
 
 		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_active' ] ) );
 		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_conditional' ] ) );
@@ -442,12 +446,16 @@ class Test_PDF extends WP_UnitTestCase {
 	public function test_middle_active() {
 
 		/* Check if error correctly triggered */
+		$settings = [
+			'id' => '',
+			'active' => false,
+		];
 		$settings['active'] = false;
-		$this->assertTrue( is_wp_error( $this->model->middle_active( '', [], $settings ) ) );
+		$this->assertTrue( is_wp_error( $this->model->middle_active( '', [ 'id' => 0 ], $settings ) ) );
 
 		/* Check if setting passes */
 		$settings['active'] = true;
-		$this->assertTrue( $this->model->middle_active( true, [], $settings ) );
+		$this->assertTrue( $this->model->middle_active( true, [ 'id' => 0 ], $settings ) );
 	}
 
 	/**
@@ -496,6 +504,7 @@ class Test_PDF extends WP_UnitTestCase {
 
 		/* Set up a blank entry array */
 		$entry = [
+			'id' =>         0,
 			'created_by' => '',
 			'ip'         => '',
 		];
@@ -538,13 +547,13 @@ class Test_PDF extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_middle_owner_restriction() {
-		$this->assertTrue( $this->model->middle_owner_restriction( true, [], [ 'restrict_owner' => 'No' ] ) );
-		$this->assertTrue( is_wp_error( $this->model->middle_owner_restriction( new WP_Error( '' ), [], [ 'restrict_owner' => 'No' ] ) ) );
+		$this->assertTrue( $this->model->middle_owner_restriction( true, [ 'id' => 0 ], [ 'id' => '', 'restrict_owner' => 'No' ] ) );
+		$this->assertTrue( is_wp_error( $this->model->middle_owner_restriction( new WP_Error( '' ), [ 'id' => 0 ], [  'id' => '', 'restrict_owner' => 'No' ] ) ) );
 
 		/* test if we are redirecting */
 		try {
 			wp_set_current_user( 0 );
-			$this->model->middle_owner_restriction( true, [], [ 'restrict_owner' => 'Yes' ] );
+			$this->model->middle_owner_restriction( true, [ 'id' => 0 ], [  'id' => '', 'restrict_owner' => 'Yes' ] );
 		} catch ( Exception $e ) {
 			$this->assertEquals( 'Redirecting', $e->getMessage() );
 		}
@@ -553,7 +562,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$user_id = $this->factory->user->create();
 		$this->assertIsInt( $user_id );
 		wp_set_current_user( $user_id );
-		$this->assertTrue( $this->model->middle_owner_restriction( true, [], [ 'restrict_owner' => 'Yes' ] ) );
+		$this->assertTrue( $this->model->middle_owner_restriction( true, [ 'id' => 0 ], [  'id' => '', 'restrict_owner' => 'Yes' ] ) );
 
 		wp_set_current_user( 0 );
 	}
@@ -568,6 +577,7 @@ class Test_PDF extends WP_UnitTestCase {
 
 		/* Set up our testing data */
 		$entry = [
+			'id' => 0,
 			'date_created' => gmdate( 'Y-m-d H:i:s', strtotime( '-32 minutes' ) ),
 			'ip'           => '197.64.12.40',
 		];
@@ -575,7 +585,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$_SERVER['REMOTE_ADDR'] = $entry['ip'];
 
 		/* Test we get a timeout error */
-		$results = $this->model->middle_logged_out_timeout( true, $entry, [] );
+		$results = $this->model->middle_logged_out_timeout( true, $entry, [ 'id' => '', ] );
 		$this->assertTrue( is_wp_error( $results ) );
 		$this->assertEquals( 'timeout_expired', $results->get_error_code() );
 
@@ -583,24 +593,24 @@ class Test_PDF extends WP_UnitTestCase {
 		$entry['created_by'] = 5;
 
 		try {
-			$this->model->middle_logged_out_timeout( true, $entry, [] );
+			$this->model->middle_logged_out_timeout( true, $entry, [ 'id' => '', ] );
 		} catch ( Exception $e ) {
 			$this->assertEquals( 'Redirecting', $e->getMessage() );
 		}
 
 		/* Update timeout settings and check again */
 		$gfpdf->options->update_option( 'logged_out_timeout', '33' );
-		$this->assertTrue( $this->model->middle_logged_out_timeout( true, $entry, [] ) );
+		$this->assertTrue( $this->model->middle_logged_out_timeout( true, $entry, [ 'id' => '', ] ) );
 
 		/* Check if the test should be skipped */
 		$_SERVER['REMOTE_ADDR'] = '12.123.123.124';
-		$this->assertTrue( $this->model->middle_logged_out_timeout( true, $entry, [] ) );
-		$this->assertTrue( is_wp_error( $this->model->middle_logged_out_timeout( new WP_Error(), $entry, [] ) ) );
+		$this->assertTrue( $this->model->middle_logged_out_timeout( true, $entry, [ 'id' => '', ] ) );
+		$this->assertTrue( is_wp_error( $this->model->middle_logged_out_timeout( new WP_Error(), $entry, [ 'id' => '', ] ) ) );
 
 		$user_id = $this->factory->user->create();
 		$this->assertIsInt( $user_id );
 		wp_set_current_user( $user_id );
-		$this->assertTrue( $this->model->middle_logged_out_timeout( true, $entry, [] ) );
+		$this->assertTrue( $this->model->middle_logged_out_timeout( true, $entry, [ 'id' => '', ] ) );
 
 		wp_set_current_user( 0 );
 	}
@@ -614,30 +624,31 @@ class Test_PDF extends WP_UnitTestCase {
 
 		/* Set up our testing data */
 		$entry = [
+			'id' => 0,
 			'ip' => '197.64.12.40',
 		];
 
 		/* Check for WP Error */
-		$this->assertTrue( is_wp_error( $this->model->middle_auth_logged_out_user( true, $entry, [] ) ) );
+		$this->assertTrue( is_wp_error( $this->model->middle_auth_logged_out_user( true, $entry, [ 'id' => '', ] ) ) );
 
 		/* Check for redirect */
 		$entry['created_by'] = 5;
 
 		try {
-			$this->model->middle_auth_logged_out_user( true, $entry, [] );
+			$this->model->middle_auth_logged_out_user( true, $entry, [ 'id' => '', ] );
 		} catch ( Exception $e ) {
 			$this->assertEquals( 'Redirecting', $e->getMessage() );
 		}
 
 		/* Test that the middleware is skipped */
 		$_SERVER['REMOTE_ADDR'] = $entry['ip'];
-		$this->assertTrue( $this->model->middle_auth_logged_out_user( true, $entry, [] ) );
+		$this->assertTrue( $this->model->middle_auth_logged_out_user( true, $entry, [ 'id' => '', ] ) );
 
 		unset( $_SERVER['REMOTE_ADDR'] );
 		$user_id = $this->factory->user->create();
 		$this->assertIsInt( $user_id );
 		wp_set_current_user( $user_id );
-		$this->assertTrue( $this->model->middle_auth_logged_out_user( true, $entry, [] ) );
+		$this->assertTrue( $this->model->middle_auth_logged_out_user( true, $entry, [ 'id' => '', ] ) );
 
 		wp_set_current_user( 0 );
 	}
@@ -649,7 +660,7 @@ class Test_PDF extends WP_UnitTestCase {
 	 */
 	public function test_middle_user_capability() {
 		/* Check for WP Error */
-		$this->assertTrue( is_wp_error( $this->model->middle_user_capability( new WP_Error(), [], [] ) ) );
+		$this->assertTrue( is_wp_error( $this->model->middle_user_capability( new WP_Error(), [ 'id' => 0, ], [ 'id' => '', ] ) ) );
 
 		/* create subscriber and test access */
 		$user_id = $this->factory->user->create();
@@ -657,7 +668,7 @@ class Test_PDF extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 
 		/* get the results */
-		$results = $this->model->middle_user_capability( true, [ 'created_by' => 0 ], [] );
+		$results = $this->model->middle_user_capability( true, [ 'id' => 0,  'created_by' => 0 ], [ 'id' => '', ] );
 
 		$this->assertTrue( is_wp_error( $results ) );
 		$this->assertEquals( 'access_denied', $results->get_error_code() );
@@ -667,14 +678,14 @@ class Test_PDF extends WP_UnitTestCase {
 		$user->remove_role( 'subscriber' );
 		$user->add_role( 'administrator' );
 
-		$this->assertTrue( $this->model->middle_user_capability( true, [ 'created_by' => 0 ], [] ) );
+		$this->assertTrue( $this->model->middle_user_capability( true, [ 'id' => 0, 'created_by' => 0 ], [ 'id' => '', ] ) );
 
 		/* Remove elevated user privilages and set the default capability 'gravityforms_view_entries' */
 		$user->remove_role( 'administrator' );
 		$user->add_role( 'subscriber' );
 
 		/* Double check they have been removed */
-		$results = $this->model->middle_user_capability( true, [ 'created_by' => 0 ], [] );
+		$results = $this->model->middle_user_capability( true, [ 'id' => 0, 'created_by' => 0 ], [ 'id' => '', ] );
 
 		$this->assertTrue( is_wp_error( $results ) );
 		$this->assertEquals( 'access_denied', $results->get_error_code() );
@@ -683,7 +694,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$user->add_cap( 'gravityforms_view_entries' );
 		$user->get_role_caps();
 		$user->update_user_level_from_caps();
-		$this->assertTrue( $this->model->middle_user_capability( true, [ 'created_by' => 0 ], [] ) );
+		$this->assertTrue( $this->model->middle_user_capability( true, [ 'id' => 0, 'created_by' => 0 ], [ 'id' => '', ] ) );
 
 		wp_set_current_user( 0 );
 	}
@@ -728,8 +739,8 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'download', $pdfs[0] );
 
 		$this->assertNotFalse( strpos( $pdfs[0]['name'], 'test-' ) );
-		$this->assertNotFalse( strpos( $pdfs[0]['view'], 'http://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1' ) );
-		$this->assertNotFalse( strpos( $pdfs[0]['download'], 'http://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1&#038;action=download' ) );
+		$this->assertNotFalse( strpos( $pdfs[0]['view'], 'http://example.org/?gpdf=1&pid=556690c67856b&lid=1' ) );
+		$this->assertNotFalse( strpos( $pdfs[0]['download'], 'http://example.org/?gpdf=1&pid=556690c67856b&lid=1&action=download' ) );
 
 		/* Process fancy permalinks */
 		$wp_rewrite->set_permalink_structure( '/%postname%/' );
@@ -863,44 +874,44 @@ class Test_PDF extends WP_UnitTestCase {
 	 */
 	public function provider_get_pdf_url_no_perma() {
 		return [
-			[ '240arkj92kda', '50', false, false, 'http://example.org/?gpdf=1&#038;pid=240arkj92kda&#038;lid=50' ],
-			[ 'kjoai2', '25', false, false, 'http://example.org/?gpdf=1&#038;pid=kjoai2&#038;lid=25' ],
+			[ '240arkj92kda', '50', false, false, 'http://example.org/?gpdf=1&pid=240arkj92kda&lid=50' ],
+			[ 'kjoai2', '25', false, false, 'http://example.org/?gpdf=1&pid=kjoai2&lid=25' ],
 			[
 				'AIfawjoi24012',
 				'9992',
 				false,
 				false,
-				'http://example.org/?gpdf=1&#038;pid=AIfawjoi24012&#038;lid=9992',
+				'http://example.org/?gpdf=1&pid=AIfawjoi24012&lid=9992',
 			],
-			[ 'JJiawfafwwaa', '5020', false, false, 'http://example.org/?gpdf=1&#038;pid=JJiawfafwwaa&#038;lid=5020' ],
-			[ 'fa2a20koawas', '2', false, false, 'http://example.org/?gpdf=1&#038;pid=fa2a20koawas&#038;lid=2' ],
+			[ 'JJiawfafwwaa', '5020', false, false, 'http://example.org/?gpdf=1&pid=JJiawfafwwaa&lid=5020' ],
+			[ 'fa2a20koawas', '2', false, false, 'http://example.org/?gpdf=1&pid=fa2a20koawas&lid=2' ],
 			[
 				'JJiawfafwwaa',
 				'5020',
 				true,
 				false,
-				'http://example.org/?gpdf=1&#038;pid=JJiawfafwwaa&#038;lid=5020&#038;action=download',
+				'http://example.org/?gpdf=1&pid=JJiawfafwwaa&lid=5020&action=download',
 			],
 			[
 				'fa2a20koawas',
 				'2',
 				false,
 				true,
-				'http://example.org/?gpdf=1&#038;pid=fa2a20koawas&#038;lid=2&#038;print=1',
+				'http://example.org/?gpdf=1&pid=fa2a20koawas&lid=2&print=1',
 			],
 			[
 				'kjoai2',
 				'25',
 				true,
 				true,
-				'http://example.org/?gpdf=1&#038;pid=kjoai2&#038;lid=25&#038;action=download&#038;print=1',
+				'http://example.org/?gpdf=1&pid=kjoai2&lid=25&action=download&print=1',
 			],
 			[
 				'AIfawjoi24012',
 				'9992',
 				true,
 				true,
-				'http://example.org/?gpdf=1&#038;pid=AIfawjoi24012&#038;lid=9992&#038;action=download&#038;print=1',
+				'http://example.org/?gpdf=1&pid=AIfawjoi24012&lid=9992&action=download&print=1',
 			],
 		];
 	}


### PR DESCRIPTION
## Description

The focus of this change is in the middleware and the PDF URL builder method. These changes are bundled together because the PDF URL generator builds signed PDF URLs, while the middleware verifies those URLs.

Additional log messages have been added to all PDF authentication middleware, or existing logs modified, to make it clearer what is occurring.

## Testing instructions

The same tests should be performed with both Pretty Permalinks enabled and disabled (Settings -> Permalinks).

1. Setup a form with a PDF configured 
2. On the Confirmation page add the [gravitypdf] shortcode and [all variants of it using all available attributes  ](https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags#building-the-shortcode)
3. Also on the Cnformation page, add the Gravity PDF merge tag [and all variants of it](https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags#building-the-merge-tag), both inside and outside a HTML anchor tag 
4. Submit the form and check that all links are valid, and all RAW URLs are valid when copying/pasting into the address bar 
5. When testing the signed URL, add a breakpoint at line 346 of Model_PDF.php and enable Xdebug. Attempt to view a signed PDF URL and ensure the debugger stops at the breakpoint each time.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
