### PR TITLE
Support PDF settings for individual Nested Form fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -109,6 +109,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 = 6.9.0 =
 * Feature: Add new conditional logic options to PDFs eg. Payment Status, Date Created, Starred (props: Gravity Wiz)
+* Feature: Add support for Show HTML Fields, Show Empty Fields, Show Section Break Description, and Enable Conditional Logic PDF settings when displaying Gravity Wiz Nested Forms field
 * Bug: Fix Form Editor saving problem for Gravity Forms v2.6.*
 * Bug: Fix Drag and Drop Column layout issue when the GF Styles Pro plugin is enabled
 * Bug: Fix issue sending PDF URLs with Gravity Wiz Google Sheets


### PR DESCRIPTION
## Description

Support the following:

* Show Empty Fields
* Show Field Description
* Blacklisted fields
* Conditional Logic
* Show HTML fields

## Testing instructions
1. Setup Parent / Child form combo
2. In the Child form, setup fields that have conditional logic, Section Break descriptions, HTML fields, and pricing fields
3. Submit a test entry with multiple Nested Forms entries, altering the inputs
4. Setup multiple Core PDFs on the form, altering the Show HTML Fields, Show Empty Fields, Show Section Break Description, and Enable Conditional Logic PDF settings for each
5. Preview the PDFs for accuracy

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
