### PR TITLE
Fix PHP error if WP_Error() object passed to shortcode processor

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -108,6 +108,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 == Changelog ==
 
 = 6.10.1 =
+* Bug: Resolve PHP error when processing shortcode with invalid entry object
 * Bug: Adhere to conditional logic and exclude CSS class for Page Break fields
 * Housekeeping: Add gfpdf_system_status_report_items filter for Gravity PDF System Status report details
 

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -167,7 +167,7 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 * @since 6.3
 	 */
 	public function gravitypdf_process_during_merge_tag_replacement( $html, $form, $entry ) {
-		if ( empty( $entry['id'] ) || ! is_string( $html ) ) {
+		if ( ! is_array( $entry ) || empty( $entry['id'] ) || ! is_string( $html ) ) {
 			return $html;
 		}
 

--- a/tests/phpunit/unit-tests/test-shortcodes.php
+++ b/tests/phpunit/unit-tests/test-shortcodes.php
@@ -345,6 +345,12 @@ class Test_Shortcode extends WP_UnitTestCase {
 		$form['confirmation']['type'] = 'redirect';
 		$results                      = $this->model->gravitypdf_confirmation( [ 'data' ], $form, $lead );
 		$this->assertEquals( 'data', $results[0] );
+
+		/* Check there are no errors when passing a WP_Error instead of an entry */
+		$confirmation = 'Thanks for getting in touch. [gravitypdf id="555ad84787d7e"]';
+		$results      = $this->model->gravitypdf_confirmation( $confirmation, $form, new \WP_Error() );
+		$this->assertSame( $confirmation, $results );
+
 	}
 
 	/**


### PR DESCRIPTION
## Description

Customer reported issue with form submission process when using legacy Gravity Forms PayPal add-on. Logs showed $entry was a WP_Error object instead of an array.

Updated code to handle this edge-case.

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
