### PR TITLE
Support permalinks with trailing slash removed

### DIFF
--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -858,6 +858,8 @@ class Model_PDF extends Helper_Abstract_Model {
 				$url .= 'download/';
 			}
 
+			$url = user_trailingslashit( $url );
+
 			if ( $print ) {
 				$url .= '?print=1';
 			}


### PR DESCRIPTION
## Description

Resolves #1489 (although we didn't have a problem accessing signed PDF URLs under this configuration)


## Testing instructions
1. Enable Pretty Permalinks in the WordPress settings
2. Remove the trailing `/` from the custom permalinks section 
3. View a PDF from the admin area

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
