### PR TITLE
Use Codecov action for PHP Coverage Report

### DIFF
--- a/.github/workflows/phpunit.tests.yml
+++ b/.github/workflows/phpunit.tests.yml
@@ -126,8 +126,13 @@ jobs:
         run: yarn test:php:multisite --verbose
         continue-on-error: ${{ matrix.php == '8.1' }}
 
-      - name: Code Coverage
+      - name: Generate Code Coverage Report for PHP
         if: ${{ matrix.report }}
         run: |
-          yarn run test:php --do-not-cache-result --verbose --coverage-clover=tmp/coverage/report-xml/php-coverage1.xml
-          bash <(curl -s https://codecov.io/bash);
+          yarn run test:php --do-not-cache-result --verbose --coverage-clover=/var/www/html/wp-content/plugins/gravity-pdf/tmp/coverage/report-xml/php-coverage1.xml
+
+      - name: Code Coverage Upload
+        uses: codecov/codecov-action@v3
+        if: ${{ matrix.report }}
+        with:
+          files: tmp/coverage/report-xml/php-coverage1.xml


### PR DESCRIPTION
## Description

Resolves missing code coverage report on the PHP GitHub actions.

## Testing instructions
Automated tests

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
