### PR TITLE
Reset the Background Queue after Dispatch

### DIFF
--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -216,6 +216,9 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller implements Helper_
 				->push_to_queue( $this->get_queue_tasks( $entry, $form ) )
 				->save()
 				->dispatch();
+
+			/* Create a fresh queue in case the queue needs to be used again */
+			$this->queue = new Helper_Pdf_Queue( $this->log );
 		}
 
 		$this->disable_queue = false;
@@ -249,6 +252,9 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller implements Helper_
 			$this->queue
 				->save()
 				->dispatch();
+
+			/* Create a fresh queue in case the queue needs to be used again */
+			$this->queue = new Helper_Pdf_Queue( $this->log );
 		}
 	}
 


### PR DESCRIPTION
## Description
This fixes an issue when creating multiple entries via the GFAPI, whereby the queue was not empty before each new entry was processed. The more entries added in a single request, the more duplicate notifications were sent.

## Testing instructions
1. Enable PDF Notifications on a test form and PDF Background Processing in the settings
2. Generate multiple entries on demand using code like this:

```
add_action('admin_init', function() {
	if( empty( $_GET['test1'] ) ) {
		return;
	}

	$backup_post = $_POST;

	for ( $i = 0; $i < 3; $i ++ ) {
		$entry = [
			'input_1' => 'test' . rand(),
			'input_3' => 'test' . rand(),
			'input_4' => 'test' . rand(),
		];

		$results = \GFAPI::submit_form( 848, $entry );

		$_POST = $backup_post;
		\GFFormsModel::flush_current_lead();
		\GFFormDisplay::$submission = [];
	}
} );
```

3. Verify you only get 3 emails with a PDF attached to each.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
