### PR TITLE
Fix error savings forms in Gravity Forms 2.6

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -107,6 +107,9 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 == Changelog ==
 
+= 6.8.1 =
+* Bug: Fix Form Editor saving problem for Gravity Forms v2.6.*
+
 = 6.8.0 =
 * Feature: Add PDF Download metabox to Gravity Flow Inbox for logged-in users with appropriate capability
 * Feature: Add AI-generated translations for French, Spanish, Italian, German, Dutch, Russian, and Chinese

--- a/src/Controller/Controller_Form_Settings.php
+++ b/src/Controller/Controller_Form_Settings.php
@@ -263,11 +263,8 @@ class Controller_Form_Settings extends Helper_Abstract_Controller implements Hel
 			return $form;
 		}
 
-		if ( method_exists( '\GFFormsModel', 'flush_current_form' ) ) {
-			\GFFormsModel::flush_current_form( \GFFormsModel::get_form_cache_key( $form_id ) );
-		} else {
-			\GFFormsModel::flush_current_forms();
-		}
+		/* In the unlikely event the PDFs have been updated since the execution cycle begun, clear the form cache */
+		\GFFormsModel::flush_current_forms();
 
 		$updated_form                = $this->gform->get_form( $form_id );
 		$form['gfpdf_form_settings'] = $updated_form['gfpdf_form_settings'] ?? [];


### PR DESCRIPTION
## Description

The `\GFFormsModel::get_form_cache_key( $form_id )` method wasn't introduced until v2.7, and this was causing a fatal error in Gravity Forms 2.6 when saving the form in the editor.

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
