### PR TITLE
Fix Survey Field Unit Test Failure

### DIFF
--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Survey.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Survey.php
@@ -53,7 +53,7 @@ class Test_Field_Survey extends WP_UnitTestCase {
 	public function test_html() {
 		$html = $this->pdf_field->html();
 
-		$this->assertStringContainsString( "<table class='gsurvey-likert' id='input_1_26'>", $html );
+		$this->assertStringContainsString( "<table aria-label='Likert Survey Field' class='gsurvey-likert' id='input_1_26'>", $html );
 		$this->assertStringContainsString( "<input name='input_26' type='radio' value='glikertcol2636762f85' checked='checked' id='choice_1_26_1' />", $html );
 	}
 }


### PR DESCRIPTION
## Description

Markup change upstream caused the issue.

## Testing instructions
Let automated tests do its thing.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
