### PR TITLE
Move Core Font Installer Notice to selected pages.

### DIFF
--- a/tests/phpunit/unit-tests/test-actions.php
+++ b/tests/phpunit/unit-tests/test-actions.php
@@ -138,6 +138,8 @@ class Test_Actions extends WP_UnitTestCase {
 		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
 		$this->assertIsInt( $user_id );
 		wp_set_current_user( $user_id );
+		/* Check if Helper_Notice class will trigger on GravityPDF page */
+		$_GET['subview'] = 'PDF';
 
 		/* Verify notice now present */
 		$this->controller->route_notices();
@@ -147,6 +149,16 @@ class Test_Actions extends WP_UnitTestCase {
 
 		/* Cleanup notices */
 		$gfpdf->notices->clear();
+		unset( $_GET['subview'] );
+
+		/* Check if GFCommon class will trigger on Gravity page */
+		$_GET['page'] = 'gf_edit_forms';
+
+		/* Verify notice now present */
+		$this->controller->route_notices();
+
+		/* Verify GravityForm's default error messages now exists */
+		$this->assertNotEmpty( \GFCommon::$errors );
 
 		/* Check routes aren't handled when not in admin area */
 		set_current_screen( 'front' );


### PR DESCRIPTION
## Description
WIP. I have only set the  Core Font Installer Notice exclusively to Gravity PDF pages. I need to add this to these pages as well:

1. Form List
2. Form Settings
3. Form Entry List
4. Form Entry Details

<!-- Describe what you have changed or added. -->
<!-- Link to the support ticket(s) where appropriate. -->
#1439 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
