### PR TITLE
Enable Multisite test runner on GA

### DIFF
--- a/.github/workflows/phpunit.tests.yml
+++ b/.github/workflows/phpunit.tests.yml
@@ -118,7 +118,13 @@ jobs:
           yarn env:install
 
       - name: Run PHPUnit tests
+        if: ${{ ! matrix.multisite }}
         run: yarn test:php --do-not-cache-result --verbose
+        continue-on-error: ${{ matrix.php == '8.1' }}
+
+      - name: Run Multisite PHPUnit tests
+        if: ${{ matrix.multisite }}
+        run: yarn test:php:multisite --verbose
         continue-on-error: ${{ matrix.php == '8.1' }}
 
       # TODO: XDEBUG isnt working for unit tests https://github.com/WordPress/gutenberg/issues/42286

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -407,6 +407,8 @@ class Test_PDF extends WP_UnitTestCase {
 		gf_upgrade()->install();
 
 		/* Setup some test data */
+		$_SERVER['HTTP_HOST'] = str_replace( [ 'http://', 'http://' ], '', home_url() );
+		
 		$results          = $this->create_form_and_entries();
 		$entry            = $results['entry'];
 		$entry['form_id'] = $results['form']['id'];


### PR DESCRIPTION
## Description

GA wasn't running out multisite PHPUnit test. This PR fixes that and patches an issue with one of the multi-site specific tests

## Testing instructions
Automated testing suite.

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
