### PR TITLE
Replace mPDF HTTP Request with wp_remote_get()

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://gravitypdf.com/donate-to-plugin/
 Tags: gravityforms, gravity, forms, pdf, automation, attachment, email
 Requires at least: 5.3
 Tested up to: 6.1
-Stable tag: 6.5.2
+Stable tag: 6.5.3
 Requires PHP: 7.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl.txt
@@ -106,6 +106,9 @@ If you aren't able to meet the v6 minimum requirements [you can download v5 whic
 16. A bunch of paid PDF designs are available, as well as additional functionality.
 
 == Changelog ==
+
+= 6.5.3 =
+* Bug: Fix image/asset loading issue due to a cURL error
 
 = 6.5.2 =
 * Bug: Fix PHP error when a non-string is passed to the Kses sanitizing class

--- a/pdf.php
+++ b/pdf.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Gravity PDF
-Version: 6.5.2
+Version: 6.5.3
 Description: Automatically generate highly-customisable PDF documents using Gravity Forms.
 Author: Blue Liquid Designs
 Author URI: https://blueliquiddesigns.com.au
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /*
  * Set base constants we'll use throughout the plugin
  */
-define( 'PDF_EXTENDED_VERSION', '6.5.2' ); /* the current plugin version */
+define( 'PDF_EXTENDED_VERSION', '6.5.3' ); /* the current plugin version */
 define( 'PDF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); /* plugin directory path */
 define( 'PDF_PLUGIN_URL', plugin_dir_url( __FILE__ ) ); /* plugin directory url */
 define( 'PDF_PLUGIN_BASENAME', plugin_basename( __FILE__ ) ); /* the plugin basename */

--- a/src/Helper/Helper_Mpdf_Http_Client.php
+++ b/src/Helper/Helper_Mpdf_Http_Client.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace GFPDF\Helper;
+
+use \GFPDF_Vendor\Mpdf\Http\Response;
+use \GFPDF_Vendor\Mpdf\Http\ClientInterface;
+use \GFPDF_Vendor\Mpdf\MpdfException;
+use \GFPDF_Vendor\Mpdf\Log\Context;
+use \Psr\Http\Message\RequestInterface;
+use \Psr\Log\LoggerAwareInterface;
+use \Psr\Log\LoggerInterface;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2022, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @since 6.5.3
+ */
+class Helper_Mpdf_Http_Client implements ClientInterface, LoggerAwareInterface {
+	private $logger;
+	private $debug;
+
+	public function __construct( LoggerInterface $logger, $debug = false ) {
+		$this->logger = $logger;
+		$this->debug  = $debug;
+	}
+
+	/**
+	 * Make a network request using wp_remote_get() and return a PSR-7 Response
+	 *
+	 * @param RequestInterface $request
+	 *
+	 * @return Response
+	 * @throws MpdfException
+	 *
+	 * @since 6.5.3
+	 */
+	public function sendRequest( RequestInterface $request ) {
+		if ( null === $request->getUri() ) {
+			return new Response();
+		}
+
+		$url = $request->getUri();
+		$this->logger->debug( \sprintf( 'Fetching (wp_remote_get()) content of remote URL "%s"', $url ), [ 'context' => Context::REMOTE_CONTENT ] );
+
+		$http_call_args = apply_filters(
+			'gfpdf_http_request_arguments',
+			[
+				'timeout' => 10,
+			]
+		);
+		$http_call      = wp_remote_get( (string) $url, $http_call_args );
+
+		if ( is_wp_error( $http_call ) ) {
+			$this->logger->error( $http_call->get_error_message(), [ 'context' => Context::REMOTE_CONTENT ] );
+			if ( $this->debug ) {
+				throw new MpdfException( $http_call->get_error_message() );
+			}
+
+			return new Response();
+		}
+
+		$headers     = wp_remote_retrieve_headers( $http_call );
+		$status_code = wp_remote_retrieve_response_code( $http_call );
+		$body        = wp_remote_retrieve_body( $http_call );
+
+		$response = new Response( $status_code, $headers->getAll(), $body );
+
+		if ( $status_code !== 200 ) {
+			$message = \sprintf( 'HTTP error: %d', $status_code );
+			$this->logger->error( $message, [ 'context' => Context::REMOTE_CONTENT ] );
+			if ( $this->debug ) {
+				throw new MpdfException( $message );
+			}
+		}
+
+		return $response;
+	}
+
+	/**
+	 * @param LoggerInterface $logger
+	 *
+	 * @return void
+	 *
+	 * @since 6.5.3
+	 */
+	public function setLogger( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+}

--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -4,6 +4,7 @@ namespace GFPDF\Helper;
 
 use Exception;
 use GFPDF_Vendor\Mpdf\Config\FontVariables;
+use GFPDF_Vendor\Mpdf\Container\SimpleContainer;
 use GFPDF_Vendor\Mpdf\Mpdf;
 use GFPDF_Vendor\Mpdf\MpdfException;
 use GFPDF_Vendor\Mpdf\Utils\UtfString;
@@ -619,9 +620,17 @@ class Helper_PDF {
 	 * @since 4.0
 	 */
 	protected function begin_pdf() {
+		$options = \GPDFAPI::get_options_class();
+
 		$default_font_config = ( new FontVariables() )->getDefaults();
 
-		$this->mpdf = new Helper_Mpdf(
+		$http_client = new Helper_Mpdf_Http_Client( $this->log, $options->get_option( 'debug_mode', 'No' ) === 'Yes' );
+		$container   = new SimpleContainer(
+			[
+				'httpClient' => $http_client,
+			]
+		);
+		$this->mpdf  = new Helper_Mpdf(
 			apply_filters(
 				'gfpdf_mpdf_class_config',
 				[
@@ -658,7 +667,8 @@ class Helper_PDF {
 				$this->entry,
 				$this->settings,
 				$this
-			)
+			),
+			$container
 		);
 
 		$this->mpdf->setLogger( $this->log );


### PR DESCRIPTION
## Description

Resolve issues loading images / assets when using mPDF's native cURL functionality.

Fixes #1440

## Testing instructions


## Screenshots <!-- if applicable -->

## Checklist:
- [X] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
