### PR TITLE
Disable Signed URLs when Entry ID taken from URL Param

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -107,6 +107,9 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 == Changelog ==
 
+= 6.9.1 =
+* Security: Disable the Signed URL feature in the [gravitypdf] shortcode when a URL parameter provides the entry ID (e.g. Page Confirmations)
+
 = 6.9.0 =
 * Feature: Add new conditional logic options to PDFs eg. Payment Status, Date Created, Starred (props: Gravity Wiz)
 * Feature: Add support for Show HTML Fields, Show Empty Fields, Show Section Break Description, and Enable Conditional Logic PDF settings when displaying Gravity Wiz Nested Forms field

--- a/src/Model/Model_Shortcodes.php
+++ b/src/Model/Model_Shortcodes.php
@@ -91,7 +91,8 @@ class Model_Shortcodes extends Helper_Abstract_Pdf_Shortcode {
 		$attributes = apply_filters( 'gfpdf_gravityforms_shortcode_attributes', $attributes );
 
 		try {
-			$attributes['entry'] = $this->get_entry_id_if_empty( $attributes['entry'] );
+			$original_entry_id   = $attributes['entry'];
+			$attributes['entry'] = $this->get_entry_id_if_empty( $original_entry_id );
 
 			/* Do PDF validation */
 			$this->get_pdf_config( $attributes['entry'], $attributes['id'] );
@@ -103,7 +104,7 @@ class Model_Shortcodes extends Helper_Abstract_Pdf_Shortcode {
 			$attributes['url'] = $pdf->get_pdf_url( $attributes['id'], $attributes['entry'], $download, $print );
 
 			/* Sign the URL to allow direct access to the PDF until it expires */
-			if ( ! empty( $attributes['signed'] ) ) {
+			if ( ! empty( $attributes['signed'] ) && ! empty( $original_entry_id ) ) {
 				$attributes['url'] = $this->url_signer->sign( $attributes['url'], $attributes['expires'] );
 			}
 

--- a/tests/phpunit/unit-tests/test-shortcodes.php
+++ b/tests/phpunit/unit-tests/test-shortcodes.php
@@ -229,7 +229,7 @@ class Test_Shortcode extends WP_UnitTestCase {
 		);
 
 		$this->assertStringContainsString( '?gpdf=1&pid=556690c67856b&lid=1&action=download', $url );
-		$this->assertStringNotContainsString( '<a href=', $url );
+		$this->assertStringNotContainsString( 'href=', $url );
 		$this->assertStringNotContainsString( 'Download PDF', $url );
 
 		/* Test for signed URL */
@@ -286,6 +286,24 @@ class Test_Shortcode extends WP_UnitTestCase {
 		$_GET['lid'] = $entry['id'];
 		$this->assertStringContainsString( 'Download PDF', $this->model->process( [ 'id' => '556690c67856b' ] ) );
 
+		unset( $_GET['lid'] );
+		$_GET['entry'] = $entry['id'];
+		$this->assertStringContainsString( 'Download PDF', $this->model->process( [ 'id' => '556690c67856b' ] ) );
+
+		/* Test we ignore the signed feature if the entry ID is taken from a URL parameter */
+		$url2 = $this->model->process(
+			[
+				'id'     => '556690c67856b',
+				'signed' => '1',
+			]
+		);
+
+		$this->assertStringContainsString( 'Download PDF', $url2 );
+		$this->assertStringContainsString( 'href=', $url2 );
+		$this->assertStringNotContainsString( '&#038;signature=', $url2 );
+		$this->assertStringNotContainsString( '&#038;expires=', $url2 );
+
+		/* Test for errors */
 		$_GET['lid'] = '5000';
 		$this->assertStringContainsString( '<pre class="gravitypdf-error">', $this->model->process( [ 'id' => '556690c67856b' ] ) );
 


### PR DESCRIPTION
## Description

Close this security loophole:

> Do not use the [Signed PDF URL feature](https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags#signed-optional) with the Page Confirmation type, as an end user will be able to change the entry ID in the URL and get access to other PDFs. Signed URLs can be safely used with Text or Redirect Confirmation types. Alternatively, non-signed PDF URLs are not vulnerable, and can be safely used in Page Confirmations.

## Testing instructions
1. Setup a form + PDF
2. Copy the PDF download shortcode and paste it on a WordPress page. Add the `signed=1` attribute to the shortcode
3. Edit the form's default confirmation and set up a Page Confirmation
4. Choose the WordPress page you added the shortcode to
5. Add `entry={entry_id}` to the Query String setting
6. Submit the test form and verify the PDF Download Link doesn't include the standard signed URL parameters

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
