### PR TITLE
Better compatibility with Weglot

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -114,6 +114,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 * Bug: Fix Drag and Drop Column layout issue when the GF Styles Pro plugin is enabled
 * Bug: Fix issue sending PDF URLs with Gravity Wiz Google Sheets
 * Bug: Improve display of Rich Text Textarea fields by removing top margin on individual paragraphs
+* Bug: Resolve compatibility issue that corrupted PDFs when using Weglot
 * Housekeeping: Exclude popular WordPress staging environments from site count when activating Gravity PDF licenses
 * Housekeeping: Improve Gravity PDF license activation success and error messages
 * Security: Improve security of network requests to Gravity PDF licensing server

--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -204,6 +204,12 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		/* Third Party Conflict Fixes */
 		add_filter( 'gfpdf_pre_view_or_download_pdf', [ $this, 'sgoptimizer_html_minification_fix' ] );
 		add_filter( 'gfpdf_legacy_pre_view_or_download_pdf', [ $this, 'sgoptimizer_html_minification_fix' ] );
+		add_filter(
+			'gfpdf_pre_pdf_generation_output',
+			function() {
+				add_filter( 'weglot_active_translation', '__return_false' );
+			}
+		);
 
 		/* Meta boxes */
 		add_filter( 'gform_entry_detail_meta_boxes', [ $this->model, 'register_pdf_meta_box' ], 10, 3 );


### PR DESCRIPTION
## Description

The Weglot plugin includes a feature that auto-injects the language selector. This was running when the PDF is viewed/downloaded, and could corrupt the documents.

## Testing instructions
I wasn't able to replicate the problem on a fresh development site, and it was only present on a customer's site. I'm unsure of the exact combination of variables that triggers this bug, but tested the fix on the customers website. 

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
