### PR TITLE
Clear template cache when plugin deactivated

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -110,6 +110,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 = 6.9.1 =
 * Security: Disable the Signed URL feature in the [gravitypdf] shortcode when a URL parameter provides the entry ID (e.g. Page Confirmations)
 * Bug: Gracefully handle invalid conditional logic rules when adding date entry meta support
+* Bug: Clear template cache when plugin deactivated
 * Bug: Display field for entry metadata PDF conditional rule when there are no form fields compatible with conditional logic
 
 = 6.9.0 =

--- a/src/Controller/Controller_Activation.php
+++ b/src/Controller/Controller_Activation.php
@@ -70,5 +70,9 @@ class Controller_Activation {
 
 		/* Remove our scheduled tasks */
 		wp_clear_scheduled_hook( 'gfpdf_cleanup_tmp_dir' );
+
+		/* Flush caches */
+		$templates = \GPDFAPI::get_templates_class();
+		$templates->flush_template_transient_cache();
 	}
 }


### PR DESCRIPTION
## Description

When ever the plugin is deactivated the PDF template cache transients will be deleted.

Resolves #1507

## Testing instructions
1. Deactivate Gravity PDF
2. Install custom template via FTP
3. Reactivate Gravity PDF
4. Open PDF Template Manager and locate template installed in step 2

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
