### PR TITLE
Give Nested Forms Entries a Unique ID

### DIFF
--- a/src/Helper/Fields/Field_Form.php
+++ b/src/Helper/Fields/Field_Form.php
@@ -74,16 +74,27 @@ class Field_Form extends Helper_Abstract_Fields {
 		$html = '';
 
 		/* Get the Nested Form Entries */
-		$value = explode( ',', $this->value() );
-		foreach ( $value as $id ) {
+		$value    = explode( ',', $this->value() );
+		$field_id = $this->field->id;
+		foreach ( $value as $key => $id ) {
 			$entry = $this->gform->get_entry( (int) trim( $id ) );
 			if ( is_wp_error( $entry ) ) {
 				continue;
 			}
 
 			/* Output the entry HTML mark-up */
-			$html .= parent::html( $this->get_repeater_html( $form, $entry ) );
+			$markup = $this->get_repeater_html( $form, $entry );
+
+			/* Ensure the IDs are all unique by suffixing with the key */
+			$markup = preg_replace( '/id="(.+?)"/', 'id="nested-$1-' . esc_attr( $key ) . '"', $markup );
+
+			$this->field->id = "$field_id-$key";
+
+			$html .= parent::html( $markup );
 		}
+
+		/* Reset the ID back to the original value */
+		$this->field->id = $field_id;
 
 		return $html;
 	}

--- a/src/Helper/Fields/Field_Repeater.php
+++ b/src/Helper/Fields/Field_Repeater.php
@@ -151,6 +151,21 @@ class Field_Repeater extends Helper_Abstract_Fields {
 		$this->get_repeater_html( $value, $this->field );
 		$html = ob_get_clean();
 
+		/* Ensure a unique ID for all elements in the Repeater field */
+		$i    = 0;
+		$html = preg_replace_callback(
+			'/id="(.+?)"/',
+			function( $matches ) use ( &$i ) {
+				return sprintf(
+					'id="repeater-%s-%s-%s"',
+					$this->field->id,
+					$matches[1],
+					$i++
+				);
+			},
+			$html
+		);
+
 		/* If output wasn't enabled by default, disable again */
 		if ( ! $output_already_enabled ) {
 			$this->disable_output();

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Form.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Form.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Fields {
+
+	use WP_UnitTestCase;
+
+	/**
+	 * @package     Gravity PDF
+	 * @copyright   Copyright (c) 2022, Blue Liquid Designs
+	 * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+	 */
+
+	/**
+	 * @package GFPDF\Helper\Fields
+	 *
+	 * @group   helper
+	 * @group   fields
+	 */
+	class Test_Field_Form extends WP_UnitTestCase {
+
+		public $form;
+
+		public $gf_field;
+
+		public $pdf_field;
+
+		public function set_up() {
+			parent::set_up();
+
+			$this->form = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+
+			$entry = [
+				'id'      => 0,
+				'form_id' => $this->form['id'],
+				'1'       => implode( ',', array_column( $GLOBALS['GFPDF_Test']->entries['all-form-fields'], 'id' ) ),
+			];
+
+			$this->gf_field = new \GP_Field_Nested_Form( [
+				'id'       => 1,
+				'gpnfForm' => $this->form['id'],
+			] );
+
+			$this->pdf_field = new Field_Form( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+		}
+
+		public function test_unique_ids() {
+			$html = $this->pdf_field->html();
+
+			$this->assertStringNotContainsString( 'id="field-1"', $html );
+			$this->assertStringContainsString( 'id="field-1-0"', $html );
+			$this->assertStringContainsString( 'id="field-1-1"', $html );
+
+			$this->assertStringNotContainsString( 'id="field-3"', $html );
+			$this->assertStringContainsString( 'id="nested-field-3-0"', $html );
+			$this->assertStringContainsString( 'id="nested-field-3-1"', $html );
+
+			$this->assertStringNotContainsString( 'id="field-41-option-1"', $html);
+			$this->assertStringContainsString( 'id="nested-field-41-option-1-0"', $html );
+			$this->assertStringContainsString( 'id="nested-field-41-option-1-1"', $html );
+		}
+
+	}
+}
+
+namespace {
+
+	class GP_Field_Nested_Form extends \GF_Field {
+		public $type = 'form';
+	}
+
+}

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Repeater.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Repeater.php
@@ -97,4 +97,16 @@ class Test_Field_Repeater extends WP_UnitTestCase {
 		$this->assertSame(  'This a sample HTML' , $repeater_data['HTML.17'] );
 		$this->assertSame(  'This a sample HTML' , $repeater_data['HTML'] );
 	}
+
+	public function test_unique_ids() {
+		$html = $this->pdf_field->html();
+
+		$this->assertStringNotContainsString( 'id="field-999"', $html );
+		$this->assertStringContainsString( 'id="repeater-999-field-999-0"', $html );
+		$this->assertStringContainsString( 'id="repeater-999-field-999-11"', $html );
+
+		$this->assertStringNotContainsString( 'id="field-15"', $html );
+		$this->assertStringContainsString( 'id="repeater-999-field-15-1"', $html );
+		$this->assertStringContainsString( 'id="repeater-999-field-15-12"', $html );
+	}
 }


### PR DESCRIPTION
## Description

The HTML markup generated for fields includes the standard ID "field-#". Inside the Nested Forms field, there could be multiples of the same ID. This PR ensures that all IDs are unique for Nested Form fields.

## Testing instructions
1. Setup a Parent / Child form with the Nested Forms add-on 
2. Create PDF on the Parent form
3. Submit test entry with multiple child entries 
4. View source code of generated PDF and ensure no ID conflicts for the Nested Form fields output 

Follow above steps for the native Repeater field and check no conflicts.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
