### PR TITLE
Support Pre-WP5.9 with Core Font Installer Feature

### DIFF
--- a/src/Controller/Controller_Save_Core_Fonts.php
+++ b/src/Controller/Controller_Save_Core_Fonts.php
@@ -132,7 +132,8 @@ class Controller_Save_Core_Fonts extends Helper_Abstract_Controller implements H
 	protected function download_and_save_font() {
 
 		/* Verify the font name provided is approved */
-		$core_font_list = wp_json_file_decode( __DIR__ . '/../../dist/payload/core-fonts.json', [ 'associative' => true ] );
+		/* phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents */
+		$core_font_list = json_decode( file_get_contents( __DIR__ . '/../../dist/payload/core-fonts.json' ), true );
 		if ( $core_font_list === null ) {
 			$this->log->error( 'Core font list could not be loaded' );
 


### PR DESCRIPTION
## Description

Resolves #1391

## Testing instructions
Run the Core Font Installer on WordPress 5.8

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
