### PR TITLE
Add filterable class to PDF links on Entry List and Details Pages

### DIFF
--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -736,6 +736,7 @@ class Model_PDF extends Helper_Abstract_Model {
 					'settings' => $settings,
 					'entry_id' => $entry['id'],
 					'form_id'  => $form['id'],
+					'class'    => 'gravitypdf-download-link',
 				];
 			}
 		}

--- a/src/View/html/PDF/entry_detailed_pdf.php
+++ b/src/View/html/PDF/entry_detailed_pdf.php
@@ -32,8 +32,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<div class="gfpdf_detailed_pdf_cta" aria-label="<?php echo esc_attr( sprintf( __( 'View or download %s.pdf', 'gravity-forms-pdf-extended' ), $pdf['name'] ) ); ?>">
 				<?php do_action( 'gfpdf_entry_detail_pre_pdf_links_markup', $pdf, $args['pdfs'] ); ?>
 
-				<a href="<?php echo esc_url( $pdf['view'] ); ?>" target="_blank"><?php echo esc_html__( 'View', 'gravity-forms-pdf-extended' ); ?></a> |
-				<a href="<?php echo esc_url( $pdf['download'] ); ?>"><?php echo esc_html__( 'Download', 'gravity-forms-pdf-extended' ); ?></a>
+				<a href="<?php echo esc_url( $pdf['view'] ); ?>" class="<?php echo esc_attr( $pdf['class'] ); ?>" target="_blank" data-type="view"><?php echo esc_html__( 'View', 'gravity-forms-pdf-extended' ); ?></a> |
+				<a href="<?php echo esc_url( $pdf['download'] ); ?>" class="<?php echo esc_attr( $pdf['class'] ); ?>" data-type="download"><?php echo esc_html__( 'Download', 'gravity-forms-pdf-extended' ); ?></a>
 
 				<?php do_action( 'gfpdf_entry_detail_post_pdf_links_markup', $pdf, $args['pdfs'] ); ?>
 			</div>

--- a/src/View/html/PDF/entry_list_pdf_multiple.php
+++ b/src/View/html/PDF/entry_list_pdf_multiple.php
@@ -29,8 +29,10 @@ $parent_link_text = $download ? __( 'Download PDFs', 'gravity-forms-pdf-extended
 				<?php foreach ( $args['pdfs'] as $pdf ): ?>
 					<li>
 						<a href="<?php echo $download ? esc_url( $pdf['download'] ) : esc_url( $pdf['view'] ); ?>"
+						   class="<?php echo esc_attr( $pdf['class'] ); ?>"
 							<?php echo $download ? '' : 'target="_blank"'; ?>
 						   data-label="<?php echo esc_attr( $pdf['name'] ); ?>"
+						   data-type="<?php echo esc_attr( $args['view'] ); ?>"
 						>
 							<?php echo esc_html( $pdf['name'] ); ?>
 						</a>

--- a/src/View/html/PDF/entry_list_pdf_single.php
+++ b/src/View/html/PDF/entry_list_pdf_single.php
@@ -21,6 +21,10 @@ $is_download = $args['view'] === 'download';
 ?>
 
 |
-<a href="<?php echo $is_download ? esc_url( $args['pdf']['download'] ) : esc_url( $args['pdf']['view'] ); ?>" <?php echo $is_download ? '' : 'target="_blank"'; ?>>
+<a  href="<?php echo $is_download ? esc_url( $args['pdf']['download'] ) : esc_url( $args['pdf']['view'] ); ?>"
+	class="<?php echo esc_attr( $args['pdf']['class'] ); ?>"
+	data-type="<?php echo esc_attr( $args['view'] ); ?>"
+	<?php echo $is_download ? '' : 'target="_blank"'; ?>
+>
 	<?php echo $is_download ? esc_html__( 'Download PDF', 'gravity-forms-pdf-extended' ) : esc_html__( 'View PDF', 'gravity-forms-pdf-extended' ); ?>
 </a>


### PR DESCRIPTION
## Description

Also include the type of PDF link it is as a data attribute (view or download). These changes are necessary for the upcoming Enhanced Download add-on.

## Testing instructions
The E2E tests will catch any issues. 

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
