### PR TITLE
Legal Signing: Adhere to smaller signature widths + vertical alignment

### DIFF
--- a/src/Helper/Fields/Field_Fg_Ls_Signature.php
+++ b/src/Helper/Fields/Field_Fg_Ls_Signature.php
@@ -43,13 +43,15 @@ class Field_Fg_Ls_Signature extends Helper_Abstract_Fields {
 				esc_attr( rgar( $data, 'image' ) )
 			);
 		} else {
-			$height = $this->field['canvasHeight'] ?? '150';
+			$width  = $this->field['canvasWidth'] ?? 400;
+			$height = $this->field['canvasHeight'] ?? 150;
 
 			$styles = [
 				'background-color' => $this->field['backgroundColor'] ?? '#FFF',
 				'color'            => $this->field['penColor'] ?? '#000',
 				'font-family'      => ( $data['font'] ?? 'caveat' ) . ', cursive',
 				'height'           => (int) $height,
+				'width'            => $width < 400 ? (int) $width : 400,
 			];
 
 			$css = '';
@@ -58,7 +60,7 @@ class Field_Fg_Ls_Signature extends Helper_Abstract_Fields {
 			}
 
 			$html = sprintf(
-				'<table>
+				'<table style="%2$s">
 					<tr>
 						<td class="legalsigning-field-signature__signed-signature" style="%2$s">%1$s</td>
 					</tr>

--- a/src/View/html/PDF/add_legalsigning_styles.php
+++ b/src/View/html/PDF/add_legalsigning_styles.php
@@ -35,6 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	font-size: 38px;
 	line-height: 55px;
 	text-align: center;
+	vertical-align: middle;
   }
 
   .legalsigning-field-signature__signed-by,


### PR DESCRIPTION
## Description

Minor tweaks to the new Legal Signing field support added in https://github.com/GravityPDF/gravity-pdf/pull/1515


## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
