### PR TITLE
Upgrade mPDF to 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "require": {
     "php": ">=7.3",
-    "mpdf/mpdf": "8.0.*",
+    "mpdf/mpdf": "^8.1",
     "monolog/monolog": "^2.1.0",
     "spatie/url-signer": "^1.1",
     "mpdf/qrcode": "^1.0",


### PR DESCRIPTION
## Description

We delayed upgrading to mPDF 8.1 previously due to an image rendering bug which appears to be resolved now. 

## Testing instructions

If using the Docker testing environment, run:

```bash
rm composer.lock
npm run env docker-run -- php composer install
bash ./bin/vendor-prefix.sh
```

Otherwise, run:

```bash
rm composer.lock
composer install
bash ./bin/vendor-prefix.sh
```

The following items need testing:

1. All Core Template
1. All Universal Templates
1. All Invoice Templates
1. All Letter Templates
1. All Certificate Templates

Note: I have pushed updates out for Tritan and Aryal so the SVG images get displayed correctly.

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
