### PR TITLE
Add PHP8.3 to automated test suite

### DIFF
--- a/.github/workflows/phpunit.tests.yml
+++ b/.github/workflows/phpunit.tests.yml
@@ -48,14 +48,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.2', '8.1', '8.0', '7.4', '7.3' ]
+        php: [ '8.3', '8.2', '8.1', '8.0', '7.4', '7.3' ]
         os: [ ubuntu-latest ]
         multisite: [ false ]
         include:
-          - php: '8.2'
+          - php: '8.3'
             os: ubuntu-latest
             multisite: true
-          - php: '8.2'
+          - php: '8.3'
             os: ubuntu-latest
             multisite: false
             report: true


### PR DESCRIPTION
## Description

Include PHP 8.3 when running PHPUnit

## Testing instructions
Let GitHub Actions do its thing

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
