### PR TITLE
Allow a maximum of 8 User-Defined CSS Classes in Core Template

### DIFF
--- a/src/Helper/Helper_Abstract_Fields.php
+++ b/src/Helper/Helper_Abstract_Fields.php
@@ -345,7 +345,7 @@ abstract class Helper_Abstract_Fields {
 		$label = esc_html( $this->get_label() );
 		$type  = $this->field->get_input_type();
 
-		$html = '<div id="' . esc_attr( 'field-' . $this->field->id ) . '" class="gfpdf-field ' . esc_attr( 'gfpdf-' . $type ) . ' ' . esc_attr( $this->field->cssClass ) . '">
+		$html = '<div id="' . esc_attr( 'field-' . $this->field->id ) . '" class="gfpdf-field ' . esc_attr( 'gfpdf-' . $type ) . ' ' . esc_attr( $this->get_field_classes() ) . '">
 					<div class="inner-container">';
 
 		if ( $show_label ) {
@@ -392,5 +392,21 @@ abstract class Helper_Abstract_Fields {
 		$converted = [ '&#91;', '&#93;', '&#123;', '&#125;' ];
 
 		return str_replace( $find, $converted, $value );
+	}
+
+	/**
+	 * To avoid mPDF memory errors trying to determine the CSS specificity we will limit the field to 8 user classes
+	 *
+	 * @see https://github.com/mpdf/mpdf/issues/1753
+	 *
+	 * @return string
+	 *
+	 * @since 6.5
+	 */
+	public function get_field_classes(): string {
+		return implode(
+			' ',
+			array_slice( explode( ' ', $this->field->cssClass ), 0, 8 )
+		);
 	}
 }

--- a/tests/phpunit/unit-tests/json/all-form-fields.json
+++ b/tests/phpunit/unit-tests/json/all-form-fields.json
@@ -38,7 +38,7 @@
       "inputMaskValue": "",
       "allowsPrepopulate": false,
       "description": "This is the single line text description",
-      "cssClass": "exclude",
+      "cssClass": "exclude class1 class2 class3 class4 class5 class6 class7 class8 class9 class10",
       "inputType": ""
     },
     {
@@ -70,6 +70,7 @@
       "inputMaskValue": "",
       "allowsPrepopulate": false,
       "description": "This is the paragraph text description",
+      "cssClass": "class1 class2",
       "inputType": ""
     },
     {

--- a/tests/phpunit/unit-tests/test-field-markup.php
+++ b/tests/phpunit/unit-tests/test-field-markup.php
@@ -4,9 +4,13 @@ namespace GFPDF\Tests;
 
 use GF_Field_Consent;
 use GF_Field_Repeater;
+use GF_Field_Text;
+use GF_Field_Textarea;
 use GFAPI;
 use GFPDF\Helper\Fields\Field_Consent;
 use GFPDF\Helper\Fields\Field_Repeater;
+use GFPDF\Helper\Fields\Field_Text;
+use GFPDF\Helper\Fields\Field_Textarea;
 use GFPDF\Helper\Helper_QueryPath;
 use GPDFAPI;
 use WP_UnitTestCase;
@@ -68,5 +72,37 @@ class Test_Field_Markup extends WP_UnitTestCase {
 		$this->assertSame( 1, $html->find( '.consent-accepted' )->count() );
 		$this->assertSame( 1, $html->find( '.consent-accepted-label' )->count() );
 		$this->assertSame( 1, $html->find( '.consent-text' )->count() );
+	}
+
+	public function test_maximum_allowed_css_each_field(){
+		$form  = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+
+		$form_id          = GFAPI::add_form( $form );
+		$entry['form_id'] = $form_id;
+		$entry_id         = GFAPI::add_entry( $entry );
+
+		/* Verify classes are truncated at 8 */
+		$text_field = new GF_Field_Text( $form['fields'][0] );
+
+		$field = new Field_Text( $text_field, GFAPI::get_entry( $entry_id ), GPDFAPI::get_form_class(), GPDFAPI::get_misc_class() );
+		$array_css = explode( ' ', $field->get_field_classes() );
+
+		$this->assertCount( 8, $array_css );
+
+		$this->assertContains( 'exclude', $array_css );
+		$this->assertContains( 'class7', $array_css );
+		$this->assertContains( 'class4', $array_css );
+		$this->assertNotContains( 'class8', $array_css );
+
+		/* Verify nothing is truncated */
+		$text_field = new GF_Field_Textarea( $form['fields'][1] );
+
+		$field = new Field_Textarea( $text_field, GFAPI::get_entry( $entry_id ), GPDFAPI::get_form_class(), GPDFAPI::get_misc_class() );
+		$array_css = explode( ' ', $field->get_field_classes() );
+
+		$this->assertCount( 2, $array_css );
+
+		$this->assertCount( 2, $array_css );
 	}
 }


### PR DESCRIPTION
This PR set a limited amount of custom CSS per field in PDF generation. We still process the PDF but were going to ignore the rest of these custom CSS and log the "excluded" along side with its field information.

WIP - Unit test
## Description

<!-- Describe what you have changed or added. -->
#1425 
<!-- Link to the support ticket(s) where appropriate. -->

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->

In the Form field settings, add 8 or more user defined CSS class. 
Check the PDF's html (?html=1) to see if limits the classes.

<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/434866/200747845-57ccc0d7-111b-4c65-9ca4-e6c9b0cf013f.png)
![image](https://user-images.githubusercontent.com/434866/200748009-35a3053f-3c07-4539-9143-e148422644b8.png)

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
