### PR TITLE
Expanded: Refresh the Gravity PDF settings for form meta database update

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -110,6 +110,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 = 6.10.1 =
 * Bug: Resolve PHP error when processing shortcode with invalid entry object
 * Bug: Adhere to conditional logic and exclude CSS class for Page Break fields
+* Bug: In more situations the Gravity PDF settings will be refreshed before the form meta is saved to the database
 * Housekeeping: Run temporary directory cleanup routine twice daily and delete files older than 12 hours
 * Housekeeping: Add gfpdf_system_status_report_items filter for Gravity PDF System Status report details
 


### PR DESCRIPTION
## Description

The updated logic will refresh the Gravity PDF settings before the form meta is saved to the database in the following cases:

1. Form Editor AJAX save
2. Form Editor fallaback save
3. Form Settings AJAX save
4. Form Notification Status change
5. Form Notification Duplicate/Delete action
6. Gravity Wiz Conditional Pricing Feed save

## Checklist:
- [X] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
