### PR TITLE
Remove type hinting in Controller_Export_Entries

### DIFF
--- a/bin/install-gravityforms.sh
+++ b/bin/install-gravityforms.sh
@@ -10,8 +10,8 @@ if [ -f ".env" ]; then
 fi
 
 # Install in both development + test environments
-npm run wp-env run cli wp gf install -- -- --key=$GF_LICENSE --version=beta --activate --force
-npm run wp-env run tests-cli wp gf install -- -- --key=$GF_LICENSE --version=beta --activate --force
+npm run wp-env run cli wp gf install -- -- --key=$GF_LICENSE --activate --force
+npm run wp-env run tests-cli wp gf install -- -- --key=$GF_LICENSE --activate --force
 
 # Install add-ons in the test environment
 npm run wp-env run tests-cli wp gf install gravityformspolls -- --key=$GF_LICENSE --activate --force

--- a/src/Controller/Controller_Export_Entries.php
+++ b/src/Controller/Controller_Export_Entries.php
@@ -33,7 +33,11 @@ class Controller_Export_Entries {
 	 *
 	 * @since 6.0
 	 */
-	public function add_pdfs_to_export_fields( array $form ): array {
+	public function add_pdfs_to_export_fields( $form ) {
+		if ( empty( $form['id'] ) ) {
+			return $form;
+		}
+
 		$pdfs = \GPDFAPI::get_form_pdfs( $form['id'] );
 
 		if ( is_wp_error( $pdfs ) ) {
@@ -60,13 +64,14 @@ class Controller_Export_Entries {
 	 * @param string           $value
 	 * @param int              $form_id
 	 * @param string|int|float $field_id
+	 * @param array            $entry
 	 *
 	 * @return string The URL, or an empty string
 	 *
 	 * @since 6.0
 	 */
-	public function get_export_field_value( $value, int $form_id, $field_id, array $entry ) {
-		if ( substr( $field_id, 0, 5 ) !== 'gpdf_' ) {
+	public function get_export_field_value( $value, $form_id, $field_id, $entry ) {
+		if ( ! isset( $entry['id'] ) || substr( $field_id, 0, 5 ) !== 'gpdf_' ) {
 			return $value;
 		}
 

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Export_Entries.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Export_Entries.php
@@ -57,6 +57,7 @@ class Test_Controller_Export_Entries extends WP_UnitTestCase {
 	public function test_get_export_field_empty_value() {
 		$form_id  = $GLOBALS['GFPDF_Test']->form['all-form-fields']['id'];
 		$field_id = 'gpdf_555ad84787d7e';
-		$this->assertEmpty( apply_filters( 'gform_export_field_value', 'item', $form_id, $field_id, [] ) );
+		$value    = 'item';
+		$this->assertSame( $value, apply_filters( 'gform_export_field_value', $value, $form_id, $field_id, [] ) );
 	}
 }


### PR DESCRIPTION
## Description

The methods are used by filters/hooks, and any plugin can change the property type. Remove the type hints to stop PHP fatal errors occurring if a different property type is passed. Instead, we'll do additional checks on these properties to see if the data required is present. 

Resolves https://github.com/GravityPDF/pdf-for-gravityview/issues/30

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
