### PR TITLE
Fix Consent Field

### DIFF
--- a/src/Helper/Fields/Field_Consent.php
+++ b/src/Helper/Fields/Field_Consent.php
@@ -61,12 +61,17 @@ class Field_Consent extends Helper_Abstract_Fields {
 	 * @since 5.1
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = $this->value();
+		$value       = $this->value();
+		$has_consent = $value['value'];
 
-		$has_consent = ! empty( $value['value'] );
+		/* Allow people to remove the consent field if a user didn't consent */
+		if ( ! $has_consent && apply_filters( 'gfpdf_hide_consent_field_if_empty', false, $this->field, $this->entry, $this->form ) ) {
+			return '';
+		}
 
-		$markup      = $has_consent ? $this->get_consented_markup( $value['label'] ) : $this->get_non_consent_markup();
-		$description = strlen( $value['description'] ) > 0 ? sprintf( '<div class="consent-text">%s</div>', $value['description'] ) : '';
+		$markup = $has_consent ? $this->get_consented_markup( $value['label'] ) : $this->get_non_consent_markup();
+
+		$description = ! empty( $value['description'] ) ? sprintf( '<div class="consent-text">%s</div>', $value['description'] ) : '';
 
 		/* consent has been given, determine order of description */
 		if ( empty( $value['placement'] ) || $value['placement'] === 'below' ) {

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Consent.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Consent.php
@@ -1,0 +1,96 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Fields;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2023, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   helper
+ * @group   fields
+ */
+class Test_Field_Consent extends WP_UnitTestCase {
+
+	public $form;
+
+	public $gf_field;
+
+	public $pdf_field;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->form = $GLOBALS['GFPDF_Test']->form['repeater-consent-form'];
+
+		foreach ( $this->form['fields'] as $field ) {
+			if ( $field->type === 'consent' ) {
+				$this->gf_field = new \GF_Field_Consent( $field );
+				break;
+			}
+		}
+
+		$entry = [
+			'form_id' => $this->form['id'],
+		];
+
+		$this->pdf_field = new Field_Consent( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+	}
+
+	public function test_if_has_consent() {
+		$entry = [
+			'form_id'                  => $this->form['id'],
+			'id'                       => '0',
+			$this->gf_field->id . '.1' => '1',
+			$this->gf_field->id . '.2' => '',
+			$this->gf_field->id . '.3' => '',
+		];
+
+		$this->pdf_field = new Field_Consent( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+
+		$this->assertStringContainsString( 'consent-accepted-label', $this->pdf_field->html() );
+	}
+
+	public function test_if_has_not_consent() {
+		$entry = [
+			'form_id'                  => $this->form['id'],
+			'id'                       => '0',
+			$this->gf_field->id . '.1' => '0',
+			$this->gf_field->id . '.2' => '',
+			$this->gf_field->id . '.3' => '',
+		];
+
+		$this->pdf_field = new Field_Consent( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+
+		$this->assertStringContainsString( 'consent-not-accepted-label', $this->pdf_field->html() );
+	}
+
+	public function test_if_skip_when_not_consented() {
+		$entry = [
+			'form_id'                  => $this->form['id'],
+			'id'                       => '0',
+			$this->gf_field->id . '.1' => '0',
+			$this->gf_field->id . '.2' => '',
+			$this->gf_field->id . '.3' => '',
+		];
+
+		$this->pdf_field = new Field_Consent( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+
+		add_filter( 'gfpdf_hide_consent_field_if_empty', '__return_true' );
+
+		$this->assertSame( '', $this->pdf_field->html() );
+
+		/* Verify it only applies if no consent given */
+		$entry[$this->gf_field->id . '.1'] = '1';
+
+		$this->pdf_field = new Field_Consent( $this->gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+
+		$this->assertStringContainsString( 'consent-accepted-label', $this->pdf_field->html() );
+	}
+}


### PR DESCRIPTION
## Description
If the consent field is empty, it should not display on PDF, just like GravityForms handling empty consent field. We have added a new filter that allows users to bypass it manually.

Note: Missing Unit tests

<!-- Link to the support ticket(s) where appropriate. -->
#1450 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
