### PR TITLE
Add form/input support for Gravity PDF Notices

### DIFF
--- a/src/Helper/Helper_Notices.php
+++ b/src/Helper/Helper_Notices.php
@@ -204,10 +204,25 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @since 4.0
 	 */
 	private function html( $text, $class = 'updated' ) {
+		$allow_form_elements = static function( $tags ) {
+			$tags['input'] = [
+				'type'  => true,
+				'name'  => true,
+				'value' => true,
+				'class' => true,
+			];
+
+			return $tags;
+		};
+
+		add_filter( 'wp_kses_allowed_html', $allow_form_elements );
+
 		?>
 		<div class="<?php echo esc_attr( $class ); ?> notice">
 			<p><?php echo wp_kses_post( $text ); ?></p>
 		</div>
 		<?php
+
+		remove_filter( 'wp_kses_allowed_html', $allow_form_elements );
 	}
 }

--- a/tests/phpunit/unit-tests/test-notices.php
+++ b/tests/phpunit/unit-tests/test-notices.php
@@ -147,4 +147,16 @@ class Test_Notices extends WP_UnitTestCase {
 		$this->assertNotFalse( strpos( $html, '<p>My First Notice</p>' ) );
 		$this->assertNotFalse( strpos( $html, '<p>My First Error</p>' ) );
 	}
+
+	public function test_html_notice() {
+		$form = 'Message <form method="post"><p><button class="button">Action</button><input class="button primary" type="submit" value="Dismiss" /></p></form>';
+
+		$this->notices->add_notice( $form );
+
+		ob_start();
+		$this->notices->process();
+		$html = ob_get_clean();
+
+		$this->assertNotFalse( strpos( $html, $form ) );
+	}
 }


### PR DESCRIPTION
## Description

This ensures the Core Font Installer prompt works as expected when the plugin is first installed.

@TODO: write unit tests

Resolves #1372

## Testing instructions
1. Install Gravity PDF on a new WordPress installation 
1. Activate the plugin 
1. Click the "Install Core Fonts" button 
1. Ensure you get redirected to the Tools page and starts the font installer

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
