### PR TITLE
Add Legal Signing field support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -107,6 +107,9 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 == Changelog ==
 
+= 6.10.0 =
+* Feature: Add native support for the Legal Signature and Legal Consent form fields added by the Legal Signing for Gravity Forms plugin
+
 = 6.9.1 =
 * Security: Disable the Signed URL feature in the [gravitypdf] shortcode when a URL parameter provides the entry ID (e.g. Page Confirmations)
 * Bug: Gracefully handle invalid conditional logic rules when adding date entry meta support

--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -142,6 +142,13 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 			add_action( 'gfpdf_pre_pdf_generation', [ $this->model, 'enable_gp_populate_anything' ] );
 			add_action( 'gfpdf_pre_pdf_generation_output', [ $this->model, 'disable_gp_populate_anything' ] );
 		}
+
+		/* Add Legal Signature support */
+		if ( defined( 'FG_LEGALSIGNING_VERSION' ) ) {
+			add_filter( 'gfpdf_mpdf_class_config', [ $this->model, 'register_legal_signing_font_path_with_mpdf' ] );
+			add_filter( 'mpdf_font_data', [ $this->model, 'register_legal_signing_fonts_with_mpdf' ] );
+			add_action( 'gfpdf_core_template', [ $this->view, 'add_legalsigning_styles' ], 10, 3 );
+		}
 	}
 
 	/**

--- a/src/Helper/Fields/Field_Fg_Ls_Consent.php
+++ b/src/Helper/Fields/Field_Fg_Ls_Consent.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace GFPDF\Helper\Fields;
+
+use Exception;
+use GF_Field_Consent;
+use GFPDF\Helper\Helper_Abstract_Fields;
+use GFPDF\Helper\Helper_Abstract_Form;
+use GFPDF\Helper\Helper_Misc;
+use GFPDF\Statics\Kses;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Controls the display and output of a Gravity Form field
+ *
+ * @since 6.10
+ */
+class Field_Fg_Ls_Consent extends Field_Consent {
+	public function form_data() {
+		$label    = $this->get_label();
+		$field_id = (int) $this->field->id;
+
+		$data = [];
+
+		/* Maintain backwards compatibility */
+		$value                            = $this->get_value();
+		$data[ $field_id . '.' . $label ] = $value;
+		$data[ $field_id ]                = $value;
+		$data[ $label ]                   = $value;
+
+		$value                                   = $this->value();
+		$data[ $field_id . '.' . $label . '.2' ] = $value;
+		$data[ $field_id . '.2' ]                = $value;
+		$data[ $label . '.2' ]                   = $value;
+
+		return [ 'field' => $data ];
+	}
+}

--- a/src/Helper/Fields/Field_Fg_Ls_Signature.php
+++ b/src/Helper/Fields/Field_Fg_Ls_Signature.php
@@ -81,8 +81,8 @@ class Field_Fg_Ls_Signature extends Helper_Abstract_Fields {
 				</div>
 			</div>',
 			$html,
-			( $this->field['nameType'] ?? '' ) === 'initials' ? esc_html__( 'Initialed By', 'forgravity_legalsigning' ) : esc_html__( 'Signed By', 'forgravity_legalsigning' ),
-			esc_html__( 'Signed using Legal Signing', 'forgravity_legalsigning' )
+			( $this->field['nameType'] ?? '' ) === 'initials' ? esc_html__( 'Initialed By', 'forgravity_legalsigning' ) : esc_html__( 'Signed By', 'forgravity_legalsigning' ), /* phpcs:ignore WordPress.WP.I18n.TextDomainMismatch */
+			esc_html__( 'Signed using Legal Signing', 'forgravity_legalsigning' ) /* phpcs:ignore WordPress.WP.I18n.TextDomainMismatch */
 		);
 
 		return parent::html( $html );

--- a/src/Helper/Fields/Field_Fg_Ls_Signature.php
+++ b/src/Helper/Fields/Field_Fg_Ls_Signature.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace GFPDF\Helper\Fields;
+
+use GFCommon;
+use GFPDF\Helper\Helper_Abstract_Fields;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Controls the display and output of Cosmic Giant's Legal Signing Signature field
+ *
+ * @since 6.10
+ */
+class Field_Fg_Ls_Signature extends Helper_Abstract_Fields {
+
+	/**
+	 * Display the HTML version of this field
+	 *
+	 * @param string $value
+	 * @param bool   $label
+	 *
+	 * @return string
+	 *
+	 * @since 6.10
+	 */
+	public function html( $value = '', $label = true ) {
+
+		$data = $this->value();
+
+		if ( isset( $data['image'] ) ) {
+			$html = sprintf(
+				'<div class="legalsigning-field-signature__signed-signature"><img src="%1$s" /></div>',
+				esc_attr( rgar( $data, 'image' ) )
+			);
+		} else {
+			$height = $this->field['canvasHeight'] ?? '150';
+
+			$styles = [
+				'background-color' => $this->field['backgroundColor'] ?? '#FFF',
+				'color'            => $this->field['penColor'] ?? '#000',
+				'font-family'      => ( $data['font'] ?? 'caveat' ) . ', cursive',
+				'height'           => (int) $height,
+			];
+
+			$css = '';
+			foreach ( $styles as $property => $val ) {
+				$css .= "$property: $val;";
+			}
+
+			$html = sprintf(
+				'<table>
+					<tr>
+						<td class="legalsigning-field-signature__signed-signature" style="%2$s">%1$s</td>
+					</tr>
+				</table>',
+				esc_html( rgar( $data, 'name' ) ),
+				esc_attr( $css )
+			);
+		}
+
+		$html = sprintf(
+			'<div class="legalsigning-field-signature__signed">
+				<div class="legalsigning-field-signature__signed-by">
+					<span class="legalsigning-field-signature__signed-by--inner">%2$s</span>
+				</div>
+				
+				<div class="legalsigning-field-signature__signed-wrapper">%1$s</div>
+				
+				<div class="legalsigning-field-signature__signed-verification">
+					<span class="legalsigning-field-signature__signed-verification--inner">%3$s</span>
+				</div>
+			</div>',
+			$html,
+			( $this->field['nameType'] ?? '' ) === 'initials' ? esc_html__( 'Initialed By', 'forgravity_legalsigning' ) : esc_html__( 'Signed By', 'forgravity_legalsigning' ),
+			esc_html__( 'Signed using Legal Signing', 'forgravity_legalsigning' )
+		);
+
+		return parent::html( $html );
+	}
+
+	/**
+	 * Get form data array for current field
+	 *
+	 * @return array
+	 *
+	 * @since 6.10
+	 */
+	public function form_data() {
+		$label    = $this->get_label();
+		$field_id = (int) $this->field->id;
+
+		$data = [];
+
+		/* Maintain backwards compatibility */
+		$value                            = $this->get_value();
+		$data[ $field_id . '.' . $label ] = $value;
+		$data[ $field_id ]                = $value;
+		$data[ $label ]                   = $value;
+
+		$value                                   = $this->value();
+		$data[ $field_id . '.' . $label . '.2' ] = $value;
+		$data[ $field_id . '.2' ]                = $value;
+		$data[ $label . '.2' ]                   = $value;
+
+		return [ 'field' => $data ];
+	}
+
+	/**
+	 * Get the standard GF value of this field
+	 *
+	 * @return string|array
+	 *
+	 * @since 6.10
+	 */
+	public function value() {
+		if ( $this->has_cache() ) {
+			return $this->cache();
+		}
+
+		$value = $this->get_value();
+		$value = \GFCommon::is_json( $value ) ? json_decode( $value, true ) : [ 'image' => $value ];
+		$this->cache( $value );
+
+		return $this->cache();
+	}
+}

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -2381,4 +2381,51 @@ class Model_PDF extends Helper_Abstract_Model {
 		remove_filter( 'gppa_allow_all_lmts', '__return_true' );
 		add_filter( 'gform_pre_replace_merge_tags', [ $this, 'process_gp_populate_anything' ], 10, 3 );
 	}
+
+	/**
+	 * Register Legal Signing path of additional font directory with mPDF
+	 *
+	 * @param array $config
+	 *
+	 * @return array
+	 *
+	 * @since
+	 */
+	public function register_legal_signing_font_path_with_mpdf( $config ) {
+		if ( ! isset( $config['fontDir'] ) || ! is_array( $config['fontDir'] ) ) {
+			$config['fontDir'] = [];
+		}
+
+		$config['fontDir'][] = WP_PLUGIN_DIR . '/' . dirname( FG_LEGALSIGNING_PLUGIN_BASENAME ) . '/dist/fonts/';
+
+		return $config;
+	}
+
+	/**
+	 * Register Legal Signing font files in mPDF
+	 *
+	 * @param array $fonts
+	 *
+	 * @return array
+	 *
+	 * @since 6.10
+	 */
+	public function register_legal_signing_fonts_with_mpdf( $fonts ) {
+		$signature_fonts = glob( WP_PLUGIN_DIR . '/' . dirname( FG_LEGALSIGNING_PLUGIN_BASENAME ) . '/dist/fonts/*.[tT][tT][fF]', GLOB_NOSORT );
+		$signature_fonts = is_array( $signature_fonts ) ? $signature_fonts : [];
+
+		foreach ( $signature_fonts as $font ) {
+			$font_id = basename( strtolower( $font ), '.ttf' );
+			/* Skip if font ID already exists */
+			if ( isset( $fonts[ $font_id ] ) ) {
+				continue;
+			}
+
+			$fonts[ $font_id ] = [
+				'R' => basename( $font ),
+			];
+		}
+
+		return $fonts;
+	}
 }

--- a/src/View/html/PDF/add_legalsigning_styles.php
+++ b/src/View/html/PDF/add_legalsigning_styles.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * The styles needed to display the Legal Signing for Gravity Forms plugin fields
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       6.10
+ */
+
+/* Exit if accessed directly */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+
+<style>
+  .legalsigning-field-signature__signed {
+	background: #FFF;
+	padding: 10px;
+	width: 400px;
+	border-radius: 3px;
+  }
+
+  .legalsigning-field-signature__signed-wrapper {
+	border: 1px solid rgba(11, 16, 51, 0.1);
+	border-radius: 10px;
+	padding: 6px 18px;
+  }
+
+  .legalsigning-field-signature__signed-signature {
+	font-size: 38px;
+	line-height: 55px;
+	text-align: center;
+  }
+
+  .legalsigning-field-signature__signed-by,
+  .legalsigning-field-signature__signed-verification {
+	text-align: center;
+  }
+
+  .legalsigning-field-signature__signed-by {
+	font-size: 7pt;
+	text-transform: uppercase;
+	letter-spacing: 0.92px;
+	margin-bottom: -7px;
+	z-index: 1;
+  }
+
+  .legalsigning-field-signature__signed-verification {
+	font-size: 8pt;
+	margin-top: -8px;
+  }
+
+  .legalsigning-field-signature__signed-by--inner,
+  .legalsigning-field-signature__signed-verification--inner {
+	border: 5px solid #FFF;
+	border-top: 0;
+	border-bottom: 0;
+	background: #FFF;
+  }
+
+  /* Text Signatures */
+  .legalsigning-field-signature__signed-signature--caveat {
+	font-family: "Caveat", caveat, cursive;
+  }
+
+  .legalsigning-field-signature__signed-signature--dancing-script {
+	font-family: "Dancing Script", dancing-script, cursive;
+  }
+
+  .legalsigning-field-signature__signed-signature--homemade-apple {
+	font-family: "Homemade Apple", homemade-apple, cursive;
+  }
+
+  .legalsigning-field-signature__signed-signature--permanent-marker {
+	font-family: "Permanent Marker", permanent-marker, cursive;
+  }
+
+  .legalsigning-field-signature__signed-signature--rock-salt {
+	font-family: "Rock Salt", rock-salt, cursive;
+  }
+</style>


### PR DESCRIPTION
## Description

This PR adds support for the Legal Signature (both text and image-based signatures) and Legal Consent fields in Gravity PDF.

## Screenshots <!-- if applicable -->

![CleanShot 2024-04-04 at 13 44 55](https://github.com/GravityPDF/gravity-pdf/assets/2918419/06e57a0f-1789-4ac5-b50b-99800717f43b)
![CleanShot 2024-04-04 at 13 45 03](https://github.com/GravityPDF/gravity-pdf/assets/2918419/844e34f8-9e95-4d55-9c62-e39856c6e202)

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
