### PR TITLE
Gravity Wiz eCommerce Coupon Product Table Support

### DIFF
--- a/src/Helper/Fields/Field_Products.php
+++ b/src/Helper/Fields/Field_Products.php
@@ -142,10 +142,11 @@ class Field_Products extends Helper_Abstract_Fields {
 
 						<tbody class="contents">
 						<?php
-						foreach ( $products['products'] as $field_id => $product ) :
+						foreach ( $products['products'] as $field_id => $product ):
+							$field_id = explode( '|', $field_id )[0];
 
 							/* Skip over Gravity Perks Ecommerce Fields */
-							if ( class_exists( 'GP_Ecommerce_Fields' ) && in_array( $fields[ $field_id ]->type, [ 'tax', 'discount' ], true ) ) {
+							if ( class_exists( 'GP_Ecommerce_Fields' ) && in_array( $fields[ $field_id ]->type, [ 'tax', 'discount', 'coupon' ], true ) ) {
 								continue;
 							}
 							?>
@@ -196,7 +197,7 @@ class Field_Products extends Helper_Abstract_Fields {
 											rowspan="<?php echo esc_attr( $gpecommerce->get_order_summary_item_count( $order_summary ) ); ?>"></td>
 									<?php endif; ?>
 									<td class="totals" style="<?php esc_attr( $gpecommerce->style( ".order-summary/tfoot/{$class}/td.column-3" ) ); ?>">
-										<?php echo esc_html( $item['name'] ); ?>
+										<?php Kses::output( $item['name'] ); ?>
 									</td>
 
 									<td class="totals" style="<?php esc_attr( $gpecommerce->style( ".order-summary/tfoot/{$class}/td.column-4" ) ); ?>">


### PR DESCRIPTION
## Description

When the Gravity Wiz eCommerce add-on is installed and activated, this PR will:

1. Resolves a HTML encoding issue in the Coupon field Label (Gravity Forms Coupon add-on) when displaying in the product table.
2. Removes the coupon from the product line items
3. Resolves a PHP Notice when checking the coupon field type due to the `$field_id` containing both the ID and code, separated by a `|` character.

## Testing instructions
1. Install the Gravity Wiz e-Commerce Perk
1. Install the Gravity Forms Coupon add-on
1. Create a form with a Product field, Option field, Subtotal field, Tax Field, Discount Field, and Coupon Field
1. Go to Forms -> Coupons and setup a coupon code for this new form
1. Submit a test entry with the product and options purchased. Apply the coupon code.
1. Setup a Core PDF on the form and view the results of that test entry

The PDF should correctly generate a Product table that matches what is shown on the Entry Details page.

## Screenshots <!-- if applicable -->

![Screen Shot 2022-08-08 at 2 20 14 pm](https://user-images.githubusercontent.com/2918419/183338399-0d753a5b-1cb8-439c-b74a-6f9a24a5cb2b.png)

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
