### PR TITLE
Remove downgrade feature to a now-unsupported version of Gravity PDF

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -107,6 +107,9 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 == Changelog ==
 
+= 6.11.0 =
+* Housekeeping: Remove downgrade notice to unsupported Gravity PDF v5.0 if minimum system requirements are not met for v6.0
+
 = 6.10.2 =
 * Bug: Hydrate Nested Forms with Gravity Wiz Populate Anything data
 

--- a/pdf.php
+++ b/pdf.php
@@ -103,15 +103,6 @@ class GFPDF_Major_Compatibility_Checks {
 	public $required_php_version = '7.3';
 
 	/**
-	 * Whether to offer a downgrade notice or not
-	 *
-	 * @var bool
-	 *
-	 * @since 6.0
-	 */
-	protected $offer_downgrade = false;
-
-	/**
 	 * Set our required variables for a fallback and attempt to initialise
 	 *
 	 * @param string $basename Plugin basename
@@ -154,15 +145,6 @@ class GFPDF_Major_Compatibility_Checks {
 
 		/* Check if any errors were thrown, enqueue them and exit early */
 		if ( count( $this->notices ) > 0 ) {
-			if ( $this->offer_downgrade ) {
-				add_action( 'admin_menu', array( $this, 'admin_rollback_menu' ), 20 );
-
-				/* don't display the notice on the rollback page */
-				if ( is_admin() && rgget( 'page' ) === 'gpdf-downgrade' ) {
-					return;
-				}
-			}
-
 			if ( class_exists( 'GFForms' ) && GFForms::is_gravity_page() ) {
 				ob_start();
 				$this->notice_body_content();
@@ -193,11 +175,6 @@ class GFPDF_Major_Compatibility_Checks {
 		if ( ! version_compare( $wp_version, $this->required_wp_version, '>=' ) ) {
 			$this->notices[] = sprintf( esc_html__( 'WordPress version %1$s is required: upgrade to the latest version. %2$sGet more info%3$s.', 'gravity-forms-pdf-extended' ), $this->required_wp_version, '<a href="https://docs.gravitypdf.com/v6/users/activation-errors#wordpress-version-x-is-required">', '</a>' );
 
-			/* Offer downgrade prompt if WP version is compatible with v5 */
-			if ( version_compare( $wp_version, '4.8', '>=' ) ) {
-				$this->offer_downgrade = true;
-			}
-
 			return false;
 		}
 
@@ -223,11 +200,6 @@ class GFPDF_Major_Compatibility_Checks {
 		if ( ! version_compare( GFCommon::$version, $this->required_gf_version, '>=' ) ) {
 			$this->notices[] = sprintf( esc_html__( '%1$sGravity Forms%2$s version %3$s or higher is required. %4$sGet more info%5$s.', 'gravity-forms-pdf-extended' ), '<a href="https://rocketgenius.pxf.io/c/1211356/445235/7938">', '</a>', $this->required_gf_version, '<a href="https://docs.gravitypdf.com/v6/users/activation-errors#gravity-forms-version-x-is-required">', '</a>' );
 
-			/* Offer downgrade prompt if GF version is compatible with v5 */
-			if ( version_compare( GFCommon::$version, '2.3.1', '>=' ) ) {
-				$this->offer_downgrade = true;
-			}
-
 			return false;
 		}
 
@@ -246,11 +218,6 @@ class GFPDF_Major_Compatibility_Checks {
 		/* Check PHP version is compatible */
 		if ( ! version_compare( phpversion(), $this->required_php_version, '>=' ) ) {
 			$this->notices[] = sprintf( esc_html__( 'You are running an %1$soutdated version of PHP%2$s. Contact your web hosting provider to update. %3$sGet more info%4$s.', 'gravity-forms-pdf-extended' ), '<a href="https://wordpress.org/support/update-php/">', '</a>', '<a href="https://docs.gravitypdf.com/v6/users/activation-errors#you-are-running-an-outdated-version-of-php">', '</a>' );
-
-			/* Offer downgrade prompt if PHP version is compatible with v5 */
-			if ( version_compare( phpversion(), '5.6', '>=' ) ) {
-				$this->offer_downgrade = true;
-			}
 
 			return false;
 		}
@@ -442,70 +409,7 @@ class GFPDF_Major_Compatibility_Checks {
 				<li style="padding-left: 20px;list-style: inside"><?php echo wp_kses_post( $notice ); ?></li>
 			<?php endforeach; ?>
 		</ul>
-
-		<?php if ( $this->offer_downgrade && PDF_PLUGIN_BASENAME === 'gravity-forms-pdf-extended/pdf.php' ): ?>
-			<form method="post" action="<?php echo esc_url( admin_url( 'index.php?page=gpdf-downgrade' ) ); ?>">
-				<?php wp_nonce_field( 'gpdf-downgrade' ); ?>
-				<p>
-					<?php esc_html_e( 'Not ready to upgrade? Try an earlier version of Gravity PDF', 'gravity-forms-pdf-extended' ); ?>
-					<button class="button primary"><?php esc_html_e( 'Downgrade Now', 'gravity-forms-pdf-extended' ); ?></button>
-				</p>
-			</form>
-		<?php endif; ?>
 		<?php
-	}
-
-	/**
-	 * Adds a 'hidden' menu item that is activated when the user elects to rollback
-	 *
-	 * @since 6.0
-	 */
-	public function admin_rollback_menu() {
-		if ( rgget( 'page' ) !== 'gpdf-downgrade' ) {
-			return;
-		}
-
-		$title = esc_html__( 'Downgrade', 'gravity-forms-pdf-extended' );
-
-		add_dashboard_page( $title, $title, 'update_plugins', 'gpdf-downgrade', array( $this, 'rollback' ) );
-	}
-
-	/**
-	 * Roll Gravity PDF back to the latest v5 release
-	 *
-	 * @since 6.0
-	 */
-	public function rollback() {
-		if ( ! check_admin_referer( 'gpdf-downgrade' ) || ! current_user_can( 'update_plugins' ) ) {
-			die( esc_html__( 'The link you followed has expired.', 'default' ) );
-		}
-
-		$plugin   = 'gravity-forms-pdf-extended';
-		$response = wp_remote_get( 'https://api.wordpress.org/plugins/info/1.0/' . $plugin . '.json' );
-		if ( wp_remote_retrieve_response_code( $response ) !== 200 ) {
-			die( esc_html__( 'Plugin downgrade failed.', 'default' ) );
-		}
-
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		if ( empty( $body['versions'] ) ) {
-			die( esc_html__( 'Plugin downgrade failed.', 'default' ) );
-		}
-
-		/* Get the first matching v5 tag and url (the latest) */
-		foreach ( array_reverse( $body['versions'] ) as $version => $download_url ) {
-			if ( $version[0] === '5' && $version[1] === '.' ) {
-				break;
-			}
-		}
-
-		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-
-		$nonce     = 'gpdf-downgrade';
-		$url       = 'index.php?page=' . $nonce;
-		$overwrite = 'downgrade-plugin';
-
-		$upgrader = new Plugin_Upgrader( new Plugin_Installer_Skin( compact( 'nonce', 'url', 'plugin', 'version', 'overwrite' ) ) );
-		$upgrader->install( $download_url, [ 'overwrite_package' => true ] );
 	}
 }
 


### PR DESCRIPTION
## Description

Gravity PDF v5 become unsupported as of 2023-04-28. This PR removes the downgrade prompt when the plugin detects the web hosting does not meet the minimum system requirements. 

Resolves #1535

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
