### PR TITLE
Fix PHP Scoper Problems

### DIFF
--- a/.php-scoper/mpdf.php
+++ b/.php-scoper/mpdf.php
@@ -74,6 +74,11 @@ return [
 				$content = str_replace( "\\$prefix\\Psr\\Log\\LoggerInterface", '', $content );
 			}
 
+			/* Global polyfills */
+			if ( basename( $filePath ) === 'functions.php' ) {
+				$content = str_replace( "namespace $prefix;", '', $content );
+			}
+
 			return $content;
 		},
 	],

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -15,5 +15,11 @@ require_once PDF_PLUGIN_DIR . 'vendor/autoload.php';
 require_once PDF_PLUGIN_DIR . 'src/deprecated.php';
 require_once PDF_PLUGIN_DIR . 'api.php';
 
-class_alias( '\GFPDF_Vendor\QueryPath\QueryPath', '\GFPDF_Vendor\QueryPath' ); /* Backwards compatibility support */
+
+
+/* QueryPath Backwards Compatibility Support */
+class_alias( '\GFPDF_Vendor\QueryPath\QueryPath', '\GFPDF_Vendor\QueryPath' );
+
+/* Load global functions file */
+require_once PDF_PLUGIN_DIR . 'vendor_prefixed/mpdf/mpdf/src/functions.php';
 require_once PDF_PLUGIN_DIR . 'vendor_prefixed/gravitypdf/querypath/src/qp_functions.php';


### PR DESCRIPTION
## Description

In older versions of WordPress without the str_starts_with() or str_ends_with() polyfills, a fatal error could occur in Mpdf when using a PHP version less than 8.0.

## Testing instructions
1. Install WordPress 5.8
2. Run PHP7.4
3. Generate a PDF

Prior to this patch a PHP error would occur. After this patch, the PDF generates without issue.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
