### PR TITLE
Add Gravity PDF Metabox to Gravity Flow Inbox

### DIFF
--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -126,6 +126,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* Display PDF links in Gravity Forms Admin Area */
 		add_action( 'gform_entries_first_column_actions', [ $this->model, 'view_pdf_entry_list' ], 10, 4 );
+		add_action( 'gravityflow_workflow_detail_sidebar', [ $this->model, 'view_pdf_gravityflow_inbox' ], 10, 4 );
 
 		/* Add save PDF actions */
 		add_action( 'gform_after_submission', [ $this->model, 'maybe_save_pdf' ], 10, 2 );

--- a/src/Helper/Helper_Templates.php
+++ b/src/Helper/Helper_Templates.php
@@ -110,6 +110,18 @@ class Helper_Templates {
 	 * @since 4.1
 	 */
 	public function get_all_templates() {
+		$options = GPDFAPI::get_options_class();
+		$debug   = $options->get_option( 'debug_mode', 'No' );
+
+		if ( $debug === 'No' ) {
+			$cache_name = $this->data->template_transient_cache . '-template-list';
+			$cache      = get_transient( $cache_name );
+
+			/* There may be no transient and we got a non-array. If that occurs reset $cache */
+			if ( is_array( $cache ) && ! empty( $cache ) ) {
+				return $cache;
+			}
+		}
 
 		$template_list                   = [];
 		$matched_templates_basename_list = [];
@@ -130,6 +142,12 @@ class Helper_Templates {
 					$unique_templates
 				)
 			);
+		}
+
+		if ( $debug === 'No' ) {
+			$cache = $template_list;
+
+			set_transient( $cache_name, $cache, 604800 );
 		}
 
 		return $template_list;
@@ -427,6 +445,7 @@ class Helper_Templates {
 	 */
 	public function flush_template_transient_cache() {
 		delete_transient( $this->data->template_transient_cache );
+		delete_transient( $this->data->template_transient_cache . '-template-list' );
 	}
 
 	/**

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -406,8 +406,10 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		wp_register_script( 'gfpdf_js_entries', PDF_PLUGIN_URL . 'dist/assets/js/gfpdf-entries.min.js', [ 'jquery' ], $version, true );
 
 		/* Localise admin script */
-		wp_localize_script( 'gfpdf_js_entrypoint', 'GFPDF', $this->data->get_localised_script_data( $this->options, $this->gform ) );
-		wp_localize_script( 'gfpdf_js_settings', 'GFPDF', $this->data->get_localised_script_data( $this->options, $this->gform ) );
+		$data = $this->data->get_localised_script_data( $this->options, $this->gform );
+
+		wp_localize_script( 'gfpdf_js_entrypoint', 'GFPDF', $data );
+		wp_localize_script( 'gfpdf_js_settings', 'GFPDF', $data );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/test-helper-templates.php
+++ b/tests/phpunit/unit-tests/test-helper-templates.php
@@ -105,39 +105,51 @@ class Test_Templates_Helper extends WP_UnitTestCase {
 		$templates = $this->templates->get_all_templates();
 
 		/* Test the standard templates */
-		$this->assertEquals( 4, count( $templates ) );
+		$this->assertCount( 4, $templates );
 
 		/* Test for additional templates in PDF working directory */
 		touch( $gfpdf->data->template_location . 'test.php' );
 		touch( $gfpdf->data->template_location . 'test2.php' );
 
+		delete_transient( $gfpdf->data->template_transient_cache . '-template-list' );
+
 		$templates = $this->templates->get_all_templates();
-		$this->assertEquals( 6, count( $templates ) );
+		$this->assertCount( 6, $templates );
 
 		/* Test for override */
-		$templates = $this->templates->get_all_templates();
 		touch( $gfpdf->data->template_location . 'zadani.php' );
 
-		$this->assertEquals( 6, count( $templates ) );
+		delete_transient( $gfpdf->data->template_transient_cache . '-template-list' );
+
+		$templates = $this->templates->get_all_templates();
+
+		$this->assertCount( 6, $templates );
 
 		/* Check that a configuration.php or configuration.archive.php file don't count */
 		touch( $gfpdf->data->template_location . 'configuration.php' );
 		touch( $gfpdf->data->template_location . 'configuration.archive.php' );
 
+		delete_transient( $gfpdf->data->template_transient_cache . '-template-list' );
+
 		$templates = $this->templates->get_all_templates();
-		$this->assertEquals( 6, count( $templates ) );
+		$this->assertCount( 6, $templates );
 
 		/* Test for multisite templates */
 		if ( is_multisite() ) {
 			touch( $gfpdf->data->multisite_template_location . 'test3.php' );
+
+			delete_transient( $gfpdf->data->template_transient_cache . '-template-list' );
+
 			$templates = $this->templates->get_all_templates();
-			$this->assertEquals( 7, count( $templates ) );
+			$this->assertCount( 7, $templates );
 
 			/* Check for override */
 			touch( $gfpdf->data->multisite_template_location . 'zadani.php' );
 
+			delete_transient( $gfpdf->data->template_transient_cache . '-template-list' );
+
 			$templates = $this->templates->get_all_templates();
-			$this->assertEquals( 7, count( $templates ) );
+			$this->assertCount( 7, $templates );
 		}
 	}
 


### PR DESCRIPTION
## Description

Add capability check before rendering the meta box in Entry List, Details, and Flow.

## Testing instructions
1. Install Gravity Flow and create a User Input or Approval step
2. Setup multiple PDFs on the associated form - active, inactive, and conditional
3. Verify the meta box displays in the admin Inbox and front-end Inbox as the admin user

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
