### PR TITLE
Add "data" protocol support in PDFs

### DIFF
--- a/src/Statics/Kses.php
+++ b/src/Statics/Kses.php
@@ -43,7 +43,9 @@ class Kses {
 	 */
 	public static function parse( string $html ): string {
 		add_filter( 'safe_style_css', '\GFPDF\Statics\Kses::get_allowed_pdf_styles' );
-		$html = wp_kses( $html, self::get_allowed_pdf_tags() );
+
+		$html = wp_kses( $html, self::get_allowed_pdf_tags(), self::get_allowed_pdf_protocols() );
+
 		remove_filter( 'safe_style_css', '\GFPDF\Statics\Kses::get_allowed_pdf_styles' );
 
 		return $html;
@@ -290,7 +292,7 @@ class Kses {
 			'name'    => true,
 		];
 
-		return $tags;
+		return apply_filters( 'gfpdf_wp_kses_allowed_html', $tags );
 	}
 
 	/**
@@ -307,7 +309,7 @@ class Kses {
 			return $styles;
 		}
 
-		return array_merge(
+		$styles = array_merge(
 			$styles,
 			[
 				'background-image-opacity',
@@ -322,5 +324,26 @@ class Kses {
 				'z-index',
 			]
 		);
+
+		return apply_filters( 'gfpdf_wp_kses_allowed_pdf_styles', $styles );
+	}
+
+	/**
+	 * A custom list of allowed protocols in the PDF
+	 *
+	 * @param array|null $protocols
+	 *
+	 * @return array
+	 *
+	 * @since 6.4.2
+	 */
+	public static function get_allowed_pdf_protocols( $protocols = null ): array {
+		if ( ! is_array( $protocols ) ) {
+			$protocols = wp_allowed_protocols();
+		}
+
+		$protocols[] = 'data';
+
+		return apply_filters( 'gfpdf_wp_kses_allowed_pdf_protocols', $protocols );
 	}
 }

--- a/tests/phpunit/unit-tests/Statics/Test_kses.php
+++ b/tests/phpunit/unit-tests/Statics/Test_kses.php
@@ -77,6 +77,7 @@ class Test_Kses extends WP_UnitTestCase {
 			['<tocpagebreak toc-odd-header-name="A" toc-odd-footer-name="B" toc-odd-header-value="C" toc-odd-footer-value="D" />'],
 			[ '<tocpagebreak toc-bookmarkText="A" toc-resetpagenum="1" toc-resetpagestyle="A" toc-suppress="1" />' ],
 			[ '<tocentry content="A" level="B" name="C" />' ],
+			[ '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII" alt="Icon" width="200mm" />']
 		];
 	}
 


### PR DESCRIPTION
## Description

The 6.4 update is stripping out images with a base-64 encoded data string in fields. Three filters have been added so developers can add new tag support dynamically if needed.

## Testing instructions

Automated test covers it.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
