### PR TITLE
Process Background Image merge tag 

### DIFF
--- a/src/View/View_PDF.php
+++ b/src/View/View_PDF.php
@@ -614,7 +614,7 @@ class View_PDF extends Helper_Abstract_View {
 	public function get_core_template_styles( $settings, $entry ) {
 		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
-		$html = $this->load_core_template_styles( $settings );
+		$html = $this->load_core_template_styles( $settings, $form, $entry );
 
 		$html = apply_filters( 'gfpdf_pdf_core_template_html_output', $html, $form, $entry, $settings );
 		$html = apply_filters( 'gfpdf_pdf_core_template_html_output_' . $form['id'], $html, $form, $entry, $settings );
@@ -625,14 +625,24 @@ class View_PDF extends Helper_Abstract_View {
 	/**
 	 * Load our core PDF template settings
 	 *
-	 * @param $settings
+	 * @param array $settings Current PDF Settings being processed
+	 * @param array $form Current form being processed (added in 6.5)
+	 * @param array $entry Current form being processed (added in 6.5)
 	 *
 	 * @return string|WP_Error
 	 *
 	 * @since 4.0
 	 */
-	public function load_core_template_styles( $settings ) {
-		return $this->load( 'core_template_styles', [ 'settings' => $settings ], false );
+	public function load_core_template_styles( $settings, $form = [], $entry = [] ) {
+		return $this->load(
+			'core_template_styles',
+			[
+				'settings' => $settings,
+				'form'     => $form,
+				'entry'    => $entry,
+			],
+			false
+		);
 	}
 
 	/**

--- a/src/View/html/PDF/core_template_styles.php
+++ b/src/View/html/PDF/core_template_styles.php
@@ -19,6 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * @var    $settings array
+ * @var    $form     array
+ * @var    $entry    array
  * @global $gfpdf
  */
 
@@ -32,7 +34,7 @@ $first_header = $settings['first_header'] ?? '';
 $first_footer = $settings['first_footer'] ?? '';
 
 $background_color      = $settings['background_color'] ?? '#FFF';
-$background_image      = $settings['background_image'] ?? '';
+$background_image      = $gfpdf->gform->process_tags( $settings['background_image'] ?? '', $form, $entry );
 $background_image_path = ! empty( $background_image ) ? $gfpdf->misc->convert_url_to_path( $background_image ) : false;
 
 $contrast                  = $gfpdf->misc->get_background_and_border_contrast( $background_color );

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -408,7 +408,6 @@ class Test_PDF extends WP_UnitTestCase {
 
 		/* Setup some test data */
 		$_SERVER['HTTP_HOST'] = str_replace( [ 'http://', 'http://' ], '', home_url() );
-		
 		$results          = $this->create_form_and_entries();
 		$entry            = $results['entry'];
 		$entry['form_id'] = $results['form']['id'];
@@ -1866,7 +1865,7 @@ class Test_PDF extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_core_template_options() {
-
+		$data  = $this->create_form_and_entries();
 		/* Setup the test data */
 		$settings = [
 			'font'             => 'Arial',
@@ -1879,12 +1878,12 @@ class Test_PDF extends WP_UnitTestCase {
 			'footer'           => 'This is the footer',
 			'first_footer'     => 'This is the first footer',
 
-			'background_image' => '/path/image.png',
+			'background_image' => '/path/image.png?{:16}',
 			'background_color' => '#FF2222',
 		];
 
 		ob_start();
-		$this->view->core_template_styles( [ 'settings' => $settings ] );
+		$this->view->core_template_styles( [ 'settings' => $settings, 'form' => $data['form'] , 'entry' =>  $data['entry'] ] );
 		$results = ob_get_clean();
 
 		/* Test the results */
@@ -1903,7 +1902,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertNotFalse( strpos( $results, 'This is the footer' ) );
 		$this->assertNotFalse( strpos( $results, 'This is the first footer' ) );
 
-		$this->assertNotFalse( strpos( $results, 'background-image: url(/path/image.png) no-repeat 0 0;' ) );
+		$this->assertNotFalse( strpos( $results, 'background-image: url(/path/image.png?https://gravitypdf.com) no-repeat 0 0;' ) );
 		$this->assertNotFalse( strpos( $results, 'background-image-resize: 4;' ) );
 
 		$this->assertNotFalse( strpos( $results, 'background-color: #FF2222;' ) );


### PR DESCRIPTION
## Description
This PR should solve the issue #1406. 
<!-- Describe what you have changed or added. -->
- I have added `$form` and `$entry` to  View_PDF's  `load_core_template_styles` method. This will enable us to use `process_tags`. 
- Added an `if` statement that checks if the background-image value contains an merge tag before proceeding.
<!-- Link to the support ticket(s) where appropriate. -->
#1406 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->

- Setup a Core PDF on the form
- In the Background Image setting insert a URL to an image in the media library
- Add a merge tag to the image URL
- View the PDF and append URL with ?html=1
- View the page source and see the merge tag was not correctly converted to the associated value

<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
