### PR TITLE
Fix Windows Path issue when using Background Image

### DIFF
--- a/src/View/html/PDF/core_template_styles.php
+++ b/src/View/html/PDF/core_template_styles.php
@@ -31,14 +31,9 @@ $footer       = $settings['footer'] ?? '';
 $first_header = $settings['first_header'] ?? '';
 $first_footer = $settings['first_footer'] ?? '';
 
-$background_color = $settings['background_color'] ?? '#FFF';
-$background_image = $settings['background_image'] ?? '';
-
-/* Try convert the background image URL to a local path */
-$background_image_path = $gfpdf->misc->convert_url_to_path( $background_image );
-if ( $background_image_path !== false ) {
-	$background_image = $background_image_path;
-}
+$background_color      = $settings['background_color'] ?? '#FFF';
+$background_image      = $settings['background_image'] ?? '';
+$background_image_path = ! empty( $background_image ) ? $gfpdf->misc->convert_url_to_path( $background_image ) : false;
 
 $contrast                  = $gfpdf->misc->get_background_and_border_contrast( $background_color );
 $contrast_background_color = $contrast['background'];
@@ -71,7 +66,7 @@ $include_product_styles = apply_filters( 'gfpdf_include_product_styles', true, $
 	<?php endif; ?>
 
 	<?php if ( ! empty( $background_image ) ) : ?>
-		background-image: url(<?php echo esc_url_raw( $background_image ); ?>) no-repeat 0 0;
+		background-image: url(<?php echo $background_image_path !== false ? esc_attr( $background_image_path ) : esc_url_raw( $background_image ); ?>) no-repeat 0 0;
 		background-image-resize: 4;
 	<?php endif; ?>
 	}


### PR DESCRIPTION
## Description

Resolves an escaping issue with a windows-based path when using `esc_url_raw()` by conditionally using `esc_attr()` instead.

## Testing instructions
1. Setup a PDF on a form and configure a Background Image 
2. Verify the image displays in the PDF

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
