### PR TITLE
Fix error when running unit test on git.

### DIFF
--- a/.php-scoper/monolog.php
+++ b/.php-scoper/monolog.php
@@ -32,7 +32,16 @@ return [
 	 *
 	 * For more see: https://github.com/humbug/php-scoper#patchers
 	 */
-	'patchers'  => [],
+	'patchers'  => [
+		function( string $filePath, string $prefix, string $content ): string {
+
+			if ( basename( $filePath ) === 'Logger.php' ) {
+				$content = str_replace( "\\$prefix\\Fiber", '\Fiber', $content );
+			}
+
+			return $content;
+		},
+	],
 
 	'whitelist' => [
 		'Psr\*',


### PR DESCRIPTION
Error in bootstrap script: Error:
Class "GFPDF_Vendor\Fiber" not found
#0 /var/www/html/wp-content/plugins/gravity-pdf/vendor_prefixed/monolog/src/Monolog/Logger.php(520):

## Description

<!-- Describe what you have changed or added. -->
<!-- Link to the support ticket(s) where appropriate. -->

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
