### PR TITLE
Prevent Fatal error when processing Kses::output with null value.

### DIFF
--- a/src/Statics/Kses.php
+++ b/src/Statics/Kses.php
@@ -27,7 +27,7 @@ class Kses {
 	 *
 	 * @since 6.4.0
 	 */
-	public static function output( string $html ): void {
+	public static function output( $html ): void {
 		/* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */
 		echo self::parse( $html );
 	}
@@ -41,10 +41,10 @@ class Kses {
 	 *
 	 * @since 6.4.0
 	 */
-	public static function parse( string $html ) {
+	public static function parse( $html ) {
 		add_filter( 'safe_style_css', '\GFPDF\Statics\Kses::get_allowed_pdf_styles' );
 
-		$html = wp_kses( $html, self::get_allowed_pdf_tags(), self::get_allowed_pdf_protocols() );
+		$html = wp_kses( (string) $html, self::get_allowed_pdf_tags(), self::get_allowed_pdf_protocols() );
 
 		remove_filter( 'safe_style_css', '\GFPDF\Statics\Kses::get_allowed_pdf_styles' );
 

--- a/tests/phpunit/unit-tests/Statics/Test_kses.php
+++ b/tests/phpunit/unit-tests/Statics/Test_kses.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace GFPDF\Statics;
 
+use GFPDF\Exceptions\GravityPdfException;
 use WP_UnitTestCase;
 
 /**
@@ -24,6 +25,14 @@ class Test_Kses extends WP_UnitTestCase {
 	 */
 	public function test_parse_pdf_tags_and_attributes( $html ) {
 		$this->assertSame( $html, Kses::parse( $html ) );
+	}
+
+	public function test_numeric_output() {
+		$this->assertSame( '1234567890', Kses::parse( 1234567890 ) );
+	}
+
+	public function test_null_output() {
+		$this->assertSame( '', Kses::parse( null ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR is a safety precaution when running Kses::output on null values. Added an `is_string` check before the said output should fix this [problem ](https://wordpress.org/support/topic/error-when-trying-to-create-pdf/#post-16165506) posted in our wordpress.org support.

## Description

<!-- Describe what you have changed or added. -->
#1427 
<!-- Link to the support ticket(s) where appropriate. -->

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons, or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
