### PR TITLE
Remove top margin from Rich Paragraph text fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -111,6 +111,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 * Bug: Fix Form Editor saving problem for Gravity Forms v2.6.*
 * Bug: Fix Drag and Drop Column layout issue when the GF Styles Pro plugin is enabled
 * Bug: Fix issue sending PDF URLs with Gravity Wiz Google Sheets
+* Bug: Improve display of Rich Text Textarea fields by removing top margin on individual paragraphs
 * Housekeeping: Exclude popular WordPress staging environments from site count when activating Gravity PDF licenses
 * Housekeeping: Improve Gravity PDF license activation success and error messages
 

--- a/src/View/html/PDF/core_template_styles.php
+++ b/src/View/html/PDF/core_template_styles.php
@@ -230,6 +230,11 @@ $include_product_styles = apply_filters( 'gfpdf_include_product_styles', true, $
 	.gfpdf-chainedselect td:nth-child(1) {
 		width: 30%;
 	}
+
+	/* Rich Text Paragraph */
+	.gfpdf-textarea .value p {
+	  margin-top: 0;
+	}
 </style>
 
 <?php if ( ! empty( $first_header ) ) : ?>


### PR DESCRIPTION
## Description

This improves the display of Paragraph fields when the Rich Text feature is enabled

Resolves #1369

## Testing instructions
See ticket #1369

## Screenshots <!-- if applicable -->
![before](https://github.com/GravityPDF/gravity-pdf/assets/2918419/e3e94823-0aa4-4dbc-a5c7-505fbe0ff466)
![after](https://github.com/GravityPDF/gravity-pdf/assets/2918419/9a62e7ca-be3d-4f15-99e4-d5b3106380b6)



## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
