### PR TITLE
Add context to gfpdf_core_template hook

### DIFF
--- a/src/View/html/PDF/core_template_styles.php
+++ b/src/View/html/PDF/core_template_styles.php
@@ -266,5 +266,6 @@ $include_product_styles = apply_filters( 'gfpdf_include_product_styles', true, $
 
 <?php
 /* See https://docs.gravitypdf.com/v6/developers/actions/gfpdf_core_template for more details about this hook */
-do_action( 'gfpdf_core_template' );
+do_action( 'gfpdf_core_template', $form, $entry, $settings );
+do_action( 'gfpdf_core_template_' . $form['id'], $form, $entry, $settings );
 ?>


### PR DESCRIPTION
## Description

Pass the `$form`, `$entry`, and `$settings` variables to the `gfpdf_core_template` hook so developers can conditionally display styles in any Core / Universal PDF template.

Also include form-specific hook `gfpdf_core_template_$formId`

## Testing instructions
Implement https://docs.gravitypdf.com/v6/developers/actions/gfpdf_core_template but accept 3 arguments to the function, then conditionally display styles in the PDF. Verify the styles appear in the generated HTML.

Do the same for `gfpdf_core_template_$formId`

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
