### PR TITLE
Fix PHP notice when $rule is not a valid array

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -109,6 +109,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 = 6.9.1 =
 * Security: Disable the Signed URL feature in the [gravitypdf] shortcode when a URL parameter provides the entry ID (e.g. Page Confirmations)
+* Bug: Gracefully handle invalid conditional logic rules when adding entry meta data support
 
 = 6.9.0 =
 * Feature: Add new conditional logic options to PDFs eg. Payment Status, Date Created, Starred (props: Gravity Wiz)

--- a/src/Controller/Controller_Form_Settings.php
+++ b/src/Controller/Controller_Form_Settings.php
@@ -292,7 +292,7 @@ class Controller_Form_Settings extends Helper_Abstract_Controller implements Hel
 	public function conditional_logic_set_rule_source_value( $source_value, $rule, $form, $logic, $entry ) {
 
 		$keys   = array_keys( $this->data->get_conditional_logic_options( $form ) );
-		$target = $rule['fieldId'];
+		$target = $rule['fieldId'] ?? null;
 
 		if ( ! $entry || ! in_array( $target, $keys, true ) ) {
 			return $source_value;
@@ -306,11 +306,11 @@ class Controller_Form_Settings extends Helper_Abstract_Controller implements Hel
 			$entry = \GFAPI::get_entry( $entry['id'] );
 		}
 
-		switch ( $rule['fieldId'] ) {
+		switch ( $target ) {
 			case 'date_created':
 			case 'payment_date':
 				/* Convert to local date without time */
-				$value = $entry[ $rule['fieldId'] ];
+				$value = $entry[ $target ];
 				if ( ! $value ) {
 					return $value;
 				}
@@ -321,7 +321,7 @@ class Controller_Form_Settings extends Helper_Abstract_Controller implements Hel
 				return date_i18n( 'Y-m-d', $lead_local_time, true );
 
 			default:
-				return rgar( $entry, $rule['fieldId'] );
+				return rgar( $entry, $target );
 		}
 	}
 
@@ -343,10 +343,11 @@ class Controller_Form_Settings extends Helper_Abstract_Controller implements Hel
 
 		/* Only deal with less/more than date rules */
 		if (
-			! in_array( $rule['fieldId'], [ 'date_created', 'payment_date' ], true ) ||
-			! in_array( $operation, [ '>', '<' ], true ) ||
 			empty( $field_value ) ||
-			empty( $target_value )
+			empty( $target_value ) ||
+			! is_array( $rule ) ||
+			! in_array( $rule['fieldId'] ?? 0, [ 'date_created', 'payment_date' ], true ) ||
+			! in_array( $operation, [ '>', '<' ], true )
 		) {
 			return $is_match;
 		}


### PR DESCRIPTION
## Description

Return early when $rule is not an array.

Had use report of the following PHP warning showing multiple times in their PDF document:

```
Warning: Trying to access array offset on value of type null in /wp-content/plugins/gravity-forms-pdf-extended/src/Controller/Controller_Form_Settings.php on line 346
```

## Testing instructions
The only way I could replicate this was by using a filter to modify the rule:

```
add_filter( 'gform_rule_pre_evaluation', function ( $rule ) {
	return null;
} );
```

The PR fixes the Gravity PDF-related errors. But if you use the filter, it does cause other errors to be triggered in the PDF by Gravity Forms. It's a case of bad input/bad output, so fixing the input problem (removing the bad filter) is the way forward.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
