### PR TITLE
Switch QueryPath to our fork

### DIFF
--- a/.php-scoper/querypath.php
+++ b/.php-scoper/querypath.php
@@ -21,8 +21,8 @@ return [
 	 * For more see: https://github.com/humbug/php-scoper#finders-and-paths
 	 */
 	'finders'   => [
-		Finder::create()->files()->in( $path . 'vendor/arthurkushman/query-path/' )->depth( '== 0' )->name( [ 'CREDITS', 'COPYING-MIT.txt' ] ),
-		Finder::create()->files()->in( $path . 'vendor/arthurkushman/query-path/src/' )->name( [ '*.php' ] ),
+		Finder::create()->files()->in( $path . 'vendor/gravitypdf/querypath/' )->depth( '== 0' )->name( [ 'CREDITS', 'COPYING-MIT.txt' ] ),
+		Finder::create()->files()->in( $path . 'vendor/gravitypdf/querypath/src/' )->name( [ '*.php' ] ),
 		Finder::create()->files()->in( $path . 'vendor/masterminds/html5/' )->depth( '== 0' )->name( [ 'LICENSE.txt', 'CREDITS' ] ),
 		Finder::create()->files()->in( $path . 'vendor/masterminds/html5/src/' )->name( [ '*.php' ] ),
 	],

--- a/bin/vendor-prefix.sh
+++ b/bin/vendor-prefix.sh
@@ -32,17 +32,18 @@ eval "rm -Rf ${PLUGIN_DIR}vendor/league"
 
 # Querypath
 eval "$PHP ${PLUGIN_DIR}php-scoper.phar add-prefix --output-dir=${PLUGIN_DIR}vendor_prefixed --config=${PLUGIN_DIR}.php-scoper/querypath.php --quiet"
-eval "rm -Rf ${PLUGIN_DIR}vendor/arthurkushman"
 eval "rm -Rf ${PLUGIN_DIR}vendor/masterminds"
 
 # Codeguy
 eval "$PHP ${PLUGIN_DIR}php-scoper.phar add-prefix --output-dir=${PLUGIN_DIR}vendor_prefixed/gravitypdf/upload --config=${PLUGIN_DIR}.php-scoper/upload.php --quiet"
-eval "rm -Rf ${PLUGIN_DIR}vendor/gravitypdf"
 
 # Mpdf
 eval "$PHP ${PLUGIN_DIR}php-scoper.phar add-prefix --output-dir=${PLUGIN_DIR}vendor_prefixed --config=${PLUGIN_DIR}.php-scoper/mpdf.php" --quiet
 eval "rm -Rf ${PLUGIN_DIR}vendor/mpdf"
 eval "rm -Rf ${PLUGIN_DIR}vendor/setasign"
 eval "rm -Rf ${PLUGIN_DIR}vendor/myclabs"
+
+# Do this at the end as we have multiple vendor packages used
+eval "rm -Rf ${PLUGIN_DIR}vendor/gravitypdf"
 
 eval "$COMPOSER dump-autoload --optimize --working-dir ${PLUGIN_DIR}"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "monolog/monolog": "^2.1.0",
     "spatie/url-signer": "^1.1",
     "mpdf/qrcode": "^1.0",
-    "arthurkushman/query-path": "^3.1",
+    "gravitypdf/querypath": "^3.2",
     "gravitypdf/upload": "^3.0"
   },
   "require-dev": {

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -16,4 +16,4 @@ require_once PDF_PLUGIN_DIR . 'src/deprecated.php';
 require_once PDF_PLUGIN_DIR . 'api.php';
 
 class_alias( '\GFPDF_Vendor\QueryPath\QueryPath', '\GFPDF_Vendor\QueryPath' ); /* Backwards compatibility support */
-require_once PDF_PLUGIN_DIR . 'vendor_prefixed/arthurkushman/query-path/src/qp_functions.php';
+require_once PDF_PLUGIN_DIR . 'vendor_prefixed/gravitypdf/querypath/src/qp_functions.php';


### PR DESCRIPTION
## Description

The fork has better PHP8.1 support

## Testing instructions
There should be no breaking changes in the switch and the automated tests would confirm this.

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
