### PR TITLE
Prevent submission when selecting a setting tooltip button

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -109,6 +109,7 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 = 6.11.0 =
 * Housekeeping: Remove downgrade notice to unsupported Gravity PDF v5.0 if minimum system requirements are not met for v6.0
+* Bug: Prevent the page reloading when selecting a tooltip on PDF settings pages
 
 = 6.10.2 =
 * Bug: Hydrate Nested Forms with Gravity Wiz Populate Anything data

--- a/src/assets/js/admin/settings/initialiseSettings.js
+++ b/src/assets/js/admin/settings/initialiseSettings.js
@@ -26,6 +26,10 @@ class InitialiseSettings {
     if (pages.isFormSettings()) {
       this.processFormSettings()
     }
+
+    /* Prevent submission when selecting a setting tooltip button */
+    $('.gfpdf-tooltip').on('click', () => false)
+      .on('keypress', () => false)
   }
 
   /**


### PR DESCRIPTION
## Description

Add click/keypress handlers to GPDF tooltips that disable native action.

Resolve #1532

## Testing instructions
1. Open Global or Form PDF Settings
2. Click on a tooltip
3. Nothing should occur when you do so

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
