### PR TITLE
Fix fatal error using GF Google Analytics Pagination feature

### DIFF
--- a/src/Model/Model_Mergetags.php
+++ b/src/Model/Model_Mergetags.php
@@ -343,7 +343,7 @@ class Model_Mergetags extends Helper_Abstract_Model {
 		}
 
 		$gform = \GPDFAPI::get_form_class();
-		return $gform->process_tags( $field_id, $gform->get_form( $form['id'] ), $gform->get_entry( $entry['id'] ) );
+		return $gform->process_tags( $field_id, $form, $entry );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Use the passed `$form` and `$entry` object when processing, as `$entry` may be created before submission and `$gform->get_entry()` will return a `WP_Error` in this instance. This is the case when using the Pagination feature in the GF Google Analytics plugin.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
