### PR TITLE
Fix layout column problem when GF Styles Pro enabled

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -109,6 +109,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 = 6.8.1 =
 * Bug: Fix Form Editor saving problem for Gravity Forms v2.6.*
+* Bug: Fix Drag and Drop Column layout issue when the GF Styles Pro plugin is enabled
 
 = 6.8.0 =
 * Feature: Add PDF Download metabox to Gravity Flow Inbox for logged-in users with appropriate capability

--- a/src/Helper/Helper_Field_Container.php
+++ b/src/Helper/Helper_Field_Container.php
@@ -299,7 +299,7 @@ class Helper_Field_Container {
 	 * @since  4.0
 	 */
 	protected function strip_field_of_any_classmaps( GF_Field $field ) {
-		$field->cssClass = str_replace( array_keys( $this->class_map ), ' ', $field->cssClass );
+		$field->cssClass = trim( str_replace( array_keys( $this->class_map ), ' ', $field->cssClass ) );
 	}
 
 	/**

--- a/src/Helper/Helper_Field_Container_Gf25.php
+++ b/src/Helper/Helper_Field_Container_Gf25.php
@@ -61,7 +61,7 @@ class Helper_Field_Container_Gf25 extends Helper_Field_Container {
 		parent::generate( $field );
 
 		if ( $this->get_field_width( $field ) < 100 && strpos( $field->cssClass, 'grid grid-' ) === false ) {
-			$field->cssClass .= ' grid grid-' . $field->layoutGridColumnSpan;
+			$field->cssClass = trim( 'grid grid-' . $field->layoutGridColumnSpan . ' ' . $field->cssClass );
 		}
 
 		/* Mark as the end of this row */

--- a/tests/phpunit/unit-tests/Helper/Test_Helper_Field_Container_Gf25.php
+++ b/tests/phpunit/unit-tests/Helper/Test_Helper_Field_Container_Gf25.php
@@ -68,10 +68,10 @@ class Test_Helper_Field_Container_Gf25 extends WP_UnitTestCase {
 
 		$this->class->generate( $field );
 
-		$this->assertSame(' grid grid-6', $field->cssClass );
+		$this->assertStringContainsString('grid grid-6', $field->cssClass );
 
 		$this->class->generate( $field );
-		$this->assertSame(' grid grid-6', $field->cssClass );
+		$this->assertStringContainsString('grid grid-6', $field->cssClass );
 
 		ob_end_clean();
 	}

--- a/tests/phpunit/unit-tests/test-field-container.php
+++ b/tests/phpunit/unit-tests/test-field-container.php
@@ -254,7 +254,7 @@ class Test_Field_Container extends WP_UnitTestCase {
 		$this->generate( $field );
 
 		/* If the field was skipped we remove any of our column class fields (gf_left_third ect) */
-		$this->assertEquals( ' ', $field->cssClass );
+		$this->assertEmpty( $field->cssClass );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Move the grid CSS classes first in the class order, so that they aren't removed due to an mPDF processing bug when there are a lot of classes.

## Testing instructions
1. Create a form with multiple drag and drop columns
2. On fields in columns, add 10 different CSS classes to those field
3. View the PDF and see those fields are not in columns.

This problem occurs because [we needed to limit the number of CSS classes that can be included on fields](https://github.com/GravityPDF/gravity-pdf/issues/1425). 

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
