### PR TITLE
Add Entry Meta as PDF Conditional Logic Options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "gform": false,
     "ConditionalLogic": false,
     "ToggleConditionalLogic": false,
+    "GetRuleValuesDropDown": false,
     "QTags": false,
     "switchEditors": false,
     "getUserSetting": false,

--- a/README.txt
+++ b/README.txt
@@ -107,7 +107,8 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 == Changelog ==
 
-= 6.8.1 =
+= 6.9.0 =
+* Feature: Add new conditional logic options to PDFs eg. Payment Status, Date Created, Starred (props: Gravity Wiz)
 * Bug: Fix Form Editor saving problem for Gravity Forms v2.6.*
 * Bug: Fix Drag and Drop Column layout issue when the GF Styles Pro plugin is enabled
 * Bug: Fix issue sending PDF URLs with Gravity Wiz Google Sheets

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "wp-coding-standards/wpcs": "~2.3.0",
     "phpcompatibility/phpcompatibility-wp": "*",
     "roave/security-advisories": "dev-master",
-    "yoast/phpunit-polyfills": "^1.0"
+    "yoast/phpunit-polyfills": "^2.0",
+    "wp-phpunit/wp-phpunit": "^6.4"
   },
   "autoload": {
     "psr-4": {

--- a/src/Controller/Controller_Form_Settings.php
+++ b/src/Controller/Controller_Form_Settings.php
@@ -283,7 +283,7 @@ class Controller_Form_Settings extends Helper_Abstract_Controller implements Hel
 	 * @param array      $rule         The GF current rule object https://docs.gravityforms.com/conditional-logic-object/#rule
 	 * @param array      $form
 	 * @param array      $logic        The GF conditional logic object https://docs.gravityforms.com/conditional-logic-object/
-	 * @param array      $entry        The entry currently being processed, if available.
+	 * @param array|null $entry        The entry currently being processed, if available.
 	 *
 	 * @return int|string
 	 *

--- a/src/Helper/Helper_Data.php
+++ b/src/Helper/Helper_Data.php
@@ -331,4 +331,218 @@ class Helper_Data {
 			]
 		);
 	}
+
+	/**
+	 * Get extra conditional logic options
+	 * Props: Gravity Wiz
+	 *
+	 * @param array $form
+	 *
+	 * @return array
+	 *
+	 * @since 6.9.0
+	 *
+	 * @link https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-conditional-logic-entry-meta.php
+	 */
+	public function get_conditional_logic_options( $form ): array {
+
+		$options = [
+			'id'             => [
+				'label'     => esc_html__( 'Entry ID', 'gravityforms' ),
+				'value'     => 'id',
+				'operators' => [
+					'is'    => 'is',
+					'isnot' => 'isNot',
+					'>'     => 'greaterThan',
+					'<'     => 'lessThan',
+				],
+			],
+
+			'status'         => [
+				'label'     => esc_html__( 'Status', 'gravityforms' ),
+				'value'     => 'status',
+				'operators' => [
+					'is'    => 'is',
+					'isnot' => 'isNot',
+				],
+				'choices'   => [
+					[
+						'text'  => 'Active',
+						'value' => 'active',
+					],
+					[
+						'text'  => 'Spam',
+						'value' => 'spam',
+					],
+					[
+						'text'  => 'Trash',
+						'value' => 'trash',
+					],
+				],
+			],
+
+			'date_created'   => [
+				'label'       => esc_html__( 'Entry Date', 'gravityforms' ),
+				'value'       => 'date_created',
+				'operators'   => [
+					'is'          => 'is',
+					'isnot'       => 'isNot',
+					'>'           => 'greaterThan',
+					'<'           => 'lessThan',
+					'contains'    => 'contains',
+					'starts_with' => 'startsWith',
+					'ends_with'   => 'endsWith',
+				],
+				'placeholder' => __( 'yyyy-mm-dd', 'gravityforms' ),
+			],
+
+			'is_starred'     => [
+				'label'     => esc_html__( 'Starred', 'gravityforms' ),
+				'value'     => 'is_starred',
+				'operators' => [
+					'is'    => 'is',
+					'isnot' => 'isNot',
+				],
+				'choices'   => [
+					[
+						'text'  => 'Yes',
+						'value' => '1',
+					],
+					[
+						'text'  => 'No',
+						'value' => '0',
+					],
+				],
+			],
+
+			'ip'             => [
+				'label'     => esc_html__( 'IP Address', 'gravityforms' ),
+				'value'     => 'ip',
+				'operators' => [
+					'is'          => 'is',
+					'isnot'       => 'isNot',
+					'contains'    => 'contains',
+					'starts_with' => 'startsWith',
+					'ends_with'   => 'endsWith',
+				],
+			],
+
+			'source_url'     => [
+				'label'     => esc_html__( 'Source URL', 'gravityforms' ),
+				'value'     => 'source_url',
+				'operators' => [
+					'is'          => 'is',
+					'isnot'       => 'isNot',
+					'contains'    => 'contains',
+					'starts_with' => 'startsWith',
+					'ends_with'   => 'endsWith',
+				],
+			],
+
+			'payment_status' => [
+				'label'     => esc_html__( 'Payment Status', 'gravityforms' ),
+				'value'     => 'payment_status',
+				'operators' => [
+					'is'    => 'is',
+					'isnot' => 'isNot',
+				],
+				'choices'   => \GFCommon::get_entry_payment_statuses_as_choices(),
+			],
+
+			'payment_date'   => [
+				'label'       => esc_html__( 'Payment Date', 'gravityforms' ),
+				'value'       => 'payment_date',
+				'operators'   => [
+					'is'          => 'is',
+					'isnot'       => 'isNot',
+					'>'           => 'greaterThan',
+					'<'           => 'lessThan',
+					'contains'    => 'contains',
+					'starts_with' => 'startsWith',
+					'ends_with'   => 'endsWith',
+				],
+				'placeholder' => __( 'yyyy-mm-dd', 'gravityforms' ),
+			],
+
+			'payment_amount' => [
+				'label'       => esc_html__( 'Payment Amount', 'gravityforms' ),
+				'value'       => 'payment_amount',
+				'operators'   => [
+					'is'          => 'is',
+					'isnot'       => 'isNot',
+					'>'           => 'greaterThan',
+					'<'           => 'lessThan',
+					'contains'    => 'contains',
+					'starts_with' => 'startsWith',
+					'ends_with'   => 'endsWith',
+				],
+				'placeholder' => '0.00',
+			],
+		];
+
+		/* Handle Entry Meta */
+		$entry_meta = \GFFormsModel::get_entry_meta( $form['id'] );
+
+		$choices_by_key = [
+			'is_approved' => [
+				1 => esc_html__( 'Approved', 'gravity-forms-pdf-extended' ),
+				2 => esc_html__( 'Disapproved', 'gravity-forms-pdf-extended' ),
+				3 => esc_html__( 'Unapproved', 'gravity-forms-pdf-extended' ),
+			],
+		];
+
+		foreach ( $entry_meta as $key => $meta ) {
+			/* Skip entry meta already registered */
+			if ( isset( $options[ $key ] ) ) {
+				continue;
+			}
+
+			$options[ $key ] = [
+				'label'     => $meta['label'],
+				'value'     => $key,
+				'operators' => [
+					'is'    => 'is',
+					'isnot' => 'isNot',
+				],
+			];
+
+			$_choices = rgar( $choices_by_key, $key );
+
+			if ( ! empty( $_choices ) ) {
+				$choices = [];
+				foreach ( $_choices as $value => $text ) {
+					$choices[] = compact( 'text', 'value' );
+				}
+
+				$options[ $key ]['choices'] = $choices;
+			}
+		}
+
+		/* Gravity Wiz Unique ID perk */
+		$post_submission_conditional_logic_field_types = [
+			'uid' => [
+				'operators' => [
+					'is'          => 'is',
+					'isnot'       => 'isNot',
+					'>'           => 'greaterThan',
+					'<'           => 'lessThan',
+					'contains'    => 'contains',
+					'starts_with' => 'startsWith',
+					'ends_with'   => 'endsWith',
+				],
+			],
+		];
+
+		$fields = \GFAPI::get_fields_by_type( $form, array_keys( $post_submission_conditional_logic_field_types ) );
+
+		foreach ( $fields as $field ) {
+			$options[ $field->id ] = [
+				'label'     => $field->label,
+				'value'     => $field->id,
+				'operators' => rgars( $post_submission_conditional_logic_field_types, $field->type . '/operators', [] ),
+			];
+		}
+
+		return $options;
+	}
 }

--- a/src/Model/Model_Form_Settings.php
+++ b/src/Model/Model_Form_Settings.php
@@ -261,13 +261,15 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		/* pass to view */
 		$controller->view->add_edit(
 			[
-				'pdf_id'       => $pdf_id,
-				'title'        => $label,
-				'button_label' => $label,
-				'form'         => $form,
-				'entry_meta'   => $entry_meta,
-				'pdf'          => $pdf,
-				'form_classes' => $form_classes,
+				'pdf_id'                          => $pdf_id,
+				'title'                           => $label,
+				'button_label'                    => $label,
+				'form'                            => $form,
+				'entry_meta'                      => $entry_meta,
+				'pdf'                             => $pdf,
+				'form_classes'                    => $form_classes,
+
+				'extra_conditional_logic_options' => $this->data->get_conditional_logic_options( $form ),
 			]
 		);
 	}

--- a/src/View/html/FormSettings/add_edit.php
+++ b/src/View/html/FormSettings/add_edit.php
@@ -26,6 +26,7 @@ global $wp_settings_fields;
 	var form = <?php echo wp_json_encode( $args['form'] ); ?>;
 	var gfpdf_current_pdf = <?php echo wp_json_encode( $args['pdf'] ); ?>;
 	var entry_meta = <?php echo wp_json_encode( $args['entry_meta'] ); ?>;
+	var gfpdf_extra_conditional_logic_options = <?php echo wp_json_encode( $args['extra_conditional_logic_options'] ); ?>;
 
 	<?php GFFormSettings::output_field_scripts(); ?>
 </script>

--- a/src/assets/js/admin/settings/pdf/handlePDFConditionalLogic.js
+++ b/src/assets/js/admin/settings/pdf/handlePDFConditionalLogic.js
@@ -13,6 +13,44 @@ export function handlePDFConditionalLogic () {
     return object
   })
 
+  /* Add support for entry meta */
+  const entryOptions = window.gfpdf_extra_conditional_logic_options
+  gform.addFilter('gform_conditional_logic_fields', function (options, form, selectedFieldId) {
+    for (const property in entryOptions) {
+      // Entry meta are already added in Notifications and Confirmations conditional logic but not in feeds.
+      // Let's just make sure that none of our entry meta options have been previously added.
+      if (Object.hasOwn(entryOptions, property) && !options.find(opt => opt.value === entryOptions[property].value)) {
+        options.push({
+          label: entryOptions[property].label,
+          value: entryOptions[property].value
+        })
+      }
+    }
+    return options
+  })
+
+  gform.addFilter('gform_conditional_logic_operators', function (operators, objectType, fieldId) {
+    if (Object.hasOwn(entryOptions, fieldId)) {
+      operators = entryOptions[fieldId].operators
+    }
+    return operators
+  })
+
+  gform.addFilter('gform_conditional_logic_values_input', function (str, objectType, ruleIndex, selectedFieldId, selectedValue) {
+    if (Object.hasOwn(entryOptions, selectedFieldId)) {
+      if (entryOptions[selectedFieldId].choices) {
+        const inputName = objectType + '_rule_value_' + ruleIndex
+        str = GetRuleValuesDropDown(entryOptions[selectedFieldId].choices, objectType, ruleIndex, selectedValue, inputName)
+      }
+
+      if (entryOptions[selectedFieldId].placeholder) {
+        str = $(str).attr('placeholder', entryOptions[selectedFieldId].placeholder)[0].outerHTML
+      }
+    }
+
+    return str
+  })
+
   /* Add change event to conditional logic field */
   $('#gfpdf_conditional_logic').on('change', function () {
     /* Only set up a .conditionalLogic object if it doesn't exist */

--- a/tests/phpunit/unit-tests/test-helper-data.php
+++ b/tests/phpunit/unit-tests/test-helper-data.php
@@ -19,9 +19,9 @@ use WP_UnitTestCase;
  * Test the PSR-4 Autoloader Implementation
  *
  * @since 4.0
- * @group data-helper
+ * @group data
  */
-class Test_Data_Helper extends WP_UnitTestCase {
+class Test_Helper_Data extends WP_UnitTestCase {
 	/**
 	 * Our Gravity PDF Data object
 	 *
@@ -162,5 +162,18 @@ class Test_Data_Helper extends WP_UnitTestCase {
 		foreach ( $required_keys as $key ) {
 			$this->assertArrayHasKey( $key, $localised_data );
 		}
+	}
+
+	public function test_get_conditional_logic_options() {
+		$form  = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+
+		$conditional_logic_options = $this->data->get_conditional_logic_options( $form );
+
+		$this->assertArrayHasKey('id', $conditional_logic_options);
+		$this->assertArrayHasKey('status', $conditional_logic_options);
+		$this->assertArrayHasKey('date_created', $conditional_logic_options);
+		$this->assertArrayHasKey('payment_status', $conditional_logic_options);
+		$this->assertArrayHasKey('gquiz_percent', $conditional_logic_options);
+		$this->assertArrayHasKey('gquiz_is_pass', $conditional_logic_options);
 	}
 }


### PR DESCRIPTION
## Description

This PR adds a bunch of new condition options available for PDFs, such as:

* Entry ID
* Status
* Entry Date
* Starred
* IP Address
* Source URL
* Payment Status
* Payment Date
* Payment Amount
* Unique ID
* Additional entry meta data, like Quiz results or GravityView Approval status

Resolves #1404

## Testing instructions
1. Reload a form with a bunch of entries which varies each of the above items
2. Setup PDFs on the form with unique conditional logic combinations
3. Verify the correct PDF is active for the entry

## Screenshots <!-- if applicable -->

![CleanShot 2024-02-27 at 13 03 07](https://github.com/GravityPDF/gravity-pdf/assets/2918419/debc538b-fee3-4ba7-b3a2-74f67b9868e4)

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->

Props to the Gravity Wiz team for creating the original snippet this code is based on, and licensing it under GPLv2: https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-conditional-logic-entry-meta.php
