### PR TITLE
Fix URL Escape issue when using Image Path

### DIFF
--- a/src/Helper/Fields/Field_Post_Image.php
+++ b/src/Helper/Fields/Field_Post_Image.php
@@ -65,7 +65,8 @@ class Field_Post_Image extends Helper_Abstract_Fields {
 		$html = '';
 		if ( ! empty( $value['url'] ) ) {
 			$html  = '<a href="' . esc_url( $value['url'] ) . '" target="_blank">';
-			$html .= '<img width="150" src="' . esc_url( $value['url'] ) . '" />';
+			$html .= '<img width="150" src="' . ( $value['path'] !== $value['url'] ? esc_attr( $value['path'] ) : esc_url( $value['url'] ) ) . '" />';
+			$html .= '</a>';
 		}
 
 		/* Include title / caption / description if needed */
@@ -80,8 +81,6 @@ class Field_Post_Image extends Helper_Abstract_Fields {
 		if ( ! empty( $value['description'] ) ) {
 			$html .= '<div class="gfpdf-post-image-description">' . esc_html( $value['description'] ) . '</div>';
 		}
-
-		$html .= '</a>';
 
 		return parent::html( $html );
 	}
@@ -131,13 +130,13 @@ class Field_Post_Image extends Helper_Abstract_Fields {
 			$value = explode( '|:|', $this->get_value() );
 
 			$img['url']         = ( isset( $value[0] ) ) ? esc_url( $value[0] ) : '';
-			$img['path']        = ( isset( $value[0] ) ) ? esc_url( $value[0] ) : '';
+			$img['path']        = $img['url'];
 			$img['title']       = ( isset( $value[1] ) ) ? esc_html( $value[1] ) : '';
 			$img['caption']     = ( isset( $value[2] ) ) ? esc_html( $value[2] ) : '';
 			$img['description'] = ( isset( $value[3] ) ) ? esc_html( $value[3] ) : '';
 
 			$path = ( isset( $value[0] ) ) ? $this->misc->convert_url_to_path( $value[0] ) : '';
-			if ( $path !== $img['url'] ) {
+			if ( $path !== false && $path !== $img['url'] ) {
 				$img['path'] = $path;
 			}
 		}

--- a/src/Helper/Fields/Field_Signature.php
+++ b/src/Helper/Fields/Field_Signature.php
@@ -123,7 +123,7 @@ class Field_Signature extends Helper_Abstract_Fields {
 			$optimised_width = apply_filters( 'gfpdf_signature_width', $optimised_width, $signature_details[0] );
 
 			$optimised_height = $signature_details[1] / 3;
-			$html             = str_replace( 'width="' . esc_attr( $width ) . '"', 'width="' . esc_attr( $optimised_width ) . '"', $html );
+			$html             = '<img src="' . esc_attr( $signature ) . '" alt="Signature" width="' . esc_attr( $optimised_width ) . '" />';
 
 			/* override the default width */
 			$width  = $optimised_width;

--- a/src/Helper/Fields/Field_Slim.php
+++ b/src/Helper/Fields/Field_Slim.php
@@ -37,7 +37,7 @@ class Field_Slim extends Helper_Abstract_Fields {
 		$url   = $value['url'];
 
 		$image = $value['path'] ?? $value['url'];
-		$html  = '<a href="' . esc_url( $url ) . '"><img src="' . esc_url( $image ) . '" /></a>';
+		$html  = '<a href="' . esc_url( $url ) . '"><img src="' . isset( $value['path'] ) ? esc_attr( $image ) : esc_url( $image ) . '" /></a>';
 
 		return parent::html( $html );
 	}

--- a/src/Helper/Fields/Field_Slim_Post.php
+++ b/src/Helper/Fields/Field_Slim_Post.php
@@ -37,7 +37,7 @@ class Field_Slim_Post extends Helper_Abstract_Fields {
 		$url   = $value['url'];
 
 		$image = $value['path'] ?? $value['url'];
-		$html  = '<a href="' . esc_url( $url ) . '"><img src="' . esc_url( $image ) . '" /></a>';
+		$html  = '<a href="' . esc_url( $url ) . '"><img src="' . isset( $value['path'] ) ? esc_attr( $image ) : esc_url( $image ) . '" /></a>';
 
 		return parent::html( $html );
 	}

--- a/src/Statics/Kses.php
+++ b/src/Statics/Kses.php
@@ -344,6 +344,9 @@ class Kses {
 
 		$protocols[] = 'data';
 
+		/* allow Windows drive letters */
+		$protocols = array_merge( $protocols, range( 'a', 'z' ) );
+
 		return apply_filters( 'gfpdf_wp_kses_allowed_pdf_protocols', $protocols );
 	}
 }

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Post_Image.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Post_Image.php
@@ -1,0 +1,105 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Fields;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2022, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   helper
+ * @group   fields
+ */
+class Test_Field_Post_Image extends WP_UnitTestCase {
+
+	/**
+	 * @var array
+	 */
+	public $form;
+
+	/**
+	 * @var \GF_Field_Post_Image
+	 */
+	public $gf_field;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->form = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+
+		foreach ( $this->form['fields'] as $field ) {
+			if ( $field->type === 'post_image' ) {
+				$this->gf_field = $field;
+				break;
+			}
+		}
+	}
+
+	public function test_html_with_windows_drive_path() {
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$field = new class( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() ) extends Field_Post_Image {
+			public function value() {
+				return [
+					'url' => 'http://example.org/image.jpg',
+					'path' => 'C:\My Documents\Images\image.jpg',
+				];
+			}
+		};
+
+		$html = str_replace( "\n", '', $field->html() );
+
+		$this->assertStringContainsString( '<a href="http://example.org/image.jpg" target="_blank"><img width="150" src="c:\My Documents\Images\image.jpg" /></a>', $html );
+	}
+
+	public function test_html_with_windows_unc_path() {
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$field = new class( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() ) extends Field_Post_Image {
+			public function value() {
+				return [
+					'url' => 'http://example.org/image.jpg',
+					'path' => '\\My Documents\Images\image.jpg',
+				];
+			}
+		};
+
+		$html = str_replace( "\n", '', $field->html() );
+
+		$this->assertStringContainsString( '<a href="http://example.org/image.jpg" target="_blank"><img width="150" src="\\My Documents\Images\image.jpg" /></a>', $html );
+
+		/* UNC path pointed to named drive on the network */
+		$field = new class( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() ) extends Field_Post_Image {
+			public function value() {
+				return [
+					'url' => 'http://example.org/image.jpg',
+					'path' => '\\system07\C$\My Documents\Images\image.jpg',
+				];
+			}
+		};
+
+		$html = str_replace( "\n", '', $field->html() );
+
+		$this->assertStringContainsString( '<a href="http://example.org/image.jpg" target="_blank"><img width="150" src="\\system07\C$\My Documents\Images\image.jpg" /></a>', $html );
+	}
+
+	public function test_html_with_linux_path() {
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$field = new class( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() ) extends Field_Post_Image {
+			public function value() {
+				return [
+					'url' => 'http://example.org/image.jpg',
+					'path' => '/var/www/html/image.jpg',
+				];
+			}
+		};
+
+		$html = str_replace( "\n", '', $field->html() );
+
+		$this->assertStringContainsString( '<a href="http://example.org/image.jpg" target="_blank"><img width="150" src="/var/www/html/image.jpg" /></a>', $html );
+	}
+}

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Signature.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Signature.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Fields;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2022, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   helper
+ * @group   fields
+ */
+class Test_Field_Signature extends WP_UnitTestCase {
+
+	/**
+	 * @var array
+	 */
+	public $form;
+
+	/**
+	 * @var \GF_Field_Signature
+	 */
+	public $gf_field;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->form = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+
+		foreach ( $this->form['fields'] as $field ) {
+			if ( $field->type === 'signature' ) {
+				$this->gf_field = $field;
+				break;
+			}
+		}
+	}
+
+	public function test_html_with_windows_drive_path() {
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$field = new class( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() ) extends Field_Signature {
+			public function value() {
+				return [
+					'img' => '<img width="150" src="c:\My Documents\Images\image.jpg" />',
+				];
+			}
+
+			public function is_empty() {
+				return false;
+			}
+		};
+
+		$html = str_replace( "\n", '', $field->html() );
+
+		$this->assertStringContainsString( '<img width="150" src="c:\My Documents\Images\image.jpg" />', $html );
+	}
+
+	public function test_html_with_windows_unc_path() {
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$field = new class( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() ) extends Field_Signature {
+			public function value() {
+				return [
+					'img' => '<img width="150" src="\\My Documents\Images\image.jpg" />',
+				];
+			}
+
+			public function is_empty() {
+				return false;
+			}
+		};
+
+		$html = str_replace( "\n", '', $field->html() );
+
+		$this->assertStringContainsString( '<img width="150" src="\\My Documents\Images\image.jpg" />', $html );
+
+		/* UNC path pointed to named drive on the network */
+		$field = new class( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() ) extends Field_Signature {
+			public function value() {
+				return [
+					'img' => '<img width="150" src="\\system07\C$\My Documents\Images\image.jpg" />',
+				];
+			}
+
+			public function is_empty() {
+				return false;
+			}
+		};
+
+		$html = str_replace( "\n", '', $field->html() );
+
+		$this->assertStringContainsString( '<img width="150" src="\\system07\C$\My Documents\Images\image.jpg" />', $html );
+	}
+
+	public function test_html_with_linux_path() {
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$field = new class( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() ) extends Field_Signature {
+			public function value() {
+				return [
+					'img' => '<img width="150" src="/var/www/html/image.jpg" />',
+				];
+			}
+
+			public function is_empty() {
+				return false;
+			}
+		};
+
+		$html = str_replace( "\n", '', $field->html() );
+
+		$this->assertStringContainsString( '<img width="150" src="/var/www/html/image.jpg" />', $html );
+	}
+}


### PR DESCRIPTION
## Description

Resolves escaping issue when using a Windows-based local path in images.

`esc_url()` will completely remove a Windows-based local path and the PDF will show an image-not-found icon.

## Testing instructions

On a Windows machine with a local development environment (not containered), add a signature field to your form, fill out the form, and view the PDF. Prior to this update the signature wouldn't show. After the update it does.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
