### PR TITLE
Fix Xdebug Installation Issue

### DIFF
--- a/.github/workflows/phpunit.tests.yml
+++ b/.github/workflows/phpunit.tests.yml
@@ -52,10 +52,10 @@ jobs:
         os: [ ubuntu-latest ]
         multisite: [ false ]
         include:
-          - php: '7.4'
+          - php: '8.1'
             os: ubuntu-latest
             multisite: true
-          - php: '7.4'
+          - php: '8.1'
             os: ubuntu-latest
             multisite: false
             report: true
@@ -113,18 +113,22 @@ jobs:
           yarn
 
       - name: Install / Setup Gravity PDF + WordPress
+        if: ${{ ! matrix.report }}
         run: |
           yarn env:install
+
+      - name: Install / Setup Gravity PDF + WordPress
+        if: ${{ matrix.report }}
+        run: |
+          PHP_ENABLE_XDEBUG=true yarn env:install          
 
       - name: Run PHPUnit tests
         if: ${{ ! matrix.multisite }}
         run: yarn test:php --do-not-cache-result --verbose
-        continue-on-error: ${{ matrix.php == '8.1' }}
 
       - name: Run Multisite PHPUnit tests
         if: ${{ matrix.multisite }}
         run: yarn test:php:multisite --verbose
-        continue-on-error: ${{ matrix.php == '8.1' }}
 
       - name: Generate Code Coverage Report for PHP
         if: ${{ matrix.report }}

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -15,7 +15,11 @@ composer install
 composer run prefix
 
 # Start local environment
-npm run wp-env start -- --xdebug=debug,coverage
+if [[ $PHP_ENABLE_XDEBUG ]]; then
+  npm run wp-env start -- --xdebug=debug,coverage
+else
+    npm run wp-env start
+fi
 
 # Fix permissions issues on test container
 npm run wp-env run wordpress chmod 777 /var/www/html/wp-content/{plugins,themes,}


### PR DESCRIPTION
## Description

The latest Xdebug dropped support for PHP7.4 and below. This PR selectively enabled Xdebug so the automated tests can pass.

## Testing instructions
Automated tests shoudl all pass

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
