### PR TITLE
Prefix v1 of the PSR-7 composer library

### DIFF
--- a/.php-scoper/mpdf.php
+++ b/.php-scoper/mpdf.php
@@ -28,6 +28,7 @@ return [
 		Finder::create()->files()->in( $path . 'vendor/mpdf/psr-log-aware-trait' )->name( [ '*.php' ] ),
 		Finder::create()->files()->in( $path . 'vendor/mpdf/psr-http-message-shim' )->name( [ '*.php' ] ),
 		Finder::create()->files()->in( $path . 'vendor/psr/log' )->name( [ '*.php', 'LICENSE' ] ),
+		Finder::create()->files()->in( $path . 'vendor/psr/http-message' )->name( [ '*.php', 'LICENSE' ] ),
 		Finder::create()->files()->in( $path . 'vendor/setasign/fpdi' )->name( [ '*.php', 'LICENSE.txt' ] ),
 		Finder::create()->files()->in( $path . 'vendor/myclabs/deep-copy' )->name( [ '*.php', 'LICENSE' ] ),
 	],
@@ -75,9 +76,5 @@ return [
 
 			return $content;
 		},
-	],
-
-	'whitelist' => [
-		'Psr\Http\*',
 	],
 ];


### PR DESCRIPTION
## Description

This resolve a conflict when an outside source loads v2 of the PSR-7 library

Resolves https://wordpress.org/support/topic/psr-4-conflict/

## Testing instructions

Verify PDFs still generate with external images included in the header/footer/body.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
