### PR TITLE
Switch to a querypath fork with PHP8.1 support

### DIFF
--- a/.php-scoper/querypath.php
+++ b/.php-scoper/querypath.php
@@ -21,8 +21,8 @@ return [
 	 * For more see: https://github.com/humbug/php-scoper#finders-and-paths
 	 */
 	'finders'   => [
-		Finder::create()->files()->in( $path . 'vendor/querypath/querypath/' )->depth( '== 0' )->name( [ 'CREDITS', 'COPYING-MIT.txt' ] ),
-		Finder::create()->files()->in( $path . 'vendor/querypath/querypath/src/' )->name( [ '*.php' ] ),
+		Finder::create()->files()->in( $path . 'vendor/arthurkushman/query-path/' )->depth( '== 0' )->name( [ 'CREDITS', 'COPYING-MIT.txt' ] ),
+		Finder::create()->files()->in( $path . 'vendor/arthurkushman/query-path/src/' )->name( [ '*.php' ] ),
 		Finder::create()->files()->in( $path . 'vendor/masterminds/html5/' )->depth( '== 0' )->name( [ 'LICENSE.txt', 'CREDITS' ] ),
 		Finder::create()->files()->in( $path . 'vendor/masterminds/html5/src/' )->name( [ '*.php' ] ),
 	],

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
   "require": {
     "php": ">=7.3",
     "mpdf/mpdf": "8.0.*",
-    "querypath/querypath": ">=3.0.0",
     "monolog/monolog": "^2.1.0",
     "codeguy/upload": "^1.3",
     "spatie/url-signer": "^1.1",
-    "mpdf/qrcode": "^1.0"
+    "mpdf/qrcode": "^1.0",
+    "arthurkushman/query-path": "^3.1"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",

--- a/src/Helper/Helper_QueryPath.php
+++ b/src/Helper/Helper_QueryPath.php
@@ -3,7 +3,7 @@
 namespace GFPDF\Helper;
 
 use GFPDF_Vendor\Masterminds\HTML5;
-use GFPDF_Vendor\QueryPath;
+use GFPDF_Vendor\QueryPath\QueryPath;
 use GFPDF_Vendor\QueryPath\DOMQuery;
 
 /**

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -15,4 +15,5 @@ require_once PDF_PLUGIN_DIR . 'vendor/autoload.php';
 require_once PDF_PLUGIN_DIR . 'src/deprecated.php';
 require_once PDF_PLUGIN_DIR . 'api.php';
 
-require_once PDF_PLUGIN_DIR . 'vendor_prefixed/querypath/querypath/src/qp_functions.php';
+class_alias( '\GFPDF_Vendor\QueryPath\QueryPath', '\GFPDF_Vendor\QueryPath' ); /* Backwards compatibility support */
+require_once PDF_PLUGIN_DIR . 'vendor_prefixed/arthurkushman/query-path/src/qp_functions.php';


### PR DESCRIPTION
## Description

I've asked the author to tag the release with the PHP8.1 fixes included. Composer should be updated with the tagged release before merging.

Resolves https://github.com/GravityPDF/gravity-pdf/issues/1364

## Testing instructions
Automated tests handle all this.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
