### PR TITLE
Add Payment Status and Payment Amount Conditional Logic options

### DIFF
--- a/src/Model/Model_Form_Settings.php
+++ b/src/Model/Model_Form_Settings.php
@@ -229,8 +229,8 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			$form_classes .= 'gfpdf-gf-2-6';
 		}
 
+		/* Add additional entry meta to automatically include in PDF Conditional Logic */
 		$entry_meta = GFFormsModel::get_entry_meta( $form_id );
-		$entry_meta = apply_filters( 'gform_entry_meta_conditional_logic_confirmations', $entry_meta, $form, '' );
 
 		/* re-register all our settings to show form-specific options */
 		$this->options->register_settings( $this->options->get_registered_fields() );

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -282,6 +282,8 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		/* Add class when on Gravity PDF pages */
 		add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
+		/* Add additional meta fields in GF conditional logic */
+		add_filter( 'gform_entry_meta', array( $this, 'set_conditional_logic_meta' ) );
 	}
 
 
@@ -354,6 +356,81 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		}
 
 		return $classes;
+	}
+
+	/**
+	 * Add payment details and miscellaneous fields in our PDF conditional logic conditions.
+	 * This is roughly based on Gravity Form Populate Anything add-on.
+	 *
+	 * @param array $entry_meta
+	 *
+	 * @return array
+	 * @since 6.5
+	 *
+	 */
+	public function set_conditional_logic_meta( $entry_meta ) {
+
+		$entry_meta['payment_status'] = [
+			'label'  => esc_html__( 'Payment Status', 'gravityforms' ),
+			'filter' => [
+				'operators' => [ 'is', 'isnot' ],
+				'choices'   => \GFCommon::get_entry_payment_statuses_as_choices(),
+			],
+		];
+
+		$entry_meta['payment_amount'] = [
+			'label'  => esc_html__( 'Payment Amount', 'gravityforms' ),
+			'filter' => [
+				'operators' => [ 'is', 'isnot', '>', '<', 'contains', 'starts_with', 'ends_with', 'text_box' ],
+			],
+		];
+
+		$entry_meta['id'] = [
+			'label'  => esc_html__( 'Entry ID', 'gravityforms' ),
+			'filter' => [
+				'operators' => [ 'is', 'isnot', '>', '<' ],
+			],
+		];
+
+		$entry_meta['is_starred'] = [
+			'label'  => esc_html__( 'Starred', 'gravityforms' ),
+			'filter' => [
+				'operators' => [ 'is', 'isnot' ],
+				'choices'   => [
+					[
+						'text'  => 'Yes',
+						'value' => 1,
+					],
+					[
+						'text'  => 'No',
+						'value' => 0,
+					],
+				],
+			],
+		];
+
+		$entry_meta['ip'] = [
+			'label'  => esc_html__( 'IP / Source URL', 'gravityforms' ),
+			'filter' => [
+				'operators' => [ 'is', 'isnot', '>', '<', 'contains' ],
+			],
+		];
+		/* @TODO : Payment date doesn't register as datefield.
+		 * WIP - Add a datepicker class on this field.
+		 * Unable to find related resources on how to accomplish this.
+		$entry_meta['payment_date'] = [
+			'label'  => esc_html__( 'Payment Date', 'gravityforms' ),
+			'filter' => [
+				'operators'       => [ 'is', 'isnot', '>', '<' ],
+				'placeholder'     => __( 'yyyy-mm-dd', 'gravityforms' ),
+				'cssClass'        => 'hasDatepicker ymd_dash',
+				'key'             => 'payment_date',
+				'preventMultiple' => false,
+			],
+
+		];
+		 * */
+		return $entry_meta;
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/test-form-settings.php
+++ b/tests/phpunit/unit-tests/test-form-settings.php
@@ -764,4 +764,15 @@ class Test_Form_Settings extends WP_UnitTestCase {
 		$results = $this->model->register_template_group( $test );
 		$this->assertTrue( isset( $results['template']['data']['template_group'] ) );
 	}
+
+	/**
+	 * Check if the structure of conditional logic meta is correct.
+	 *
+	 * @since 6.4
+	 */
+	public function test_set_conditional_logic_meta() {
+		$entry_meta =  \GFFormsModel::get_entry_meta( $this->form_id ) ;
+		$this->assertCount( 5, $entry_meta );
+		$this->assertCount( 9, $entry_meta['payment_status']['filter']['choices'] );
+	}
 }


### PR DESCRIPTION
## Description

This PR registers two new choices in the conditional logic selector:

1. Payment Status
2. Payment Amount

I've opted not to include additional entry meta like Entry ID, or Entry Date, at this stage as it requires additional work to support. This PR just focuses on the most important meta data.

TODO:

- [x] Check if conditional logic will pass as is, or if we need to hook into Gravity Forms and make some tweaks when the logic is being parsed
- [ ] Write E2E test

Partially resolves #1404 

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
