### PR TITLE
Remove whitespace from textarea PDF settings

### DIFF
--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -1843,9 +1843,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 				<?php foreach ( $input_data as $data_id => $data_value ): ?>
 					<?php echo esc_html( 'data-' . $data_id ); ?>="<?php echo esc_attr( $data_value ); ?>"
 				<?php endforeach; ?>
-		>
-			<?php echo esc_textarea( $value ); ?>
-		</textarea>
+		><?php echo esc_textarea( $value ); ?></textarea>
 
 		<?php if ( $toggle !== false ): ?>
 			<?php $this->end_toggle_input(); ?>


### PR DESCRIPTION
## Description

The new-lines and tabs between the opening and closing `<textarea>` tags were causing display problems in the PDF settings.

## Testing instructions
1. Activate Core Booster 2.1 and view the Additional CSS section

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
