### PR TITLE
Switch from Text to Password field for license keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
 
     "test:e2e": "cross-env NODE_ENV=test testcafe chrome tests/e2e -s takeOnFails=true,fullPage=true --disable-multiple-windows -e",
     "test:e2e:headless": "cross-env NODE_ENV=test testcafe chrome:headless tests/e2e -s takeOnFails=true,fullPage=true --disable-multiple-windows -e",
-    "test:e2e:file": "cross-env NODE_ENV=test testcafe chrome tests/e2e -s takeOnFails=true,fullPage=true",
-    "test:e2e:watch": "cross-env NODE_ENV=test testcafe chrome tests/e2e -L --disable-multiple-windows -e",
+    "test:e2e:file": "cross-env NODE_ENV=test testcafe chrome -L",
+    "test:e2e:watch": "cross-env NODE_ENV=test testcafe chrome tests/e2e -L",
     "test:php": "npm run env docker-run -- php ./vendor/bin/phpunit",
     "test:php:multisite": "npm run env docker-run -- php ./vendor/bin/phpunit -c tests/phpunit/multisite.xml",
     "test:js": "jest --verbose",

--- a/src/Helper/Helper_Abstract_Addon.php
+++ b/src/Helper/Helper_Abstract_Addon.php
@@ -523,6 +523,11 @@ abstract class Helper_Abstract_Addon {
 
 		$license_info = $this->get_license_info();
 
+		/* If the license info is empty disable check */
+		if ( empty( array_filter( $license_info ) ) ) {
+			return false;
+		}
+
 		$response = wp_remote_post(
 			$this->data->store_url,
 			[

--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -1720,18 +1720,17 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		</label>
 
 		<input autocomplete="off"
-			   type="text"
-			   class="regular-text"
+			   type="password"
 			   id="gfpdf_settings[<?php echo esc_attr( $args['id'] ); ?>]"
 			   class="<?php echo esc_attr( 'gfpdf_settings_' . $args['id'] ); ?>"
 			   name="gfpdf_settings[<?php echo esc_attr( $args['id'] ); ?>]"
-			   value="<?php echo esc_attr( $value['key'] ); ?>"
+			   value="<?php echo esc_attr( ! empty( $value['key'] ) ? sha1( $value['key'] ) : '' ); ?>"
 		/>
 
 		<?php if ( $is_active ): ?>
-			<button class="button primary white gfpdf-deactivate-license"
+			<button type="button"
+					class="button primary white gfpdf-deactivate-license"
 					data-addon-name="<?php echo esc_attr( substr( $args['id'], 8 ) ); ?>"
-					data-license="<?php echo esc_attr( $value['key'] ); ?>"
 					data-nonce="<?php echo esc_attr( wp_create_nonce( 'gfpdf_deactivate_license' ) ); ?>"
 			>
 				<?php echo esc_attr__( 'Deactivate License', 'gravity-forms-pdf-extended' ); ?>

--- a/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
+++ b/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
@@ -20,19 +20,19 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Allows plugins to use their own update API.
  *
  * @author  Easy Digital Downloads
- * @version 1.8.0
+ * @version 1.9.2
  */
 class EDD_SL_Plugin_Updater {
 
-	private $api_url = '';
-	private $api_data = [];
-	private $name = '';
-	private $slug = '';
-	private $version = '';
+	private $api_url     = '';
+	private $api_data    = [];
+	private $plugin_file = '';
+	private $name        = '';
+	private $slug        = '';
+	private $version     = '';
 	private $wp_override = false;
-	private $cache_key = '';
-
-	private $health_check_timeout = 5;
+	private $beta        = false;
+	private $failed_request_cache_key;
 
 	/**
 	 * Class constructor.
@@ -49,14 +49,15 @@ class EDD_SL_Plugin_Updater {
 
 		global $edd_plugin_data;
 
-		$this->api_url     = trailingslashit( $_api_url );
-		$this->api_data    = $_api_data;
-		$this->name        = plugin_basename( $_plugin_file );
-		$this->slug        = basename( $_plugin_file, '.php' );
-		$this->version     = $_api_data['version'];
-		$this->wp_override = isset( $_api_data['wp_override'] ) ? (bool) $_api_data['wp_override'] : false;
-		$this->beta        = ! empty( $this->api_data['beta'] ) ? true : false;
-		$this->cache_key   = 'edd_sl_' . md5( serialize( $this->slug . $this->api_data['license'] . $this->beta ) );
+		$this->api_url                  = trailingslashit( $_api_url );
+		$this->api_data                 = $_api_data;
+		$this->plugin_file              = $_plugin_file;
+		$this->name                     = plugin_basename( $_plugin_file );
+		$this->slug                     = basename( $_plugin_file, '.php' );
+		$this->version                  = $_api_data['version'];
+		$this->wp_override              = isset( $_api_data['wp_override'] ) ? (bool) $_api_data['wp_override'] : false;
+		$this->beta                     = ! empty( $this->api_data['beta'] ) ? true : false;
+		$this->failed_request_cache_key = 'edd_sl_failed_http_' . md5( $this->api_url );
 
 		$edd_plugin_data[ $this->slug ] = $this->api_data;
 
@@ -86,8 +87,7 @@ class EDD_SL_Plugin_Updater {
 
 		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ] );
 		add_filter( 'plugins_api', [ $this, 'plugins_api_filter' ], 10, 3 );
-		remove_action( 'after_plugin_row_' . $this->name, 'wp_plugin_update_row', 10 );
-		add_action( 'after_plugin_row_' . $this->name, [ $this, 'show_update_notification' ], 10, 2 );
+		add_action( 'after_plugin_row', [ $this, 'show_update_notification' ], 10, 2 );
 		add_action( 'admin_init', [ $this, 'show_changelog' ] );
 
 	}
@@ -111,11 +111,7 @@ class EDD_SL_Plugin_Updater {
 		global $pagenow;
 
 		if ( ! is_object( $_transient_data ) ) {
-			$_transient_data = new stdClass;
-		}
-
-		if ( 'plugins.php' == $pagenow && is_multisite() ) {
-			return $_transient_data;
+			$_transient_data = new stdClass();
 		}
 
 		if ( ! empty( $_transient_data->response ) && ! empty( $_transient_data->response[ $this->name ] ) && false === $this->wp_override ) {
@@ -161,6 +157,7 @@ class EDD_SL_Plugin_Updater {
 			// This is required for your plugin to support auto-updates in WordPress 5.5.
 			$version_info->plugin = $this->name;
 			$version_info->id     = $this->name;
+			$version_info->tested = $this->get_tested_version( $version_info );
 
 			$this->set_version_info_cache( $version_info );
 		}
@@ -169,122 +166,165 @@ class EDD_SL_Plugin_Updater {
 	}
 
 	/**
-	 * show update nofication row -- needed for multisite subsites, because WP won't tell you otherwise!
+	 * Gets the plugin's tested version.
+	 *
+	 * @param object $version_info
+	 *
+	 * @return null|string
+	 * @since 1.9.2
+	 */
+	private function get_tested_version( $version_info ) {
+
+		// There is no tested version.
+		if ( empty( $version_info->tested ) ) {
+			return null;
+		}
+
+		// Strip off extra version data so the result is x.y or x.y.z.
+		[ $current_wp_version ] = explode( '-', get_bloginfo( 'version' ) );
+
+		// The tested version is greater than or equal to the current WP version, no need to do anything.
+		if ( version_compare( $version_info->tested, $current_wp_version, '>=' ) ) {
+			return $version_info->tested;
+		}
+		$current_version_parts = explode( '.', $current_wp_version );
+		$tested_parts          = explode( '.', $version_info->tested );
+
+		// The current WordPress version is x.y.z, so update the tested version to match it.
+		if ( isset( $current_version_parts[2] ) && $current_version_parts[0] === $tested_parts[0] && $current_version_parts[1] === $tested_parts[1] ) {
+			$tested_parts[2] = $current_version_parts[2];
+		}
+
+		return implode( '.', $tested_parts );
+	}
+
+	/**
+	 * Show the update notification on multisite subsites.
 	 *
 	 * @param string $file
 	 * @param array  $plugin
 	 */
 	public function show_update_notification( $file, $plugin ) {
 
-		if ( is_network_admin() ) {
+		// Return early if in the network admin, or if this is not a multisite install.
+		if ( is_network_admin() || ! is_multisite() ) {
 			return;
 		}
 
-		if ( ! current_user_can( 'update_plugins' ) ) {
+		// Allow single site admins to see that an update is available.
+		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return;
 		}
 
-		if ( ! is_multisite() ) {
+		if ( $this->name !== $file ) {
 			return;
 		}
 
-		if ( $this->name != $file ) {
-			return;
-		}
-
-		// Remove our filter on the site transient
-		remove_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ], 10 );
-
+		// Do not print any message if update does not exist.
 		$update_cache = get_site_transient( 'update_plugins' );
 
-		$update_cache = is_object( $update_cache ) ? $update_cache : new stdClass();
-
-		if ( empty( $update_cache->response ) || empty( $update_cache->response[ $this->name ] ) ) {
-
-			$version_info = $this->get_repo_api_data();
-
-			if ( false === $version_info ) {
-				$version_info = $this->api_request( 'plugin_latest_version', [ 'slug' => $this->slug, 'beta' => $this->beta ] );
-
-				// Since we disabled our filter for the transient, we aren't running our object conversion on banners, sections, or icons. Do this now:
-				if ( isset( $version_info->banners ) && ! is_array( $version_info->banners ) ) {
-					$version_info->banners = $this->convert_object_to_array( $version_info->banners );
-				}
-
-				if ( isset( $version_info->sections ) && ! is_array( $version_info->sections ) ) {
-					$version_info->sections = $this->convert_object_to_array( $version_info->sections );
-				}
-
-				if ( isset( $version_info->icons ) && ! is_array( $version_info->icons ) ) {
-					$version_info->icons = $this->convert_object_to_array( $version_info->icons );
-				}
-
-				if ( isset( $version_info->contributors ) && ! is_array( $version_info->contributors ) ) {
-					$version_info->contributors = $this->convert_object_to_array( $version_info->contributors );
-				}
-
-				$this->set_version_info_cache( $version_info );
+		if ( ! isset( $update_cache->response[ $this->name ] ) ) {
+			if ( ! is_object( $update_cache ) ) {
+				$update_cache = new stdClass();
 			}
-
-			if ( ! is_object( $version_info ) ) {
-				return;
-			}
-
-			if ( version_compare( $this->version, $version_info->new_version, '<' ) ) {
-				$update_cache->response[ $this->name ] = $version_info;
-			} else {
-				$update_cache->no_update[ $this->name ] = $version_info;
-			}
-
-			$update_cache->last_checked           = time();
-			$update_cache->checked[ $this->name ] = $this->version;
-
-			set_site_transient( 'update_plugins', $update_cache );
-
-		} else {
-
-			$version_info = $update_cache->response[ $this->name ];
-
+			$update_cache->response[ $this->name ] = $this->get_repo_api_data();
 		}
 
-		// Restore our filter
-		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ] );
+		// Return early if this plugin isn't in the transient->response or if the site is running the current or newer version of the plugin.
+		if ( empty( $update_cache->response[ $this->name ] ) || version_compare( $this->version, $update_cache->response[ $this->name ]->new_version, '>=' ) ) {
+			return;
+		}
 
-		if ( ! empty( $update_cache->response[ $this->name ] ) && version_compare( $this->version, $version_info->new_version, '<' ) ) {
+		printf(
+			'<tr class="plugin-update-tr %3$s" id="%1$s-update" data-slug="%1$s" data-plugin="%2$s">',
+			$this->slug,
+			$file,
+			in_array( $this->name, $this->get_active_plugins(), true ) ? 'active' : 'inactive'
+		);
 
-			// build a plugin list row, with update notification
-			$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
-			# <tr class="plugin-update-tr"><td colspan="' . $wp_list_table->get_column_count() . '" class="plugin-update colspanchange">
-			echo '<tr class="plugin-update-tr" id="' . $this->slug . '-update" data-slug="' . $this->slug . '" data-plugin="' . $this->slug . '/' . $file . '">';
-			echo '<td colspan="3" class="plugin-update colspanchange">';
-			echo '<div class="update-message notice inline notice-warning notice-alt">';
+		echo '<td colspan="3" class="plugin-update colspanchange">';
+		echo '<div class="update-message notice inline notice-warning notice-alt"><p>';
 
-			$changelog_link = self_admin_url( 'index.php?edd_sl_action=view_plugin_changelog&plugin=' . $this->name . '&slug=' . $this->slug . '&TB_iframe=true&width=772&height=911' );
+		$changelog_link = '';
+		if ( ! empty( $update_cache->response[ $this->name ]->sections->changelog ) ) {
+			$changelog_link = add_query_arg(
+				[
+					'edd_sl_action' => 'view_plugin_changelog',
+					'plugin'        => rawurlencode( $this->name ),
+					'slug'          => rawurlencode( $this->slug ),
+					'TB_iframe'     => 'true',
+					'width'         => 77,
+					'height'        => 911,
+				],
+				self_admin_url( 'index.php' )
+			);
+		}
+		$update_link = add_query_arg(
+			[
+				'action' => 'upgrade-plugin',
+				'plugin' => rawurlencode( $this->name ),
+			],
+			self_admin_url( 'update.php' )
+		);
 
-			if ( empty( $version_info->download_link ) ) {
-				printf(
-					__( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s.', 'gravity-forms-pdf-extended' ),
-					esc_html( $version_info->name ),
-					'<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
-					esc_html( $version_info->new_version ),
+		printf(
+		/* translators: the plugin name. */
+			esc_html__( 'There is a new version of %1$s available.', 'gravity-forms-pdf-extended' ),
+			esc_html( $plugin['Name'] )
+		);
+
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			echo ' ';
+			esc_html_e( 'Contact your network administrator to install the update.', 'gravity-forms-pdf-extended' );
+		} elseif ( empty( $update_cache->response[ $this->name ]->package ) && ! empty( $changelog_link ) ) {
+			echo ' ';
+			wp_kses_post(
+				sprintf(
+				/* translators: 1. opening anchor tag, do not translate 2. the new plugin version 3. closing anchor tag, do not translate. */
+					__( '%1$sView version %2$s details%3$s.', 'gravity-forms-pdf-extended' ),
+					'<a target="_blank" class="thickbox open-plugin-details-modal" href="' . esc_url( $changelog_link ) . '">',
+					esc_html( $update_cache->response[ $this->name ]->new_version ),
 					'</a>'
-				);
-			} else {
-				printf(
-					__( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s or %5$supdate now%6$s.', 'gravity-forms-pdf-extended' ),
-					esc_html( $version_info->name ),
-					'<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
-					esc_html( $version_info->new_version ),
+				)
+			);
+		} elseif ( ! empty( $changelog_link ) ) {
+			echo ' ';
+			wp_kses_post(
+				sprintf(
+					__( '%1$sView version %2$s details%3$s or %4$supdate now%5$s.', 'gravity-forms-pdf-extended' ),
+					'<a target="_blank" class="thickbox open-plugin-details-modal" href="' . esc_url( $changelog_link ) . '">',
+					esc_html( $update_cache->response[ $this->name ]->new_version ),
 					'</a>',
-					'<a href="' . esc_url( wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $this->name, 'upgrade-plugin_' . $this->name ) ) . '">',
+					'<a target="_blank" class="update-link" href="' . esc_url( wp_nonce_url( $update_link, 'upgrade-plugin_' . $file ) ) . '">',
 					'</a>'
-				);
-			}
-
-			do_action( "in_plugin_update_message-{$file}", $plugin, $version_info );
-
-			echo '</div></td></tr>';
+				)
+			);
+		} else {
+			wp_kses_post(
+				sprintf(
+					' %1$s%2$s%3$s',
+					'<a target="_blank" class="update-link" href="' . esc_url( wp_nonce_url( $update_link, 'upgrade-plugin_' . $file ) ) . '">',
+					esc_html__( 'Update now.', 'gravity-forms-pdf-extended' ),
+					'</a>'
+				)
+			);
 		}
+
+		do_action( "in_plugin_update_message-{$file}", $plugin, $plugin );
+
+		echo '</p></div></td></tr>';
+	}
+
+	/**
+	 * Gets the plugins active in a multisite network.
+	 *
+	 * @return array
+	 */
+	private function get_active_plugins() {
+		$active_plugins         = (array) get_option( 'active_plugins' );
+		$active_network_plugins = (array) get_site_option( 'active_sitewide_plugins' );
+
+		return array_merge( $active_plugins, array_keys( $active_network_plugins ) );
 	}
 
 	/**
@@ -300,13 +340,13 @@ class EDD_SL_Plugin_Updater {
 	 */
 	public function plugins_api_filter( $_data, $_action = '', $_args = null ) {
 
-		if ( $_action != 'plugin_information' ) {
+		if ( 'plugin_information' !== $_action ) {
 
 			return $_data;
 
 		}
 
-		if ( ! isset( $_args->slug ) || ( $_args->slug != $this->slug ) ) {
+		if ( ! isset( $_args->slug ) || ( $_args->slug !== $this->slug ) ) {
 
 			return $_data;
 
@@ -336,7 +376,6 @@ class EDD_SL_Plugin_Updater {
 			if ( false !== $api_response ) {
 				$_data = $api_response;
 			}
-
 		} else {
 			$_data = $edd_api_request_transient;
 		}
@@ -381,6 +420,9 @@ class EDD_SL_Plugin_Updater {
 	 *
 	 */
 	private function convert_object_to_array( $data ) {
+		if ( ! is_array( $data ) && ! is_object( $data ) ) {
+			return [];
+		}
 		$new_data = [];
 		foreach ( $data as $key => $value ) {
 			$new_data[ $key ] = is_object( $value ) ? $this->convert_object_to_array( $value ) : $value;
@@ -399,9 +441,8 @@ class EDD_SL_Plugin_Updater {
 	 */
 	public function http_request_args( $args, $url ) {
 
-		$verify_ssl = $this->verify_ssl();
 		if ( strpos( $url, 'https://' ) !== false && strpos( $url, 'edd_action=package_download' ) ) {
-			$args['sslverify'] = $verify_ssl;
+			$args['sslverify'] = $this->verify_ssl();
 		}
 
 		return $args;
@@ -414,67 +455,151 @@ class EDD_SL_Plugin_Updater {
 	 * @param string $_action The requested action.
 	 * @param array  $_data   Parameters for the API action.
 	 *
-	 * @return false|object
+	 * @return false|object|void
 	 * @uses get_bloginfo()
 	 * @uses wp_remote_post()
 	 * @uses is_wp_error()
 	 *
 	 */
 	private function api_request( $_action, $_data ) {
+		$data = array_merge( $this->api_data, $_data );
 
-		global $wp_version, $edd_plugin_url_available;
+		if ( $data['slug'] !== $this->slug ) {
+			return;
+		}
 
-		$verify_ssl = $this->verify_ssl();
+		// Don't allow a plugin to ping itself
+		if ( trailingslashit( home_url() ) === $this->api_url ) {
+			return false;
+		}
 
-		// Do a quick status check on this domain if we haven't already checked it.
-		$store_hash = md5( $this->api_url );
-		if ( ! is_array( $edd_plugin_url_available ) || ! isset( $edd_plugin_url_available[ $store_hash ] ) ) {
-			$test_url_parts = parse_url( $this->api_url );
+		if ( $this->request_recently_failed() ) {
+			return false;
+		}
 
-			$scheme = ! empty( $test_url_parts['scheme'] ) ? $test_url_parts['scheme'] : 'http';
-			$host   = ! empty( $test_url_parts['host'] ) ? $test_url_parts['host'] : '';
-			$port   = ! empty( $test_url_parts['port'] ) ? ':' . $test_url_parts['port'] : '';
+		return $this->get_version_from_remote();
+	}
 
-			if ( empty( $host ) ) {
-				$edd_plugin_url_available[ $store_hash ] = false;
-			} else {
-				$test_url                                = $scheme . '://' . $host . $port;
-				$response                                = wp_remote_get( $test_url, [ 'timeout' => $this->health_check_timeout, 'sslverify' => $verify_ssl ] );
-				$edd_plugin_url_available[ $store_hash ] = is_wp_error( $response ) ? false : true;
+	/**
+	 * Determines if a request has recently failed.
+	 *
+	 * @return bool
+	 * @since 1.9.1
+	 *
+	 */
+	private function request_recently_failed() {
+		$failed_request_details = get_option( $this->failed_request_cache_key );
+
+		// Request has never failed.
+		if ( empty( $failed_request_details ) || ! is_numeric( $failed_request_details ) ) {
+			return false;
+		}
+
+		/*
+		 * Request previously failed, but the timeout has expired.
+		 * This means we're allowed to try again.
+		 */
+		if ( time() > $failed_request_details ) {
+			delete_option( $this->failed_request_cache_key );
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Logs a failed HTTP request for this API URL.
+	 * We set a timestamp for 1 hour from now. This prevents future API requests from being
+	 * made to this domain for 1 hour. Once the timestamp is in the past, API requests
+	 * will be allowed again. This way if the site is down for some reason we don't bombard
+	 * it with failed API requests.
+	 *
+	 * @see   EDD_SL_Plugin_Updater::request_recently_failed
+	 *
+	 * @since 1.9.1
+	 */
+	private function log_failed_request() {
+		update_option( $this->failed_request_cache_key, strtotime( '+1 hour' ) );
+	}
+
+	/**
+	 * If available, show the changelog for sites in a multisite install.
+	 */
+	public function show_changelog() {
+
+		if ( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' !== $_REQUEST['edd_sl_action'] ) {
+			return;
+		}
+
+		if ( empty( $_REQUEST['plugin'] ) ) {
+			return;
+		}
+
+		if ( empty( $_REQUEST['slug'] ) || $this->slug !== $_REQUEST['slug'] ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			wp_die( esc_html__( 'You do not have permission to install plugin updates', 'gravity-forms-pdf-extended' ), esc_html__( 'Error', 'gravity-forms-pdf-extended' ), [ 'response' => 403 ] );
+		}
+
+		$version_info = $this->get_repo_api_data();
+		if ( isset( $version_info->sections ) ) {
+			$sections = $this->convert_object_to_array( $version_info->sections );
+			if ( ! empty( $sections['changelog'] ) ) {
+				echo '<div style="background:#fff;padding:10px;">' . wp_kses_post( $sections['changelog'] ) . '</div>';
 			}
 		}
 
-		if ( false === $edd_plugin_url_available[ $store_hash ] ) {
-			return false;
-		}
+		exit;
+	}
 
-		$data = array_merge( $this->api_data, $_data );
-
-		if ( $data['slug'] != $this->slug ) {
-			return false;
-		}
-
-		if ( $this->api_url == trailingslashit( home_url() ) ) {
-			return false; // Don't allow a plugin to ping itself
-		}
-
+	/**
+	 * Gets the current version information from the remote site.
+	 *
+	 * @return array|false
+	 */
+	private function get_version_from_remote() {
 		$api_params = [
-			'edd_action' => 'get_version',
-			'license'    => ! empty( $data['license'] ) ? $data['license'] : '',
-			'item_name'  => isset( $data['item_name'] ) ? $data['item_name'] : false,
-			'item_id'    => isset( $data['item_id'] ) ? $data['item_id'] : false,
-			'version'    => isset( $data['version'] ) ? $data['version'] : false,
-			'slug'       => $data['slug'],
-			'author'     => $data['author'],
-			'url'        => home_url(),
-			'beta'       => ! empty( $data['beta'] ),
+			'edd_action'  => 'get_version',
+			'license'     => ! empty( $this->api_data['license'] ) ? $this->api_data['license'] : '',
+			'item_name'   => isset( $this->api_data['item_name'] ) ? $this->api_data['item_name'] : false,
+			'item_id'     => isset( $this->api_data['item_id'] ) ? $this->api_data['item_id'] : false,
+			'version'     => isset( $this->api_data['version'] ) ? $this->api_data['version'] : false,
+			'slug'        => $this->slug,
+			'author'      => $this->api_data['author'],
+			'url'         => home_url(),
+			'beta'        => $this->beta,
+			'php_version' => phpversion(),
+			'wp_version'  => get_bloginfo( 'version' ),
 		];
 
-		$request = wp_remote_post( $this->api_url, [ 'timeout' => 15, 'sslverify' => $verify_ssl, 'body' => $api_params ] );
+		/**
+		 * Filters the parameters sent in the API request.
+		 *
+		 * @param array  $api_params The array of data sent in the request.
+		 * @param array  $this-      >api_data    The array of data set up in the class constructor.
+		 * @param string $this-      >plugin_file The full path and filename of the file.
+		 */
+		$api_params = apply_filters( 'edd_sl_plugin_updater_api_params', $api_params, $this->api_data, $this->plugin_file );
 
-		if ( ! is_wp_error( $request ) ) {
-			$request = json_decode( wp_remote_retrieve_body( $request ) );
+		$request = wp_remote_post(
+			$this->api_url,
+			[
+				'timeout'   => 15,
+				'sslverify' => $this->verify_ssl(),
+				'body'      => $api_params,
+			]
+		);
+
+		if ( is_wp_error( $request ) || ( 200 !== wp_remote_retrieve_response_code( $request ) ) ) {
+			$this->log_failed_request();
+
+			return false;
 		}
+
+		$request = json_decode( wp_remote_retrieve_body( $request ) );
 
 		if ( $request && isset( $request->sections ) ) {
 			$request->sections = maybe_unserialize( $request->sections );
@@ -500,95 +625,23 @@ class EDD_SL_Plugin_Updater {
 	}
 
 	/**
-	 * If available, show the changelog for sites in a multisite install.
-	 */
-	public function show_changelog() {
-
-		global $edd_plugin_data;
-
-		if ( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' != $_REQUEST['edd_sl_action'] ) {
-			return;
-		}
-
-		if ( empty( $_REQUEST['plugin'] ) ) {
-			return;
-		}
-
-		if ( empty( $_REQUEST['slug'] ) ) {
-			return;
-		}
-
-		if ( ! current_user_can( 'update_plugins' ) ) {
-			wp_die( __( 'You do not have permission to install plugin updates', 'gravity-forms-pdf-extended' ), __( 'Error', 'gravity-forms-pdf-extended' ), [ 'response' => 403 ] );
-		}
-
-		$data         = $edd_plugin_data[ $_REQUEST['slug'] ];
-		$version_info = $this->get_cached_version_info();
-
-		if ( false === $version_info ) {
-
-			$api_params = [
-				'edd_action' => 'get_version',
-				'item_name'  => isset( $data['item_name'] ) ? $data['item_name'] : false,
-				'item_id'    => isset( $data['item_id'] ) ? $data['item_id'] : false,
-				'slug'       => $_REQUEST['slug'],
-				'author'     => $data['author'],
-				'url'        => home_url(),
-				'beta'       => ! empty( $data['beta'] ),
-			];
-
-			$verify_ssl = $this->verify_ssl();
-			$request    = wp_remote_post( $this->api_url, [ 'timeout' => 15, 'sslverify' => $verify_ssl, 'body' => $api_params ] );
-
-			if ( ! is_wp_error( $request ) ) {
-				$version_info = json_decode( wp_remote_retrieve_body( $request ) );
-			}
-
-			if ( ! empty( $version_info ) && isset( $version_info->sections ) ) {
-				$version_info->sections = maybe_unserialize( $version_info->sections );
-			} else {
-				$version_info = false;
-			}
-
-			if ( ! empty( $version_info ) ) {
-				foreach ( $version_info->sections as $key => $section ) {
-					$version_info->$key = (array) $section;
-				}
-			}
-
-			$this->set_version_info_cache( $version_info );
-
-			// Delete the unneeded option
-			delete_option( md5( 'edd_plugin_' . sanitize_key( $_REQUEST['plugin'] ) . '_' . $this->beta . '_version_info' ) );
-		}
-
-		if ( isset( $version_info->sections ) ) {
-			$sections = $this->convert_object_to_array( $version_info->sections );
-			if ( ! empty( $sections['changelog'] ) ) {
-				echo '<div style="background:#fff;padding:10px;">' . wp_kses_post( $sections['changelog'] ) . '</div>';
-			}
-		}
-
-		exit;
-	}
-
-	/**
-	 * Gets the plugin's cached version information from the database.
+	 * Get the version info from the cache, if it exists.
 	 *
 	 * @param string $cache_key
 	 *
-	 * @return boolean|string
+	 * @return object
 	 */
 	public function get_cached_version_info( $cache_key = '' ) {
 
 		if ( empty( $cache_key ) ) {
-			$cache_key = $this->cache_key;
+			$cache_key = $this->get_cache_key();
 		}
 
 		$cache = get_option( $cache_key );
 
+		// Cache is expired
 		if ( empty( $cache['timeout'] ) || time() > $cache['timeout'] ) {
-			return false; // Cache is expired
+			return false;
 		}
 
 		// We need to turn the icons into an array, thanks to WP Core forcing these into an object at some point.
@@ -610,12 +663,12 @@ class EDD_SL_Plugin_Updater {
 	public function set_version_info_cache( $value = '', $cache_key = '' ) {
 
 		if ( empty( $cache_key ) ) {
-			$cache_key = $this->cache_key;
+			$cache_key = $this->get_cache_key();
 		}
 
 		$data = [
 			'timeout' => strtotime( '+3 hours', time() ),
-			'value'   => json_encode( $value ),
+			'value'   => wp_json_encode( $value ),
 		];
 
 		update_option( $cache_key, $data, 'no' );
@@ -632,6 +685,18 @@ class EDD_SL_Plugin_Updater {
 	 */
 	private function verify_ssl() {
 		return (bool) apply_filters( 'edd_sl_api_request_verify_ssl', true, $this );
+	}
+
+	/**
+	 * Gets the unique key (option name) for a plugin.
+	 *
+	 * @return string
+	 * @since 1.9.0
+	 */
+	private function get_cache_key() {
+		$string = $this->slug . $this->api_data['license'] . $this->beta;
+
+		return 'edd_sl_' . md5( serialize( $string ) );
 	}
 
 }

--- a/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
+++ b/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
@@ -23,7 +23,6 @@ export function setupLicenseDeactivation () {
     const data = {
       action: 'gfpdf_deactivate_license',
       addon_name: slug,
-      license: $(this).data('license'),
       nonce: $(this).data('nonce')
     }
 

--- a/tests/e2e/tabs/license/sample-plugin-license.test.js
+++ b/tests/e2e/tabs/license/sample-plugin-license.test.js
@@ -8,7 +8,7 @@ test('should display error message for invalid license key', async t => {
   // Actions
   await run.navigateCoreBooster('gf_settings&subview=PDF&tab=license')
   await t
-    .typeText(run.samplePluginInputBox, run.invalidLicenseKey, { paste: true })
+    .typeText(run.samplePluginInputBox, run.invalidLicenseKey, { paste: true, replace: true })
     .click(run.saveSettings)
 
   // Assertions
@@ -21,7 +21,7 @@ test('should display success message and deactivation option for active license 
   // Actions
   await run.navigateCoreBooster('gf_settings&subview=PDF&tab=license')
   await t
-    .typeText(run.samplePluginInputBox, run.validLicenseKey, { paste: true })
+    .typeText(run.samplePluginInputBox, run.validLicenseKey, { paste: true, replace: true })
     .click(run.saveSettings)
 
   // Assertions

--- a/tests/e2e/utilities/page-model/tabs/license.js
+++ b/tests/e2e/utilities/page-model/tabs/license.js
@@ -6,7 +6,7 @@ class License {
     // Core Booster field
     this.samplePluginInputBox = Selector('#gfpdf-fieldset-license_gravity-pdf-example-plugin').find('[id="gfpdf_settings[license_gravity-pdf-example-plugin]"]')
     this.validLicenseKey = '987654321'
-    this.invalidLicenseKey = '12345678934535435334'
+    this.invalidLicenseKey = '123456789'
     this.invalidLicenseKeyMessage = Selector('.gforms_note_error').withText('Invalid license key provided')
     this.deactivateLinkMessage = Selector('button').withText('Deactivate License')
     this.successMessage = Selector('.gforms_note_success').withText('Your support license key has been successfully validated.')

--- a/tests/phpunit/unit-tests/test-addon.php
+++ b/tests/phpunit/unit-tests/test-addon.php
@@ -235,6 +235,12 @@ class Test_Addon extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', $api_response );
 
+		$this->addon->update_license_info( [
+			'license' => '12345',
+			'status'  => 'active',
+			'message' => '',
+		] );
+
 		$this->assertFalse( wp_next_scheduled( 'gfpdf_' . $this->addon->get_slug() . '_license_check' ) );
 		$this->assertFalse( $this->addon->schedule_license_check() );
 		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_' . $this->addon->get_slug() . '_license_check' ) );

--- a/tests/phpunit/unit-tests/test-settings.php
+++ b/tests/phpunit/unit-tests/test-settings.php
@@ -436,6 +436,17 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->assertEquals( 'Invalid license key provided', $results['license_other-plugin_message'] );
 		$this->assertEquals( 'missing', $results['license_other-plugin_status'] );
 
+		/* Check that the hashed license reverts back to the unhashed version before saving */
+		$results = $this->model->maybe_active_licenses(
+			[
+				'license_other-plugin'         => sha1( 'license key' ),
+				'license_other-plugin_message' => 'message',
+				'license_other-plugin_status'  => 'active',
+			]
+		);
+
+		$this->assertEquals( 'license key', $results['license_other-plugin'] );
+
 		/* Reset our work */
 		remove_filter( 'pre_http_request', $api_response );
 		$gfpdf->data->addon = [];


### PR DESCRIPTION
## Description

To reduce the chance of an unauthorised third party stealing a Gravity PDF license key from a customer whose site they manage, the license page will now use Password field's instead of Text fields. The pre-populated passwords will be hashed using `sha1` on the front end to prevent the source code from being inspected.

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
