### PR TITLE
Template cache flushes and performance improvements

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -110,8 +110,11 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 = 6.9.1 =
 * Security: Disable the Signed URL feature in the [gravitypdf] shortcode when a URL parameter provides the entry ID (e.g. Page Confirmations)
 * Bug: Gracefully handle invalid conditional logic rules when adding date entry meta support
-* Bug: Clear template cache when plugin deactivated
 * Bug: Display field for entry metadata PDF conditional rule when there are no form fields compatible with conditional logic
+* Bug: Ensure the template cache is correctly cleared when PDF Debug Mode is enabled
+* Bug: Flush the template cache after installing new templates via the PDF Template Manager
+* Bug: Clear template cache when plugin deactivated
+* Housekeeping: Small improvement to performance when reading template and font files from disk
 
 = 6.9.0 =
 * Feature: Add new conditional logic options to PDFs eg. Payment Status, Date Created, Starred (props: Gravity Wiz)

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -2095,7 +2095,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 */
 	public function add_unregistered_fonts_to_mPDF( $fonts ) {
 
-		$user_fonts = glob( $this->data->template_font_location . '*.[tT][tT][fF]' );
+		$user_fonts = glob( $this->data->template_font_location . '*.[tT][tT][fF]', GLOB_NOSORT );
 		$user_fonts = ( is_array( $user_fonts ) ) ? $user_fonts : [];
 
 		$flattened_fonts_array = [];

--- a/src/Model/Model_Templates.php
+++ b/src/Model/Model_Templates.php
@@ -155,7 +155,7 @@ class Model_Templates extends Helper_Abstract_Model {
 
 		/* Get the template headers now all the files are in the right location */
 		$this->templates->flush_template_transient_cache();
-		$headers = $this->get_template_info( glob( $unzipped_dir_name . '*.php' ) );
+		$headers = $this->get_template_info( glob( $unzipped_dir_name . '*.php', GLOB_NOSORT ) );
 
 		/* Fix template path */
 		$headers = array_map(
@@ -361,7 +361,7 @@ class Model_Templates extends Helper_Abstract_Model {
 		}
 
 		/* Check unzipped templates for a valid v4 header, or v3 string pattern */
-		$files = glob( $dir . '*.php' );
+		$files = glob( $dir . '*.php', GLOB_NOSORT );
 
 		if ( ! is_array( $files ) || count( $files ) === 0 ) {
 			throw new Exception( esc_html__( 'No valid PDF template found in Zip archive.', 'gravity-forms-pdf-extended' ) );

--- a/tests/phpunit/unit-tests/test-helper-templates.php
+++ b/tests/phpunit/unit-tests/test-helper-templates.php
@@ -387,7 +387,7 @@ class Test_Templates_Helper extends WP_UnitTestCase {
 		$this->assertFalse( get_transient( $gfpdf->data->template_transient_cache ) );
 		$gfpdf->options->update_option( 'debug_mode', 'Yes' );
 		$this->templates->get_template_info_by_path( PDF_PLUGIN_DIR . 'src/templates/zadani.php' );
-		$this->assertFalse( get_transient( $gfpdf->data->template_transient_cache ) );
+		$this->assertCount( 1, get_transient( $gfpdf->data->template_transient_cache ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This fixes two bugs related to the flushing of the PDF template cache, and makes a small improvement to performance when reading files from disk:

* Bug: Ensure the template cache is correctly cleared when PDF Debug Mode is enabled
* Bug: Flush the template cache after installing new templates via the PDF Template Manager
* Housekeeping: Small improvement to performance when reading template and font files from disk

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
