### PR TITLE
Process PDF URLs when using Gravity Wiz Google Sheets

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -110,6 +110,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 = 6.8.1 =
 * Bug: Fix Form Editor saving problem for Gravity Forms v2.6.*
 * Bug: Fix Drag and Drop Column layout issue when the GF Styles Pro plugin is enabled
+* Bug: Fix issue sending PDF URLs with Gravity Wiz Google Sheets
 * Housekeeping: Exclude popular WordPress staging environments when activating Gravity PDF licenses
 * Housekeeping: Improve Gravity PDF license activation success and error messages
 

--- a/src/Controller/Controller_Mergetags.php
+++ b/src/Controller/Controller_Mergetags.php
@@ -65,5 +65,6 @@ class Controller_Mergetags extends Helper_Abstract_Controller implements Helper_
 		add_filter( 'gform_field_map_choices', [ $this->model, 'add_field_map_choices' ], 10, 4 );
 		add_filter( 'gform_addon_field_value', [ $this->model, 'process_field_value' ], 10, 4 );
 		add_filter( 'gform_mailchimp_field_value', [ $this->model, 'process_field_value_mailchimp' ], 10, 4 );
+		add_filter( 'gpgs_row_value', [ $this->model, 'process_field_value_gp_google_sheets' ], 10, 4 );
 	}
 }

--- a/src/Model/Model_Mergetags.php
+++ b/src/Model/Model_Mergetags.php
@@ -363,4 +363,21 @@ class Model_Mergetags extends Helper_Abstract_Model {
 		return $this->process_field_value( $field_value, $gform->get_form( $form_id ), $entry, $field_id );
 	}
 
+	/**
+	 * Process Gravity Wiz Google Sheets data
+	 *
+	 * @param string $field_value
+	 * @param int $form_id
+	 * @param int $field_id
+	 * @param array $entry
+	 *
+	 * @return mixed
+	 *
+	 * @since 6.8.1
+	 */
+	public function process_field_value_gp_google_sheets( $field_value, $form_id, $field_id, $entry ) {
+		$gform = \GPDFAPI::get_form_class();
+		return $this->process_field_value( $field_value, $gform->get_form( $form_id ), $entry, $field_id );
+	}
+
 }


### PR DESCRIPTION
## Description

Users could map PDF URLs in the GWiz Google Sheets feed, but these URLs would not be correctly processed and sent. 

Fixes #1491

## Testing instructions
In a form with a PDF configured:

1. Add a Google Sheets feed and map the PDF URL, signed PDF URL, and Custom Value with PDF merge tag to columns in the spreadsheet
2. Submit the form

The spreadsheet will now contain the correct PDF URLs. 

## Screenshots <!-- if applicable -->
![CleanShot 2024-02-26 at 15 58 36@2x](https://github.com/GravityPDF/gravity-pdf/assets/2918419/6ab5e596-f902-4450-aa61-c579554bb24b)


## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
