### PR TITLE
Fix Field Select not displaying when the saved value is 0

### DIFF
--- a/src/Helper/Fields/Field_Select.php
+++ b/src/Helper/Fields/Field_Select.php
@@ -87,7 +87,7 @@ class Field_Select extends Helper_Abstract_Fields {
 		$value = $this->value();
 
 		if ( apply_filters( 'gfpdf_field_is_empty_value_instead_of_label', true, $value, $this->field, $this->entry, $this->form, $this ) ) {
-			return empty( $value['value'] );
+			return $value['value'] === '';
 		}
 
 		return parent::is_empty();

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Select.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Select.php
@@ -57,6 +57,27 @@ class Test_Field_Select extends WP_UnitTestCase {
 		remove_filter( 'gfpdf_field_is_empty_value_instead_of_label', '__return_false' );
 	}
 
+	public function test_is_empty_true() {
+
+		$pdf_field = new Field_Select( $this->gf_field, [ 'form_id' => $this->form['id'], 3 => '', ], \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+		$this->assertTrue( $pdf_field->is_empty() );
+
+		$pdf_field = new Field_Select( $this->gf_field, [ 'form_id' => $this->form['id'], 3 => null, ], \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+		$this->assertTrue( $pdf_field->is_empty() );
+	}
+
+	public function test_is_empty_false() {
+
+		$pdf_field = new Field_Select( $this->gf_field, [ 'form_id' => $this->form['id'], 3 => true, ], \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+		$this->assertFalse( $pdf_field->is_empty() );
+
+		$pdf_field = new Field_Select( $this->gf_field, [ 'form_id' => $this->form['id'], 3 => 'Jane', ], \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+		$this->assertFalse( $pdf_field->is_empty() );
+
+		$pdf_field = new Field_Select( $this->gf_field, [ 'form_id' => $this->form['id'], 3 => 0, ], \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+		$this->assertFalse( $pdf_field->is_empty() );
+	}
+
 	public function test_value_with_empty_value() {
 		$value = $this->pdf_field->value();
 


### PR DESCRIPTION
## Description
This PR will check if the select value is "real" empty by update the `is_empty` conditon to `===` instead of `empty()` which returns false if the value is 0.
<!-- Describe what you have changed or added. -->
<!-- Link to the support ticket(s) where appropriate. -->

#1377

## Testing instructions
Create a Select field with one of the option value is 0.  When saved and viewed it should NOT display in the pdf.
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
