### PR TITLE
Prefix PSR composer packages

### DIFF
--- a/.php-scoper/monolog.php
+++ b/.php-scoper/monolog.php
@@ -21,7 +21,8 @@ return [
 	 * For more see: https://github.com/humbug/php-scoper#finders-and-paths
 	 */
 	'finders'   => [
-		Finder::create()->files()->in( $path . 'vendor/monolog/monolog/' )->name( [ '*.php', 'LICENSE' ] ),
+		Finder::create()->files()->in( $path . 'vendor/monolog/monolog' )->name( [ '*.php', 'LICENSE' ] ),
+		Finder::create()->files()->in( $path . 'vendor/psr/log' )->exclude( 'Test' )->name( [ '*.php', 'LICENSE' ] ),
 	],
 
 	/*
@@ -41,9 +42,5 @@ return [
 
 			return $content;
 		},
-	],
-
-	'whitelist' => [
-		'Psr\*',
-	],
+	]
 ];

--- a/.php-scoper/mpdf.php
+++ b/.php-scoper/mpdf.php
@@ -26,6 +26,7 @@ return [
 		Finder::create()->files()->in( $path . 'vendor/mpdf/mpdf/data' )->name( [ '*' ] ),
 		Finder::create()->files()->in( $path . 'vendor/mpdf/qrcode/' )->exclude( 'tests' )->name( [ '*.php', 'LICENSE', '*.dat' ] ),
 		Finder::create()->files()->in( $path . 'vendor/mpdf/psr-log-aware-trait' )->name( [ '*.php' ] ),
+		Finder::create()->files()->in( $path . 'vendor/psr/http-message' )->name( [ '*.php', 'LICENSE' ] ),
 		Finder::create()->files()->in( $path . 'vendor/setasign/fpdi' )->name( [ '*.php', 'LICENSE.txt' ] ),
 		Finder::create()->files()->in( $path . 'vendor/myclabs/deep-copy' )->name( [ '*.php', 'LICENSE' ] ),
 	],
@@ -60,9 +61,5 @@ return [
 
 			return $content;
 		},
-	],
-
-	'whitelist' => [
-		'Psr\*',
 	],
 ];

--- a/.php-scoper/querypath.php
+++ b/.php-scoper/querypath.php
@@ -49,8 +49,4 @@ return [
 			);
 		},
 	],
-
-	'whitelist' => [
-		'Psr\*',
-	],
 ];

--- a/.php-scoper/upload.php
+++ b/.php-scoper/upload.php
@@ -34,8 +34,4 @@ return [
 	 * For more see: https://github.com/humbug/php-scoper#patchers
 	 */
 	'patchers'  => [],
-
-	'whitelist' => [
-		'Psr\*',
-	],
 ];

--- a/.php-scoper/url-signer.php
+++ b/.php-scoper/url-signer.php
@@ -36,8 +36,4 @@ return [
 	 * For more see: https://github.com/humbug/php-scoper#patchers
 	 */
 	'patchers'  => [],
-
-	'whitelist' => [
-		'Psr\*',
-	],
 ];

--- a/api.php
+++ b/api.php
@@ -44,7 +44,8 @@ final class GPDFAPI {
 	 *
 	 * See https://docs.gravitypdf.com/v6/developers/api/get_log_class/ for more information about this method
 	 *
-	 * @return \Psr\Log\LoggerInterface
+	 * @return \GFPDF_Vendor\Psr\Log\LoggerInterface
+	 * @internal Prefixed namespace in 6.7.1 to resolve 3rd party plugin conflict with PSR Log v3
 	 *
 	 * @since 4.0
 	 */

--- a/bin/vendor-prefix.sh
+++ b/bin/vendor-prefix.sh
@@ -22,7 +22,7 @@ mkdir "${PLUGIN_DIR}vendor_prefixed"
 touch "${PLUGIN_DIR}vendor_prefixed/.gitkeep"
 
 # Monolog
-eval "$PHP ${PLUGIN_DIR}php-scoper.phar add-prefix --output-dir=${PLUGIN_DIR}vendor_prefixed/monolog --config=${PLUGIN_DIR}.php-scoper/monolog.php --quiet"
+eval "$PHP ${PLUGIN_DIR}php-scoper.phar add-prefix --output-dir=${PLUGIN_DIR}vendor_prefixed --config=${PLUGIN_DIR}.php-scoper/monolog.php --quiet"
 eval "rm -Rf ${PLUGIN_DIR}vendor/monolog"
 
 # URL Signer
@@ -45,5 +45,6 @@ eval "rm -Rf ${PLUGIN_DIR}vendor/myclabs"
 
 # Do this at the end as we have multiple vendor packages used
 eval "rm -Rf ${PLUGIN_DIR}vendor/gravitypdf"
+eval "rm -Rf ${PLUGIN_DIR}vendor/psr/http-message"
 
 eval "$COMPOSER dump-autoload --optimize --working-dir ${PLUGIN_DIR}"

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
   "autoload": {
     "psr-4": {
       "GFPDF\\": "src/",
-      "Psr\\Http\\Message\\": "vendor/psr/http-message/src",
       "Psr\\Log\\": "vendor/psr/log/Psr/Log"
     },
     "classmap": [

--- a/src/Controller/Controller_Actions.php
+++ b/src/Controller/Controller_Actions.php
@@ -11,7 +11,7 @@ use GFPDF\Helper\Helper_Interface_Actions;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Model\Model_Actions;
 use GFPDF\View\View_Actions;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Controller/Controller_Custom_Fonts.php
+++ b/src/Controller/Controller_Custom_Fonts.php
@@ -20,7 +20,7 @@ use GFPDF\Helper\Helper_Data;
 use GFPDF\Model\Model_Custom_Fonts;
 use GFPDF_Vendor\GravityPdf\Upload\Exception as UploadException;
 use GFPDF_Vendor\GravityPdf\Upload\Validation\Extension;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;

--- a/src/Controller/Controller_Install.php
+++ b/src/Controller/Controller_Install.php
@@ -13,7 +13,7 @@ use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Controller_Uninstaller;
 use GFPDF\Model\Model_Install;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -12,7 +12,7 @@ use GFPDF\Helper\Helper_Interface_Filters;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Model\Model_PDF;
 use GFPDF\View\View_PDF;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 use SiteGround_Optimizer\Minifier\Minifier;
 
 /**

--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -9,7 +9,7 @@ use GFPDF\Helper\Helper_Interface_Actions;
 use GFPDF\Helper\Helper_Interface_Filters;
 use GFPDF\Helper\Helper_Pdf_Queue;
 use GFPDF\Model\Model_PDF;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Controller/Controller_Save_Core_Fonts.php
+++ b/src/Controller/Controller_Save_Core_Fonts.php
@@ -6,7 +6,7 @@ use GFPDF\Helper\Helper_Abstract_Controller;
 use GFPDF\Helper\Helper_Data;
 use GFPDF\Helper\Helper_Interface_Actions;
 use GFPDF\Helper\Helper_Misc;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Controller/Controller_Settings.php
+++ b/src/Controller/Controller_Settings.php
@@ -15,7 +15,7 @@ use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Model\Model_Settings;
 use GFPDF\View\View_Settings;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Controller/Controller_Shortcodes.php
+++ b/src/Controller/Controller_Shortcodes.php
@@ -8,7 +8,7 @@ use GFPDF\Helper\Helper_Abstract_View;
 use GFPDF\Helper\Helper_Interface_Filters;
 use GFPDF\Model\Model_Shortcodes;
 use GFPDF\View\View_Shortcodes;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Helper/Helper_Abstract_Addon.php
+++ b/src/Helper/Helper_Abstract_Addon.php
@@ -2,7 +2,7 @@
 
 namespace GFPDF\Helper;
 
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -5,7 +5,7 @@ namespace GFPDF\Helper;
 use GFPDF\Controller\Controller_Custom_Fonts;
 use GFPDF\Model\Model_Custom_Fonts;
 use GFPDF\Statics\Kses;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 use WP_Error;
 
 /**

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -8,7 +8,7 @@ use GFPDF\Exceptions\GravityPdfShortcodePdfConfigNotFoundException;
 use GFPDF\Exceptions\GravityPdfShortcodePdfInactiveException;
 use GPDFAPI;
 use GravityView_View;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Helper/Helper_Logger.php
+++ b/src/Helper/Helper_Logger.php
@@ -11,7 +11,7 @@ use GFPDF_Vendor\Monolog\Handler\StreamHandler;
 use GFPDF_Vendor\Monolog\Logger;
 use GFPDF_Vendor\Monolog\Processor\IntrospectionProcessor;
 use GFPDF_Vendor\Monolog\Processor\MemoryPeakUsageProcessor;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -6,7 +6,7 @@ use DOMElement;
 use Exception;
 use GFCommon;
 use GFMultiCurrency;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use WP_Error;

--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -7,7 +7,7 @@ use GFPDF_Vendor\Mpdf\Config\FontVariables;
 use GFPDF_Vendor\Mpdf\Mpdf;
 use GFPDF_Vendor\Mpdf\MpdfException;
 use GFPDF_Vendor\Mpdf\Utils\UtfString;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Helper/Helper_Pdf_Queue.php
+++ b/src/Helper/Helper_Pdf_Queue.php
@@ -5,7 +5,7 @@ namespace GFPDF\Helper;
 use Exception;
 use GF_Background_Process;
 use GFCommon;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Helper/Helper_Templates.php
+++ b/src/Helper/Helper_Templates.php
@@ -4,7 +4,7 @@ namespace GFPDF\Helper;
 
 use Exception;
 use GPDFAPI;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 use stdClass;
 
 /**

--- a/src/Helper/Helper_Trait_Logger.php
+++ b/src/Helper/Helper_Trait_Logger.php
@@ -2,7 +2,7 @@
 
 namespace GFPDF\Helper;
 
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Model/Model_Form_Settings.php
+++ b/src/Model/Model_Form_Settings.php
@@ -16,7 +16,7 @@ use GFPDF\Helper\Helper_Options_Fields;
 use GFPDF\Helper\Helper_PDF_List_Table;
 use GFPDF\Helper\Helper_Templates;
 use GFPDF\View\View_GravityForm_Settings_Markup;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Model/Model_Install.php
+++ b/src/Model/Model_Install.php
@@ -10,7 +10,7 @@ use GFPDF\Helper\Helper_Form;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Pdf_Queue;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Model/Model_Mergetags.php
+++ b/src/Model/Model_Mergetags.php
@@ -7,7 +7,7 @@ use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Interface_Url_Signer;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Options_Fields;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -26,7 +26,7 @@ use GFPDF_Vendor\Spatie\UrlSigner\Exceptions\InvalidSignatureKey;
 use GFQuiz;
 use GFResults;
 use GP_Populate_Anything_Live_Merge_Tags;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use WP_Error;

--- a/src/Model/Model_Settings.php
+++ b/src/Model/Model_Settings.php
@@ -12,7 +12,7 @@ use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Options_Fields;
 use GFPDF\Helper\Helper_Templates;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Model/Model_System_Report.php
+++ b/src/Model/Model_System_Report.php
@@ -10,7 +10,7 @@ use GFPDF\Helper\Helper_Data;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Templates;
 use GFPDF_Major_Compatibility_Checks;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Model/Model_Templates.php
+++ b/src/Model/Model_Templates.php
@@ -13,7 +13,7 @@ use GFPDF_Vendor\GravityPdf\Upload\Validation\Extension;
 use GFPDF_Vendor\GravityPdf\Upload\Validation\Mimetype;
 use GFPDF_Vendor\GravityPdf\Upload\Validation\Size;
 use GPDFAPI;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/Model/Model_Uninstall.php
+++ b/src/Model/Model_Uninstall.php
@@ -9,7 +9,7 @@ use GFPDF\Helper\Helper_Form;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Pdf_Queue;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/View/View_PDF.php
+++ b/src/View/View_PDF.php
@@ -22,7 +22,7 @@ use GFPDF\Helper\Helper_Templates;
 use GFPDF\Statics\Kses;
 use GFPDFEntryDetail;
 use GWConditionalLogicDateFields;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 use WP_Error;
 
 /**

--- a/src/View/View_Settings.php
+++ b/src/View/View_Settings.php
@@ -12,7 +12,7 @@ use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Options_Fields;
 use GFPDF\Helper\Helper_Templates;
 use GFPDF_Major_Compatibility_Checks;
-use Psr\Log\LoggerInterface;
+use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * @package     Gravity PDF

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -16,7 +16,6 @@ use GFPDF\Model;
 use GFPDF\View;
 use GFPDF_Core;
 use GFPDF_Major_Compatibility_Checks;
-use Psr\Log\LoggerInterface;
 
 /*
  * Bootstrap / Router Class
@@ -47,9 +46,10 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	/**
 	 * Holds our log class
 	 *
-	 * @var LoggerInterface
+	 * @var \GFPDF_Vendor\Psr\Log\LoggerInterface
 	 *
 	 * @since 4.0
+	 * @internal Prefixed namespace in 6.7.1 to resolve 3rd party plugin conflict with PSR Log v3
 	 */
 	public $log;
 

--- a/tests/phpunit/unit-tests/test-logger.php
+++ b/tests/phpunit/unit-tests/test-logger.php
@@ -41,7 +41,7 @@ class Test_Logger extends WP_UnitTestCase {
 	 * @since 4.2
 	 */
 	public function test_logger() {
-		$this->assertInstanceOf( '\Psr\Log\LoggerInterface', $this->logger->get_logger() );
+		$this->assertInstanceOf( '\GFPDF_Vendor\Psr\Log\LoggerInterface', $this->logger->get_logger() );
 		$this->assertEquals(
 			10,
 			has_filter(


### PR DESCRIPTION
## Description

Resolves 3rd party plugin compatibility issues when PSR v3 is loaded. Due to backwards compatibility, only PSRv2 is supported by Gravity PDF.

To prevent unnecessary breaking changes, we are still shipping PSR v2 with Gravity PDF. The Bulk Generator and PDF for GravityView add-ons both reference the unprefixed LoggerInterface class for type hinting.

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
