### PR TITLE
Fix autoloading errors

### DIFF
--- a/.php-scoper/mpdf.php
+++ b/.php-scoper/mpdf.php
@@ -27,7 +27,6 @@ return [
 		Finder::create()->files()->in( $path . 'vendor/mpdf/qrcode/' )->exclude( 'tests' )->name( [ '*.php', 'LICENSE', '*.dat' ] ),
 		Finder::create()->files()->in( $path . 'vendor/mpdf/psr-log-aware-trait' )->name( [ '*.php' ] ),
 		Finder::create()->files()->in( $path . 'vendor/psr/log' )->name( [ '*.php', 'LICENSE' ] ),
-		Finder::create()->files()->in( $path . 'vendor/psr/http-message' )->name( [ '*.php', 'LICENSE' ] ),
 		Finder::create()->files()->in( $path . 'vendor/setasign/fpdi' )->name( [ '*.php', 'LICENSE.txt' ] ),
 		Finder::create()->files()->in( $path . 'vendor/myclabs/deep-copy' )->name( [ '*.php', 'LICENSE' ] ),
 	],
@@ -75,5 +74,9 @@ return [
 
 			return $content;
 		},
+	],
+
+	'whitelist' => [
+		'Psr\Http\*',
 	],
 ];

--- a/README.txt
+++ b/README.txt
@@ -108,7 +108,7 @@ If you aren't able to meet the v6 minimum requirements [you can download v5 whic
 == Changelog ==
 
 = 6.7.1 =
-* Bug: Resolve dependency conflict with third party plugins who include the PSR Log v3 package
+* Bug: Improve dependency conflicts with third party plugins who bundle PSR Log v2 or v3
 * Housekeeping: Use 4xx HTTP Status Codes for non-server related errors when generating PDFs
 
 = 6.7.0 =

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
   "autoload": {
     "psr-4": {
       "GFPDF\\": "src/",
+      "Psr\\Http\\Message\\": "vendor/psr/http-message/src",
       "Psr\\Log\\": "vendor/psr/log/Psr/Log"
     },
     "classmap": [


### PR DESCRIPTION
## Description

Continuation of work done in https://github.com/GravityPDF/gravity-pdf/pull/1473

## Testing instructions
1. Verify signed PDF URL
2. Verify Bulk Generator extension
3. Verify Previewer extension
4. Verify PDF generates
5. Verify logging works

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
