### PR TITLE
Process Populate Anything Tags in $form_data array

### DIFF
--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -138,7 +138,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* Add Gravity Perk Population Anything Support */
 		if ( class_exists( '\GP_Populate_Anything_Live_Merge_Tags' ) ) {
-			add_action( 'gfpdf_pre_pdf_generation_initilise', [ $this->model, 'enable_gp_populate_anything' ] );
+			add_action( 'gfpdf_pre_pdf_generation', [ $this->model, 'enable_gp_populate_anything' ] );
 			add_action( 'gfpdf_pre_pdf_generation_output', [ $this->model, 'disable_gp_populate_anything' ] );
 		}
 	}


### PR DESCRIPTION
## Description

Resolves problems in custom PDF templates.

## Testing instructions
1. With Gravity Wiz and Populate Anything Perk installed, import this Gravity Form 
[simple-populate-anything-form.json.txt](https://github.com/GravityPDF/gravity-pdf/files/11057682/simple-populate-anything-form.json.txt) (remove the .txt extension)
2. Submit a test entry by filling out the name field
3. Configure a Core PDF template on the form with the Show HTML Fields setting enabled, and verify the live merge tags in the HTML are processed
4. Configure a custom PDF template on the form and echo the `$form_data['html_id'][5]` HTML field, and verify the live merge tags are processed in the HTML

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
