### PR TITLE
Fix Core v3 Template Issues

### DIFF
--- a/src/Helper/Fields/Field_V3_Products.php
+++ b/src/Helper/Fields/Field_V3_Products.php
@@ -37,11 +37,21 @@ class Field_V3_Products extends Field_Products {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
+		$output_enabled = false;
+		if ( $this->get_output() ) {
+			$this->disable_output();
+			$output_enabled = true;
+		}
+
 		$html = parent::html( $value, $label );
 
+		if ( $output_enabled ) {
+			$this->enable_output();
+		}
+
 		/* Format the order label correctly */
-		$label = apply_filters( 'gform_order_label', esc_html__( 'Order', 'gravityforms' ), $this->form->id );
-		$label = apply_filters( 'gform_order_label_' . $this->form->id, $label, $this->form->id );
+		$label = apply_filters( 'gform_order_label', esc_html__( 'Order', 'gravityforms' ), $this->form['id'] );
+		$label = apply_filters( 'gform_order_label_' . $this->form['id'], $label, $this->form['id'] );
 
 		$heading = '<h2 class="default entry-view-section-break">' . esc_html( $label ) . '</h2>';
 

--- a/src/deprecated.php
+++ b/src/deprecated.php
@@ -479,7 +479,7 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 					$results['field'][] = $field->type !== 'section' ? $class->html() : $class->html( $config['section_content'] );
 				} else {
 					$class->enable_output();
-					$field->type !== 'section' ? $class->html() : $class->html( $config['section_content'] );
+					$field->type !== 'section' ? $class->html() : $class->html( $config['section_content'] ?? false );
 				}
 			}
 		}


### PR DESCRIPTION
## Description

This PR fixes:

1. Duplicate Product Table
2. PHP Notice due to bad form ID reference
3. Array key undefined reference

## Testing instructions

Install the following template and configure on a form with a:

1. Section Break
1. HTML Field
1. Product field

[onepage.php.txt](https://github.com/GravityPDF/gravity-pdf/files/9266118/onepage.php.txt)

Verify there isn't a duplicate product table, or any PHP errors/warnings present.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
