### PR TITLE
Always deactivate license key after AJAX request

### DIFF
--- a/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
+++ b/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
@@ -31,13 +31,13 @@ export function setupLicenseDeactivation () {
       /* Remove our loading spinner */
       $spinner.remove()
 
-      if (response.success) {
-        /* cleanup inputs */
-        $('#gfpdf_settings\\[license_' + slug + '\\]').val('')
-        $('#gfpdf_settings\\[license_' + slug + '_message\\]').val('')
-        $('#gfpdf_settings\\[license_' + slug + '_status\\]').val('')
-        $container.find('button').remove()
+      /* cleanup inputs */
+      $('#gfpdf_settings\\[license_' + slug + '\\]').val('')
+      $('#gfpdf_settings\\[license_' + slug + '_message\\]').val('')
+      $('#gfpdf_settings\\[license_' + slug + '_status\\]').val('')
+      $container.find('button').remove()
 
+      if (response.success) {
         $container
           .find('#message')
           .removeClass('error')

--- a/tests/phpunit/unit-tests/test-ajax.php
+++ b/tests/phpunit/unit-tests/test-ajax.php
@@ -498,7 +498,7 @@ class Test_PDF_Ajax extends WP_Ajax_UnitTestCase {
 			/* do nothing (error expected) */
 		}
 
-		$this->assertEquals( 'An error occurred during deactivation, please try again', json_decode( $this->_last_response )->error );
+		$this->assertStringContainsString( 'An unknown error occurred', json_decode( $this->_last_response )->error );
 	}
 
 	public function test_ajax_save_core_font() {


### PR DESCRIPTION
## Description

Regardless of the outcome of the API request, always remove the license key from the database. This prevents UX issues if a license is manually deactivated from the GravityPDF.com account.

Update the error message to let a user know the license may not have been deactivated successfully, with a link to their account.

Resolves #1432

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
