### PR TITLE
Validate template filename (A-z0-9_-)  format.

### DIFF
--- a/src/Model/Model_Templates.php
+++ b/src/Model/Model_Templates.php
@@ -382,10 +382,16 @@ class Model_Templates extends Helper_Abstract_Model {
 	public function check_for_valid_pdf_templates( $files = [] ) {
 		foreach ( $files as $file ) {
 
+			$basename = wp_basename( $file );
+
+			if ( ! preg_match( '/^[a-zA-Z0-9-_]+.php$/', $basename ) ) {
+				throw new Exception( sprintf( esc_html__( 'The filename %s contains invalid characters. Only alphanumeric, hyphen, and underscore allowed.', 'gravity-forms-pdf-extended' ), $basename ) );
+			}
+
 			/* Check if we have a valid v4 template header in the file */
 			$info = $this->templates->get_template_info_by_path( $file );
 
-			if ( ! isset( $info['template'] ) || strlen( $info['template'] ) === 0 ) {
+			if ( $info['group'] === esc_html__( 'Legacy', 'gravity-forms-pdf-extended' ) ) {
 				/* Check if it's a v3 template */
 				$fp        = fopen( $file, 'rb' );
 				$file_data = fread( $fp, 8192 );
@@ -393,7 +399,7 @@ class Model_Templates extends Helper_Abstract_Model {
 
 				/* Check the first 8kiB contains the string RGForms or GFForms, which signifies our v3 templates */
 				if ( strpos( $file_data, 'RGForms' ) === false && strpos( $file_data, 'GFForms' ) === false ) {
-					throw new Exception( sprintf( esc_html__( 'The PHP file %s is not a valid PDF Template.', 'gravity-forms-pdf-extended' ), basename( $file ) ) );
+					throw new Exception( sprintf( esc_html__( 'The PHP file %s is not a valid PDF Template.', 'gravity-forms-pdf-extended' ), $basename ) );
 				}
 			}
 		}

--- a/tests/phpunit/unit-tests/test-templates.php
+++ b/tests/phpunit/unit-tests/test-templates.php
@@ -274,6 +274,19 @@ class Test_Templates extends WP_UnitTestCase {
 
 		$this->assertFalse( isset( $e ) );
 
+		/* Add an invalid filename to the zip and verify an error occurs */
+		$zip->open( $test_file );
+		$zip->addFile( PDF_PLUGIN_DIR . 'src/templates/zadani.php', 'zad@!@#$%^&*().php' );
+		$zip->close();
+
+		try {
+			$this->model->unzip_and_verify_templates( $test_file );
+		} catch ( Exception $e ) {
+			//do nothing
+		}
+
+		$this->assertStringContainsString( 'contains invalid characters.', $e->getMessage() );
+
 		/* Cleanup */
 		unlink( $test_file );
 		$gfpdf->misc->rmdir( $test_dir );
@@ -293,7 +306,7 @@ class Test_Templates extends WP_UnitTestCase {
 
 		$info = $this->model->get_template_info( $files );
 
-		$this->assertSame( 2, count( $info ) );
+		$this->assertCount( 2, $info );
 		$this->assertArrayHasKey( 'version', $info[0] );
 		$this->assertArrayHasKey( 'version', $info[1] );
 		$this->assertEquals( 'Zadani', $info[0]['template'] );


### PR DESCRIPTION

## Description
Add an if statement that checks if the submitted template filename has an invalid characters and return an Exception if it does.
This is based `v6.4` release. 

<!-- Describe what you have changed or added. -->
Get the template filename path and since `basename` automatically strips invalid characters. I need to manually pluck the filename and compare it to via regexp based on the provided pattern on #1384  
<!-- Link to the support ticket(s) where appropriate. -->
#1384  
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
Upload a filename with invalid characters e.g @~!#. etc
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/434866/193491400-a4793eff-5f92-41ad-8fff-33103fa74811.png)
![image](https://user-images.githubusercontent.com/434866/193491426-121e6c0c-3413-42f6-8e57-e2453a69fb83.png)


## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
