### PR TITLE
Correctly sanitize the conditional logic setting

### DIFF
--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -1253,10 +1253,11 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			$settings['type'] = '';
 		}
 
-		switch ( $settings['type'] ) {
-			case 'conditional_logic':
-				return ! empty( $value ) ? wp_json_encode( \GFFormsModel::sanitize_conditional_logic( json_decode( $value, true ) ) ) : '';
+		if ( ( $settings['id'] ?? '' ) === 'conditionalLogic' ) {
+			return ! empty( $value ) ? wp_json_encode( \GFFormsModel::sanitize_conditional_logic( json_decode( $value, true ) ) ) : '';
+		}
 
+		switch ( $settings['type'] ) {
 			case 'rich_editor':
 				if ( strpos( $value, 'telnet://{' ) === false ) {
 					/*

--- a/tests/phpunit/unit-tests/test-options-api.php
+++ b/tests/phpunit/unit-tests/test-options-api.php
@@ -954,7 +954,7 @@ class Test_Options_API extends WP_UnitTestCase {
 	 * @dataProvider provider_sanitize_all_fields
 	 */
 	public function test_sanitize_all_fields( $type, $value, $expected ) {
-		$this->assertEquals( $expected, $this->options->sanitize_all_fields( $value, '', [], [ 'type' => $type ] ) );
+		$this->assertEquals( $expected, $this->options->sanitize_all_fields( $value, '', [], [ 'id' => $type, 'type' => $type ] ) );
 	}
 
 	/**
@@ -1003,13 +1003,13 @@ class Test_Options_API extends WP_UnitTestCase {
 			],
 
 			[
-				'conditional_logic',
+				'conditionalLogic',
 				'',
 				''
 			],
 
 			[
-				'conditional_logic',
+				'conditionalLogic',
 				wp_json_encode( [
 					'actionType' => 'see',
 					'logicType'  => 'boat',


### PR DESCRIPTION
## Description

The conditional logic JSON was being passed through `sanitize_text_field()`, instead of `\GFFormsModel::sanitize_conditional_logic()`. This update ensures the JSON data is correctly decoded, sanitized, and then recoded.

## Testing instructions
Let automated tests run.

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
