### PR TITLE
Prefix PSR libraries for Mpdf only

### DIFF
--- a/.php-scoper/mpdf.php
+++ b/.php-scoper/mpdf.php
@@ -26,6 +26,8 @@ return [
 		Finder::create()->files()->in( $path . 'vendor/mpdf/mpdf/data' )->name( [ '*' ] ),
 		Finder::create()->files()->in( $path . 'vendor/mpdf/qrcode/' )->exclude( 'tests' )->name( [ '*.php', 'LICENSE', '*.dat' ] ),
 		Finder::create()->files()->in( $path . 'vendor/mpdf/psr-log-aware-trait' )->name( [ '*.php' ] ),
+		Finder::create()->files()->in( $path . 'vendor/psr/log' )->name( [ '*.php', 'LICENSE' ] ),
+		Finder::create()->files()->in( $path . 'vendor/psr/http-message' )->name( [ '*.php', 'LICENSE' ] ),
 		Finder::create()->files()->in( $path . 'vendor/setasign/fpdi' )->name( [ '*.php', 'LICENSE.txt' ] ),
 		Finder::create()->files()->in( $path . 'vendor/myclabs/deep-copy' )->name( [ '*.php', 'LICENSE' ] ),
 	],
@@ -41,6 +43,7 @@ return [
 	'patchers'  => [
 		function( string $filePath, string $prefix, string $content ): string {
 
+			/* Mpdf fixes */
 			if ( basename( $filePath ) === 'Tag.php' ) {
 				$content = str_replace( "'Mpdf\\\\Tag\\\\'", "'$prefix\\\\Mpdf\\\\Tag\\\\'", $content );
 			}
@@ -58,11 +61,19 @@ return [
 				$content = str_replace( "$prefix\\\\</t\\\\1", '</t\\\\1', $content );
 			}
 
+			/* Remove type hinting from prefixed logger */
+			$files = [
+				'LoggerAwareInterface.php',
+				'LoggerAwareTrait.php',
+				'MpdfPsrLogAwareTrait.php',
+				'PsrLogAwareTrait.php'
+			];
+
+			if ( in_array( basename( $filePath ), $files, true ) ) {
+				$content = str_replace( "\\$prefix\\Psr\\Log\\LoggerInterface", '', $content );
+			}
+
 			return $content;
 		},
-	],
-
-	'whitelist' => [
-		'Psr\*',
 	],
 ];

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
   "autoload": {
     "psr-4": {
       "GFPDF\\": "src/",
-      "Psr\\Http\\Message\\": "vendor/psr/http-message/src",
       "Psr\\Log\\": "vendor/psr/log/Psr/Log"
     },
     "classmap": [


### PR DESCRIPTION
## Description

This resolves a conflict with 3rd party plugins who include PSR Log v3. 

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
