### PR TITLE
Use field type, and not a subtype when blacklisting from PDF

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -118,6 +118,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 * Housekeeping: Improve Gravity PDF license activation success and error messages
 * Security: Improve security of network requests to Gravity PDF licensing server
 * Developer: Add `set_pdf_config( $config )` and `get_pdf_config()` methods to PDF Field classes
+* Developer: In the PDF field blacklist, check using the original type and not with `$field->get_input_type()`
 
 = 6.8.0 =
 * Feature: Add PDF Download metabox to Gravity Flow Inbox for logged-in users with appropriate capability

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -2319,7 +2319,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 */
 	public function field_middle_blacklist( $action, $field, $entry, $form, $config, $products, $blacklisted ) {
 		if ( $action === false ) {
-			if ( in_array( $field->get_input_type(), $blacklisted, true ) ) {
+			if ( in_array( $field->type, $blacklisted, true ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## Description

This allows us to match unique field types when excluding from the PDF.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
