### PR TITLE
Store the current PDF Configuration in the PDF Field classes

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -116,6 +116,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 * Housekeeping: Exclude popular WordPress staging environments from site count when activating Gravity PDF licenses
 * Housekeeping: Improve Gravity PDF license activation success and error messages
 * Security: Improve security of network requests to Gravity PDF licensing server
+* Developer: Add `set_pdf_config( $config )` and `get_pdf_config()` methods to PDF Field classes
 
 = 6.8.0 =
 * Feature: Add PDF Download metabox to Gravity Flow Inbox for logged-in users with appropriate capability

--- a/src/Helper/Fields/Field_Form.php
+++ b/src/Helper/Fields/Field_Form.php
@@ -128,7 +128,8 @@ class Field_Form extends Helper_Abstract_Fields {
 		/* Loop through the Repeater fields */
 		foreach ( $form['fields'] as $field ) {
 			/* Output a field using the standard method if not empty */
-			$class = $pdf_model->get_field_class( $field, $form, $entry, $products );
+			$class = $pdf_model->get_field_class( $field, $form, $entry, $products, $this->get_pdf_config() );
+
 			$class->enable_output();
 			if ( ! $class->is_empty() && strpos( $field->cssClass, 'exclude' ) === false ) {
 				$container->generate( $field );

--- a/src/Helper/Fields/Field_Poll.php
+++ b/src/Helper/Fields/Field_Poll.php
@@ -64,6 +64,10 @@ class Field_Poll extends Helper_Abstract_Fields {
 			/* Exception thrown. Load generic field loader */
 			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $gform, $misc ), $field, $entry, $this->form );
 		}
+
+		if ( $this->fieldObject instanceof \GFPDF\Helper\Helper_Interface_Field_Pdf_Config ) {
+			$this->fieldObject->set_pdf_config( $this->get_pdf_config() );
+		}
 	}
 
 	/**

--- a/src/Helper/Fields/Field_Post_Category.php
+++ b/src/Helper/Fields/Field_Post_Category.php
@@ -64,6 +64,10 @@ class Field_Post_Category extends Helper_Abstract_Fields {
 			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $gform, $misc ), $field, $entry, $this->form );
 		}
 
+		if ( $this->fieldObject instanceof \GFPDF\Helper\Helper_Interface_Field_Pdf_Config ) {
+			$this->fieldObject->set_pdf_config( $this->get_pdf_config() );
+		}
+
 		/* force the fieldObject value cache */
 		$this->value();
 	}

--- a/src/Helper/Fields/Field_Post_Custom_Field.php
+++ b/src/Helper/Fields/Field_Post_Custom_Field.php
@@ -65,6 +65,10 @@ class Field_Post_Custom_Field extends Helper_Abstract_Fields {
 			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $gform, $misc ), $field, $entry, $this->form );
 		}
 
+		if ( $this->fieldObject instanceof \GFPDF\Helper\Helper_Interface_Field_Pdf_Config ) {
+			$this->fieldObject->set_pdf_config( $this->get_pdf_config() );
+		}
+
 		/* force the fieldObject value cache */
 		$this->value();
 	}

--- a/src/Helper/Fields/Field_Repeater.php
+++ b/src/Helper/Fields/Field_Repeater.php
@@ -101,7 +101,7 @@ class Field_Repeater extends Helper_Abstract_Fields {
 					continue;
 				}
 
-				$class     = $pdf_model->get_field_class( $sub_field, $this->form, $item, $products );
+				$class     = $pdf_model->get_field_class( $sub_field, $this->form, $item, $products, $this->get_pdf_config() );
 				$form_data = $class->form_data();
 
 				if ( isset( $form_data['field'] ) ) {
@@ -227,7 +227,7 @@ class Field_Repeater extends Helper_Abstract_Fields {
 
 				/* Output a field using the standard method if not empty */
 				/** @var Helper_Abstract_Fields $class */
-				$class = $pdf_model->get_field_class( $sub_field, $this->form, $item, $products );
+				$class = $pdf_model->get_field_class( $sub_field, $this->form, $item, $products, $this->get_pdf_config() );
 
 				if ( ! $class->is_empty() ) {
 					$field->cssClass = '';

--- a/src/Helper/Fields/Field_Section.php
+++ b/src/Helper/Fields/Field_Section.php
@@ -74,7 +74,8 @@ class Field_Section extends Helper_Abstract_Fields {
 		$empty = true;
 		foreach ( $fields as $field ) {
 			if ( 'section' !== $field->type ) {
-				$class = $pdf_model->get_field_class( $field, $this->form, $this->entry, $products );
+				$class = $pdf_model->get_field_class( $field, $this->form, $this->entry, $products, $this->get_pdf_config() );
+
 				if ( ! $class->is_empty() ) {
 					$empty = false;
 					break;

--- a/src/Helper/Fields/Field_Survey.php
+++ b/src/Helper/Fields/Field_Survey.php
@@ -65,6 +65,10 @@ class Field_Survey extends Helper_Abstract_Fields {
 			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $gform, $misc ), $field, $entry, $this->form );
 		}
 
+		if ( $this->fieldObject instanceof \GFPDF\Helper\Helper_Interface_Field_Pdf_Config ) {
+			$this->fieldObject->set_pdf_config( $this->get_pdf_config() );
+		}
+
 		/* force the fieldObject value cache */
 		$this->value();
 	}

--- a/src/Helper/Helper_Abstract_Fields.php
+++ b/src/Helper/Helper_Abstract_Fields.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 4.0
  */
-abstract class Helper_Abstract_Fields {
+abstract class Helper_Abstract_Fields implements Helper_Interface_Field_Pdf_Config {
 
 	/**
 	 * Contains the field array
@@ -100,6 +100,15 @@ abstract class Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public $misc;
+
+	/**
+	 * Holds the current PDF settings and metadata
+	 *
+	 * @var array Contains the keys 'meta' and 'settings'
+	 *
+	 * @since 6.9
+	 */
+	protected $pdf_config;
 
 	/**
 	 * Set up the object
@@ -408,5 +417,29 @@ abstract class Helper_Abstract_Fields {
 			' ',
 			array_slice( explode( ' ', $this->field->cssClass ), 0, 8 )
 		);
+	}
+
+	/**
+	 * Set the current PDF configuration
+	 *
+	 * @param array $config
+	 *
+	 * @return void
+	 *
+	 * @since 6.9
+	 */
+	public function set_pdf_config( $config ) {
+		$this->pdf_config = $config;
+	}
+
+	/**
+	 * Get the current PDF configuration
+	 *
+	 * @return array
+	 *
+	 * @since 6.9
+	 */
+	public function get_pdf_config() {
+		return $this->pdf_config;
 	}
 }

--- a/src/Helper/Helper_Interface_Field_Pdf_Config.php
+++ b/src/Helper/Helper_Interface_Field_Pdf_Config.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace GFPDF\Helper;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * An interface for PDF Fields to support storing and retrieving the current PDF configuration
+ *
+ * @since 6.9
+ */
+interface Helper_Interface_Field_Pdf_Config {
+
+	/**
+	 * Set the current PDF configuration
+	 *
+	 * @param array $config Should contain the keys 'meta' and 'settings'
+	 *
+	 * @return void
+	 *
+	 * @since 6.9
+	 */
+	public function set_pdf_config( $config );
+
+	/**
+	 * Get the current PDF configuration
+	 *
+	 * @return array
+	 *
+	 * @since 6.9
+	 */
+	public function get_pdf_config();
+}

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -15,6 +15,7 @@ use GFPDF\Helper\Helper_Abstract_Model;
 use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Data;
 use GFPDF\Helper\Helper_Form;
+use GFPDF\Helper\Helper_Interface_Field_Pdf_Config;
 use GFPDF\Helper\Helper_Interface_Url_Signer;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
@@ -1629,17 +1630,18 @@ class Model_PDF extends Helper_Abstract_Model {
 	/**
 	 * Pass in a Gravity Form Field Object and get back a Gravity PDF Field Object
 	 *
-	 * @param GF_Field         $field    Gravity Form Field Object
+	 * @param GF_Field       $field    Gravity Form Field Object
 	 * @param array          $form     The Gravity Form Array
 	 * @param array          $entry    The Gravity Form Entry
 	 * @param Field_Products $products A Field_Products Object
+	 * @param array          $config   Should contain the keys 'meta' and 'settings'. Added in v6.9
 	 *
 	 * @return Helper_Abstract_Fields
 	 *
 	 * @throws Exception
 	 * @since 4.0
 	 */
-	public function get_field_class( $field, $form, $entry, Field_Products $products ) {
+	public function get_field_class( $field, $form, $entry, Field_Products $products, $config = [] ) {
 
 		$class_name = $this->misc->get_field_class( $field->type );
 
@@ -1691,6 +1693,10 @@ class Model_PDF extends Helper_Abstract_Model {
 
 			/* Exception thrown. Load generic field loader */
 			$class = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $this->gform, $this->misc ), $field, $entry, $form );
+		}
+
+		if ( $class instanceof Helper_Interface_Field_Pdf_Config ) {
+			$class->set_pdf_config( $config );
 		}
 
 		return $class;

--- a/src/View/View_PDF.php
+++ b/src/View/View_PDF.php
@@ -475,7 +475,7 @@ class View_PDF extends Helper_Abstract_View {
 		$show_section_description = $config['meta']['section_content'] ?? false; /* whether we should include a section breaks content. Default to false */
 
 		/** @var \GFPDF\Helper\Helper_Abstract_Fields $class */
-		$class = $model->get_field_class( $field, $form, $entry, $products );
+		$class = $model->get_field_class( $field, $form, $entry, $products, $config );
 
 		/* Try and display our HTML */
 		try {

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -1500,9 +1500,16 @@ class Test_PDF extends WP_UnitTestCase {
 			$this->assertEquals( $expected[ $field->id ], get_class( $this->model->get_field_class( $field, $form, $entry, $products ) ) );
 		}
 
+		/* Check config setting/getter */
+		$class = $this->model->get_field_class( $field, $form, $entry, $products, [ 'settings' => true ] );
+		$this->assertArrayHasKey( 'settings', $class->get_pdf_config() );
+
 		/* Check our fallback class */
 		$this->assertEquals( $namespace . 'Field_Default', get_class( $this->model->get_field_class( new GF_Field(), $form, $entry, $products ) ) );
 
+		/* Check config setting/getter */
+		$class = $this->model->get_field_class( new GF_Field(), $form, $entry, $products, [ 'settings' => true ] );
+		$this->assertArrayHasKey( 'settings', $class->get_pdf_config() );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This change doesn't do much on its own, but will allow fields to change how they display based on the current PDF settings. Once merged, it'll allow smarter, more dynamic fields.

## Testing instructions
1. Create a form with all available fields, including Poll, Quiz, and Survey
2. Create a PDF with a Core template
3. Verify the PDF generates correctly

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
