### PR TITLE
Resolve cssClass grid repetition using repeater fields

### DIFF
--- a/src/Helper/Helper_Field_Container_Gf25.php
+++ b/src/Helper/Helper_Field_Container_Gf25.php
@@ -60,7 +60,7 @@ class Helper_Field_Container_Gf25 extends Helper_Field_Container {
 
 		parent::generate( $field );
 
-		if ( $this->get_field_width( $field ) < 100 ) {
+		if ( $this->get_field_width( $field ) < 100 && strpos( $field->cssClass, 'grid grid-' ) === false ) {
 			$field->cssClass .= ' grid grid-' . $field->layoutGridColumnSpan;
 		}
 

--- a/tests/phpunit/unit-tests/Helper/Test_Helper_Field_Container_Gf25.php
+++ b/tests/phpunit/unit-tests/Helper/Test_Helper_Field_Container_Gf25.php
@@ -60,4 +60,19 @@ class Test_Helper_Field_Container_Gf25 extends WP_UnitTestCase {
 
 		return $html;
 	}
+
+	public function test_css_grid_insertion() {
+		$field = new \GF_Field();
+		$field->cssClass = '';
+		$field->layoutGridColumnSpan = 6;
+
+		$this->class->generate( $field );
+
+		$this->assertSame(' grid grid-6', $field->cssClass );
+
+		$this->class->generate( $field );
+		$this->assertSame(' grid grid-6', $field->cssClass );
+
+		ob_end_clean();
+	}
 }


### PR DESCRIPTION
## Description

Solves PDF generation problem when using the Nested Forms add-on with Gravity Forms Columns when using a lot of repeater data.

This problems stems from the fact that `$form['fields']` contains an array of field objects and our container changes the cssClass value by including our grid classes, when appropriate. This is normally fine, however, when inside a nested forms field those same form fields are processed multiple times and this would inject the grid CSS classes over and over again. This could cause display problems in the PDFs.

## Testing instructions
1. Create a Parent and Child form and include the Nested Forms field in the Parent  
2. The Child form needs to have fields positioned in columns using Drag and Drop
3. Configure Zadani on the parent form 
4. Submit a test entry and include 3 nested form entries 
5. View the PDF HTML mark-up using `?html=1` and ensure you don't see the same `grid grid-#` classes duplicated/repeating multiple times in the fields i.e you don't want to see: `grid grid-6 grid grid-6` or `grid grid-6 grid grid-6 grid grid-6`. 

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
