### PR TITLE
Resolve PHP8.1 unit test issues

### DIFF
--- a/.github/workflows/phpunit.tests.yml
+++ b/.github/workflows/phpunit.tests.yml
@@ -124,16 +124,21 @@ jobs:
 
       - name: Run PHPUnit tests
         if: ${{ ! matrix.multisite }}
-        run: yarn test:php --do-not-cache-result --verbose
+        run: |
+          yarn test:php --do-not-cache-result --verbose
+          yarn test:php --group ajax --do-not-cache-result --verbose
 
       - name: Run Multisite PHPUnit tests
         if: ${{ matrix.multisite }}
-        run: yarn test:php:multisite --verbose
+        run: |
+          yarn test:php:multisite --verbose
+          yarn test:php:multisite --group ajax --verbose
 
       - name: Generate Code Coverage Report for PHP
         if: ${{ matrix.report }}
         run: |
           yarn run test:php --do-not-cache-result --verbose --coverage-clover=/var/www/html/wp-content/plugins/gravity-pdf/tmp/coverage/report-xml/php-coverage1.xml
+          yarn run test:php --group ajax --do-not-cache-result --verbose --coverage-clover=/var/www/html/wp-content/plugins/gravity-pdf/tmp/coverage/report-xml/php-coverage2.xml
 
       - name: Code Coverage Upload
         uses: codecov/codecov-action@v3

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,12 @@
         </testsuite>
     </testsuites>
 
+    <groups>
+        <exclude>
+            <group>ajax</group>
+        </exclude>
+    </groups>
+
     <filter>
         <whitelist>
             <directory suffix=".php">./src/</directory>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -99,6 +99,7 @@ class GravityPDF_Unit_Tests_Bootstrap {
 		require_once $this->plugin_dir . '/../gravityformspolls/polls.php';
 		require_once $this->plugin_dir . '/../gravityformsquiz/quiz.php';
 		require_once $this->plugin_dir . '/../gravityformssurvey/survey.php';
+		require_once( GFCommon::get_base_path() . '/tooltips.php' );
 
 		/* set up Gravity Forms database */
 		add_filter( 'get_available_languages', function( $language ) {

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -22,6 +22,12 @@
         </testsuite>
     </testsuites>
 
+    <groups>
+        <exclude>
+            <group>ajax</group>
+        </exclude>
+    </groups>
+
     <filter>
         <whitelist>
             <directory suffix=".php">../../src/</directory>

--- a/tests/phpunit/unit-tests/test-ajax.php
+++ b/tests/phpunit/unit-tests/test-ajax.php
@@ -64,13 +64,13 @@ class Test_PDF_Ajax extends WP_Ajax_UnitTestCase {
 	 *
 	 * @since 4.1
 	 */
-	public static function set_upBeforeClass() {
+	public static function set_up_before_class() {
 		global $wpdb;
 		$wpdb->suppress_errors = false;
 		$wpdb->show_errors     = true;
 		$wpdb->db_connect();
 
-		parent::set_upBeforeClass();
+		parent::set_up_before_class();
 	}
 
 	/**


### PR DESCRIPTION
## Description

In testing, running phpunit --group ajax on its own worked without any changes to the codebase. It was only when running the standard suite and the AJAX tests at the same time that caused issues. I wasn't able to track down the cause in the limited time I spent investigating. Instead, have reverted to excluding AJAX tests by default and running them separately in the GitHub Actions.

## Testing instructions
All unit tests should pass.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
