### PR TITLE
Page Break fields now checks for conditional logic and exclude class

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -107,6 +107,9 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 == Changelog ==
 
+= 6.10.1 =
+* Bug: Adhere to conditional logic and exclude CSS class for Page Break fields
+
 = 6.10.0 =
 * Feature: Add native support for the Legal Signature and Legal Consent form fields added by the Legal Signing for Gravity Forms plugin
 

--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -174,6 +174,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_filter( 'gfpdf_field_middleware', [ $this->model, 'field_middle_conditional_fields' ], 10, 5 );
 		add_filter( 'gfpdf_field_middleware', [ $this->model, 'field_middle_product_fields' ], 10, 5 );
 		add_filter( 'gfpdf_field_middleware', [ $this->model, 'field_middle_html_fields' ], 10, 5 );
+		add_filter( 'gfpdf_field_middleware', [ $this->model, 'field_middle_page' ], 10, 5 );
 		add_filter( 'gfpdf_field_middleware', [ $this->model, 'field_middle_blacklist' ], 10, 7 );
 
 		/* Tap into GF notifications */
@@ -220,6 +221,9 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* Meta boxes */
 		add_filter( 'gform_entry_detail_meta_boxes', [ $this->model, 'register_pdf_meta_box' ], 10, 3 );
+
+		/* Page field support */
+		add_filter( 'gfpdf_current_form_object', [ $this->model, 'register_page_fields' ] );
 	}
 
 	/**

--- a/src/Helper/Fields/Field_Form.php
+++ b/src/Helper/Fields/Field_Form.php
@@ -66,7 +66,7 @@ class Field_Form extends Helper_Abstract_Fields {
 	 */
 	public function html( $value = '', $label = true ) {
 		/* Get the Nested Form */
-		$form = $this->gform->get_form( $this->field->gpnfForm );
+		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $this->field->gpnfForm ), $this->entry, __FUNCTION__ );
 		if ( is_wp_error( $form ) ) {
 			return parent::html();
 		}
@@ -135,7 +135,7 @@ class Field_Form extends Helper_Abstract_Fields {
 		}
 
 		/* Skip over any of the following blacklisted fields */
-		$blacklisted = apply_filters( 'gfpdf_blacklisted_fields', [ 'captcha', 'password', 'page' ] );
+		$blacklisted = apply_filters( 'gfpdf_blacklisted_fields', [ 'captcha', 'password' ] );
 
 		/* Loop through the Repeater fields */
 		foreach ( $form['fields'] as $field ) {

--- a/src/Helper/Fields/Field_Page.php
+++ b/src/Helper/Fields/Field_Page.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace GFPDF\Helper\Fields;
+
+use GFPDF\Helper\Helper_Abstract_Fields;
+use GFPDF\Statics\Kses;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Controls the display and output of a Gravity Form field
+ *
+ * @since 6.10.1
+ */
+class Field_Page extends Helper_Abstract_Fields {
+
+	/**
+	 * Display the HTML version of this field
+	 *
+	 * @param string $value
+	 * @param bool   $label
+	 *
+	 * @return string
+	 *
+	 * @since 6.10.1
+	 */
+	public function html( $value = '', $label = true ) {
+		$page_number = $this->field->pageNumber;
+
+		ob_start();
+		?>
+		<h3 id="<?php echo esc_attr( 'page-no-' . $page_number ); ?>" class="gfpdf-page gfpdf-field <?php echo esc_attr( $this->get_field_classes() ); ?>">
+			<?php echo wp_kses_post( $this->value() ); ?>
+		</h3>
+		<?php
+
+		/* Run it through a filter and output */
+		$html = apply_filters( 'gfpdf_field_page_name_html', ob_get_clean(), $page_number, $this->form );
+
+		if ( $this->get_output() ) {
+			Kses::output( $html );
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Get the page label
+	 *
+	 * @return string
+	 *
+	 * @since 6.10.1
+	 */
+	public function value() {
+		return $this->field->content;
+	}
+
+	/**
+	 * Check if the Page is hidden, or if there are no filled in fields on that page/section
+	 *
+	 * @return bool
+	 *
+	 * @since 6.10.1
+	 */
+	public function is_empty() {
+		if ( \GFFormsModel::is_page_hidden( $this->form, $this->field->pageNumber, [], $this->entry ) ) {
+			return true;
+		}
+
+		/* todo: this doesn't account for all fields if there are Section Breaks on the page */
+		if ( \GFCommon::is_section_empty( $this->field, $this->form, $this->entry ) ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/View/View_PDF.php
+++ b/src/View/View_PDF.php
@@ -394,26 +394,13 @@ class View_PDF extends Helper_Abstract_View {
 		$show_individual_product_fields = ( isset( $config['meta']['individual_products'] ) ) ? $config['meta']['individual_products'] : false; /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
 
 		/* Skip over any of the following blacklisted fields */
-		$blacklisted = apply_filters( 'gfpdf_blacklisted_fields', [ 'captcha', 'password', 'page' ] );
+		$blacklisted = apply_filters( 'gfpdf_blacklisted_fields', [ 'captcha', 'password' ] );
 
-		/*
-		 * Display the form title, if needed
-		 *  Use the filter 'gfpdf_current_pdf_configuration' to programmatically disable this functionality
-		 */
+		/* Display the form title, if needed */
 		$this->show_form_title( $show_title, $form );
 
 		/* Loop through the fields and output or skip if needed */
 		foreach ( $form['fields'] as $key => $field ) {
-
-			/*
-			 * Load our page name, if needed
-			 * Use the filter 'gfpdf_current_pdf_configuration' to programmatically disable this functionality
-			 */
-			if ( $show_page_names === true && $field->pageNumber !== $page_number ) {
-				$this->display_page_name( $page_number, $form, $container );
-				$page_number++;
-			}
-
 			/*
 			 * Middleware filter to check if the field should be skipped.
 			 *
@@ -543,6 +530,8 @@ class View_PDF extends Helper_Abstract_View {
 	 * @param Helper_Field_Container $container
 	 *
 	 * @since    4.0
+	 *
+	 * @deprecated 6.10.1 Page fields are handled like all other fields, with markup generated using a dedicated Field_Page class
 	 */
 	public function display_page_name( $page, $form, Helper_Field_Container $container ) {
 


### PR DESCRIPTION
## Description

Resolves #1463

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
