### PR TITLE
Missing conditional logic rule if no conditional fields in form

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
     "tinyMCE": false,
     "gform": false,
     "ConditionalLogic": false,
+    "GetFirstRuleField": false,
     "ToggleConditionalLogic": false,
     "GetRuleValuesDropDown": false,
     "QTags": false,

--- a/README.txt
+++ b/README.txt
@@ -110,6 +110,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 = 6.9.1 =
 * Security: Disable the Signed URL feature in the [gravitypdf] shortcode when a URL parameter provides the entry ID (e.g. Page Confirmations)
 * Bug: Gracefully handle invalid conditional logic rules when adding date entry meta support
+* Bug: Display field for entry metadata PDF conditional rule when there are no form fields compatible with conditional logic
 
 = 6.9.0 =
 * Feature: Add new conditional logic options to PDFs eg. Payment Status, Date Created, Starred (props: Gravity Wiz)

--- a/src/assets/js/admin/settings/pdf/handlePDFConditionalLogic.js
+++ b/src/assets/js/admin/settings/pdf/handlePDFConditionalLogic.js
@@ -6,11 +6,20 @@ import $ from 'jquery'
  * @since 4.0
  */
 export function handlePDFConditionalLogic () {
-  gform.addFilter('gform_conditional_object', function (object, objectType) {
+  gform.addFilter('gform_conditional_object', function (obj, objectType) {
     if (objectType === 'gfpdf') {
-      return window.gfpdf_current_pdf
+      obj = window.gfpdf_current_pdf
+
+      /* Manually setup new conditional logic object, with fallback to entry metadata if no available fields present */
+      if (!obj.conditionalLogic || obj.conditionalLogic.length === 0) {
+        obj.conditionalLogic = new ConditionalLogic()
+        obj.conditionalLogic.rules[0].fieldId = GetFirstRuleField()
+        if (obj.conditionalLogic.rules[0].fieldId === 0) {
+          obj.conditionalLogic.rules[0].fieldId = 'id'
+        }
+      }
     }
-    return object
+    return obj
   })
 
   /* Add support for entry meta */


### PR DESCRIPTION
## Description

When there are no conditional fields in the form, the PDF conditional logic feature is missing the third "rule" input for entry meta rules. This change ensures Gravity Forms correctly displays the rule input first the first rule.

Note: due to the way GFs handles field conditional logic, the same problem occurs if you add a second rule. It's not fixable on our end, but adding a third rule will display the input again. It's such an edge-case this isn't likely to happen often, and the initial rule does work.

Fixes #1510

## Testing instructions
1. Create new form and add HTML field to it
2. Create PDF for the form and enable conditional logic
3. Verify the first rule shown has all three input boxes, and you can switch between entry meta data items

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
