### PR TITLE
Update mPDF cURL User Agent

### DIFF
--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -635,6 +635,7 @@ class Helper_PDF {
 
 					'curlCaCertificate'      => ABSPATH . WPINC . '/certificates/ca-bundle.crt',
 					'curlFollowLocation'     => true,
+					'curlUserAgent'          => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0',
 
 					'allow_output_buffering' => true,
 					'autoLangToFont'         => true,


### PR DESCRIPTION
## Description

Use the latest version of Firefox. Siteground recently started blocking requests that used very old browser versions / user agents. This stopped Gravity PDF loading images / CSS via HTTP/HTTPS.

Fixes #1440

## Testing instructions
Add a Background Image to a PDF that points to a Siteground-hosted image and verify it displays correctly.

## Screenshots <!-- if applicable -->

## Checklist:
- [X] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
