### PR TITLE
Return appropriate status code when PDF error occurs

### DIFF
--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -367,12 +367,32 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 			]
 		);
 
+		switch ( $error->get_error_code() ) {
+			case 'timeout_expired':
+			case 'access_denied':
+				$status_code = 401;
+				break;
+
+			case 'not_found':
+			case 'inactive':
+			case 'conditional_logic':
+				$status_code = 404;
+				break;
+
+			case 'invalid_pdf_id':
+				$status_code = 400;
+				break;
+
+			default:
+				$status_code = 500;
+		}
+
 		/* only display detailed error to admins */
 		$whitelist_errors = [ 'timeout_expired', 'access_denied' ];
 		if ( $this->gform->has_capability( 'gravityforms_view_settings' ) || in_array( $error->get_error_code(), $whitelist_errors, true ) ) {
-			wp_die( esc_html( $error->get_error_message() ) );
+			wp_die( esc_html( $error->get_error_message() ), $status_code ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} else {
-			wp_die( esc_html__( 'There was a problem generating your PDF', 'gravity-forms-pdf-extended' ) );
+			wp_die( esc_html__( 'There was a problem generating your PDF', 'gravity-forms-pdf-extended' ), $status_code ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 }


### PR DESCRIPTION
## Description

A 400, 401, 404, or 500 status code will returned with the request if an error occurs when viewing a PDF.

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
