### PR TITLE
Improve license activation messages

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -110,6 +110,8 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 = 6.8.1 =
 * Bug: Fix Form Editor saving problem for Gravity Forms v2.6.*
 * Bug: Fix Drag and Drop Column layout issue when the GF Styles Pro plugin is enabled
+* Housekeeping: Exclude popular WordPress staging environments when activating Gravity PDF licenses
+* Housekeeping: Improve Gravity PDF license activation success and error messages
 
 = 6.8.0 =
 * Feature: Add PDF Download metabox to Gravity Flow Inbox for logged-in users with appropriate capability

--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -1707,11 +1707,11 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		<?php if ( ! empty( $value['msg'] ) ): ?>
 			<?php if ( $is_error ): ?>
 				<div class="alert gforms_note_error">
-					<?php echo esc_html( $value['msg'] ); ?>
+					<?php echo wp_kses_post( $value['msg'] ); ?>
 				</div>
 			<?php else : ?>
 				<div id="message" class="alert gforms_note_success">
-					<?php echo esc_html( $value['msg'] ); ?>
+					<?php echo wp_kses_post( $value['msg'] ); ?>
 				</div>
 			<?php endif; ?>
 		<?php endif; ?>

--- a/src/Helper/Helper_Data.php
+++ b/src/Helper/Helper_Data.php
@@ -166,17 +166,26 @@ class Helper_Data {
 		$this->addon[ $class->get_slug() ] = $class;
 	}
 
+	/**
+	 * Get the various responses for license key activations
+	 *
+	 * @param string $addon_name
+	 *
+	 * @return array
+	 */
 	public function addon_license_responses( $addon_name ) {
 		return [
-			'expired'             => __( 'Your license key expired on %s.', 'gravity-forms-pdf-extended' ),
-			'revoked'             => __( 'Your license key has been disabled', 'gravity-forms-pdf-extended' ),
-			'missing'             => __( 'Invalid license key provided', 'gravity-forms-pdf-extended' ),
-			'invalid'             => __( 'Your license is not active for this URL', 'gravity-forms-pdf-extended' ),
-			'site_inactive'       => __( 'Your license is not active for this URL', 'gravity-forms-pdf-extended' ),
-			'item_name_mismatch'  => sprintf( __( 'This appears to be an invalid license key for %s', 'gravity-forms-pdf-extended' ), $addon_name ),
-			'no_activations_left' => __( 'Your license key has reached its activation limit', 'gravity-forms-pdf-extended' ),
-			'default'             => __( 'An error occurred, please try again', 'gravity-forms-pdf-extended' ),
-			'generic'             => __( 'An error occurred during activation, please try again', 'gravity-forms-pdf-extended' ),
+			'expired'             => sprintf( __( 'This license key expired on %%s. %1$sPlease renew your license to continue receiving updates and support%2$s.', 'gravity-forms-pdf-extended' ), '<a href="%s">', '</a>' ),
+			'revoked'             => sprintf( __( 'This license key has been cancelled (most likely due to a refund request). %1$sPlease consider purchasing a new license%2$s.', 'gravity-forms-pdf-extended' ), '<a href="%s">', '</a>' ),
+			'disabled'            => sprintf( __( 'This license key has been cancelled (most likely due to a refund request). %1$sPlease consider purchasing a new license%2$s.', 'gravity-forms-pdf-extended' ), '<a href="%s">', '</a>' ),
+			'missing'             => __( 'This license key is invalid. Please check your key has been entered correctly.', 'gravity-forms-pdf-extended' ),
+			'invalid'             => __( 'The license key is invalid. Please check your key has been entered correctly.', 'gravity-forms-pdf-extended' ),
+			'site_inactive'       => __( 'Your license key is valid but does not match your current domain. This usually occurs if your domain URL changes. Please resave the settings to activate the license for this website.', 'gravity-forms-pdf-extended' ),
+			'item_name_mismatch'  => sprintf( __( 'This license key is not valid for %s. Please check your key is for this product.', 'gravity-forms-pdf-extended' ), $addon_name ),
+			'invalid_item_id'     => sprintf( __( 'This license key is not valid for %s. Please check your key is for this product.', 'gravity-forms-pdf-extended' ), $addon_name ),
+			'no_activations_left' => sprintf( __( 'This license key has reached its activation limit. %1$sPlease upgrade your license to increase the site limit (you only pay the difference)%2$s.', 'gravity-forms-pdf-extended' ), '<a href="%s">', '</a>' ),
+			'default'             => __( 'An error occurred, please try again.', 'gravity-forms-pdf-extended' ),
+			'generic'             => __( 'An error occurred, please try again.', 'gravity-forms-pdf-extended' ),
 		];
 	}
 

--- a/tests/e2e/utilities/page-model/tabs/license.js
+++ b/tests/e2e/utilities/page-model/tabs/license.js
@@ -9,9 +9,9 @@ class License {
     this.samplePluginInputBox = Selector('#gfpdf-fieldset-license_gravity-pdf-example-plugin').find('[id="gfpdf_settings[license_gravity-pdf-example-plugin]"]')
     this.validLicenseKey = '987654321'
     this.invalidLicenseKey = '123456789'
-    this.invalidLicenseKeyMessage = Selector('.gforms_note_error').withText('Invalid license key provided')
+    this.invalidLicenseKeyMessage = Selector('.gforms_note_error').withText('This license key is invalid. Please check your key has been entered correctly.')
     this.deactivateLinkMessage = Selector('button').withText('Deactivate License')
-    this.successMessage = Selector('.gforms_note_success').withText('Your support license key has been successfully validated.')
+    this.successMessage = Selector('.gforms_note_success').withText('Your support license key has been activated for this domain.')
     this.deactivateLink = Selector('.gfpdf-deactivate-license')
     this.deactivatedMessage = Selector('.success').withText('License deactivated.')
 

--- a/tests/phpunit/unit-tests/test-addon.php
+++ b/tests/phpunit/unit-tests/test-addon.php
@@ -272,14 +272,14 @@ class Test_Addon extends WP_UnitTestCase {
 		$api_response = function() {
 			return [
 				'response' => [ 'code' => 200 ],
-				'body'     => json_encode( [ 'license' => 'revoked' ] ),
+				'body'     => json_encode( [ 'license' => 'revoked', 'price_id' => 1 ] ),
 			];
 		};
 
 		add_filter( 'pre_http_request', $api_response );
 
 		$this->assertTrue( $this->addon->schedule_license_check() );
-		$this->assertEquals( 'Your license key has been disabled', $this->addon->get_license_message() );
+		$this->assertStringContainsString( 'This license key has been cancelled', $this->addon->get_license_message() );
 
 		remove_filter( 'pre_http_request', $api_response );
 		$this->addon->delete_license_info();

--- a/tests/phpunit/unit-tests/test-settings.php
+++ b/tests/phpunit/unit-tests/test-settings.php
@@ -392,7 +392,7 @@ class Test_Settings extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertEquals( 'Invalid license key provided', $results['license_other-plugin_message'] );
+		$this->assertStringContainsString( 'This license key is invalid.', $results['license_other-plugin_message'] );
 		$this->assertEquals( 'missing', $results['license_other-plugin_status'] );
 
 		/* Ensure add-on message and status are reset when license key is empty */
@@ -404,8 +404,8 @@ class Test_Settings extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertEquals( '', $results['license_other-plugin_message'] );
-		$this->assertEquals( '', $results['license_other-plugin_status'] );
+		$this->assertEmpty( $results['license_other-plugin_message'] );
+		$this->assertEmpty($results['license_other-plugin_status'] );
 
 		/* Check we don't do anything when the license is active */
 		$results = $this->model->maybe_active_licenses(
@@ -433,7 +433,7 @@ class Test_Settings extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertEquals( 'Invalid license key provided', $results['license_other-plugin_message'] );
+		$this->assertStringContainsString( 'This license key is invalid.', $results['license_other-plugin_message'] );
 		$this->assertEquals( 'missing', $results['license_other-plugin_status'] );
 
 		/* Check that the hashed license reverts back to the unhashed version before saving */
@@ -482,7 +482,7 @@ class Test_Settings extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertEquals( $expected, $results['license_my-custom-plugin_message'] );
+		$this->assertStringContainsString( $expected, $results['license_my-custom-plugin_message'] );
 
 		remove_filter( 'pre_http_request', $api_response );
 		$gfpdf->data->addon = [];
@@ -491,65 +491,61 @@ class Test_Settings extends WP_UnitTestCase {
 	/**
 	 * @return array
 	 *
-	 * @throws Exception
 	 * @since 4.2
 	 */
 	public function providerActivateLicense() {
-		$date_format = get_option( 'date_format' );
-		$dt          = new DateTimeImmutable( '', wp_timezone() );
-		$date        = $dt === false ? gmdate( $date_format, false ) : $dt->format( $date_format );
-
 		return [
 			[
-				'Your license key expired on ' . $date . '.',
+				'This license key expired on',
 				[
-					'error'   => 'expired',
-					'expires' => '',
+					'error'    => 'expired',
+					'expires'  => '',
+					'price_id' => 1,
 				],
 			],
 
 			[
-				'Your license key has been disabled',
-				[ 'error' => 'revoked' ],
+				'This license key has been cancelled',
+				[ 'error' => 'revoked', 'price_id' => 1 ],
 			],
 
 			[
-				'Invalid license key provided',
-				[ 'error' => 'missing' ],
+				'This license key is invalid',
+				[ 'error' => 'missing', 'price_id' => 1 ],
 			],
 
 			[
-				'Your license is not active for this URL',
-				[ 'error' => 'invalid' ],
+				'The license key is invalid',
+				[ 'error' => 'invalid', 'price_id' => 1 ],
 			],
 
 			[
-				'Your license is not active for this URL',
-				[ 'error' => 'site_inactive' ],
+				'Your license key is valid but does not match your current domain',
+				[ 'error' => 'site_inactive', 'price_id' => 1 ],
 			],
 
 			[
-				'This appears to be an invalid license key for My Custom Plugin',
-				[ 'error' => 'item_name_mismatch' ],
+				'This license key is not valid for My Custom Plugin',
+				[ 'error' => 'item_name_mismatch', 'price_id' => 1 ],
 			],
 
 			[
-				'Your license key has reached its activation limit',
-				[ 'error' => 'no_activations_left' ],
+				'This license key has reached its activation limit',
+				[ 'error' => 'no_activations_left', 'license_id' => '', 'payment_id' => '' ],
 			],
 
 			[
 				'An error occurred, please try again',
-				[ 'error' => 'default' ],
+				[ 'error' => 'default', 'price_id' => 1 ],
 			],
 
 			[
-				'An error occurred during activation, please try again',
-				[ 'error' => 'generic' ],
+				'An error occurred, please try again',
+				[ 'error' => 'generic', 'price_id' => 1 ],
 			],
 
 			[
-				'Your support license key has been successfully validated.',
+				'Your support license key has been activated for this domain',
 				[ 'success' => 'true' ],
 			],
 		];


### PR DESCRIPTION
## Description

TODO:

- [x] Unit tests
- [x] Update GravityPDF.com and return the license ID in the response

This PR:

* Adds more descriptive text when an activation error occurs. 
* Include specific actions to help users get their licenses activated correctly. 
* Allow activation on sites marked as non-production

## Testing instructions
Install a paid Gravity PDF extension and then test the following:

1. Activate an active license
2. Activate an expired license
3. Activate a disabled license
4. Activate a license that has reached its site limit

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
