### PR TITLE
Allow some HTML in product / option / shipping field labels

### DIFF
--- a/src/Helper/Fields/Field_Products.php
+++ b/src/Helper/Fields/Field_Products.php
@@ -153,7 +153,7 @@ class Field_Products extends Helper_Abstract_Fields {
 							<tr>
 								<td>
 									<div class="product_name">
-										<?php echo esc_html( $product['name'] ); ?>
+										<?php Kses::output( wp_specialchars_decode( $product['name'], ENT_QUOTES ) ); ?>
 									</div>
 
 									<?php
@@ -166,7 +166,7 @@ class Field_Products extends Helper_Abstract_Fields {
 											foreach ( $product['options'] as $option ) :
 												$price += $option['price'];
 												?>
-												<li><?php echo esc_html( $option['option_label'] ); ?></li>
+												<li><?php Kses::output( wp_specialchars_decode( $option['option_label'], ENT_QUOTES ) ); ?></li>
 											<?php endforeach; ?>
 										</ul>
 									<?php endif; ?>
@@ -197,7 +197,7 @@ class Field_Products extends Helper_Abstract_Fields {
 											rowspan="<?php echo esc_attr( $gpecommerce->get_order_summary_item_count( $order_summary ) ); ?>"></td>
 									<?php endif; ?>
 									<td class="totals" style="<?php esc_attr( $gpecommerce->style( ".order-summary/tfoot/{$class}/td.column-3" ) ); ?>">
-										<?php Kses::output( $item['name'] ); ?>
+										<?php Kses::output( wp_specialchars_decode( $item['name'], ENT_QUOTES ) ); ?>
 									</td>
 
 									<td class="totals" style="<?php esc_attr( $gpecommerce->style( ".order-summary/tfoot/{$class}/td.column-4" ) ); ?>">
@@ -216,7 +216,7 @@ class Field_Products extends Helper_Abstract_Fields {
 								</tr>
 								<tr>
 									<td colspan="2"
-										class="shipping totals"><?php echo esc_html( sprintf( __( 'Shipping (%s)', 'gravity-forms-pdf-extended' ), $products['products_totals']['shipping_name'] ) ); ?></td>
+										class="shipping totals"><?php Kses::output( sprintf( __( 'Shipping (%s)', 'gravity-forms-pdf-extended' ), wp_specialchars_decode( $products['products_totals']['shipping_name'], ENT_QUOTES ) ) ); ?></td>
 									<td class="shipping_amount totals"><?php echo esc_html( $products['products_totals']['shipping_formatted'] ); ?></td>
 								</tr>
 							<?php endif; ?>

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Products.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Products.php
@@ -60,5 +60,31 @@ class Test_Field_Products extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'subtotal_formatted', $value['products'][34] );
 	}
 
+	public function test_html() {
+		$html = $this->pdf_field->html();
+
+		$this->assertStringContainsString( '<li>Product Options for Basic Product: Option 2</li>', $html );
+		$this->assertStringContainsString( 'Calculation Price', $html );
+		$this->assertStringContainsString( '<li>Option for Calculation Price: Cal - Option 1</li>', $html );
+		$this->assertStringContainsString( '<td class="grandtotal_amount totals">$860.25</td>', $html );
+	}
+
+	public function test_labels_in_html() {
+		$products = \GFCommon::get_product_fields( $this->form, $this->entry );
+		$products['products'][34]['name'] = '<em>Product Basic</em>';
+		$products['products'][34]['options'][0]['option_label'] = '<img src="#"> Option 2';
+
+		$use_choice_text = true;
+		$use_admin_label = false;
+		gform_update_meta( $this->pdf_field->entry['id'], "gform_product_info_{$use_choice_text}_{$use_admin_label}", $products, $this->form['id'] );
+
+		$html = $this->pdf_field->html();
+
+		$this->assertStringContainsString( '<em>Product Basic</em>', $html );
+		$this->assertStringContainsString( '<li><img src="#"> Option 2</li>', $html );
+		$this->assertStringContainsString( 'Calculation Price', $html );
+		$this->assertStringContainsString( '<li>Option for Calculation Price: Cal - Option 1</li>', $html );
+		$this->assertStringContainsString( '<td class="grandtotal_amount totals">$860.25</td>', $html );
+	}
 
 }


### PR DESCRIPTION
## Description

Updates the Product table to allow some HTML in the field and choices labels. 

For legacy reasons, $form_data auto-escapes HTML. To display HTML in field labels we need to unescape the info first, and then run it through wp_kses_post(). 

## Testing instructions
1. Add Product, Option, and Shipping fields to a form
2. Include HTML in the label and option values
3. Submit the form
4. View a Core PDF
5. Ensure the text is formatted correctly

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
