### PR TITLE
Improve Signed PDF Log Messages and Self-Heal Secret Key

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -109,6 +109,8 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 = 6.11.0 =
 * Housekeeping: Remove downgrade notice to unsupported Gravity PDF v5.0 if minimum system requirements are not met for v6.0
+* Housekeeping: Improve log messages when creating and validating a Signed PDF URL
+* Bug: Self-heal the PDF signing secret key if it becomes invalid
 * Bug: Prevent the page reloading when selecting a tooltip on PDF settings pages
 
 = 6.10.2 =

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -355,6 +355,19 @@ class Model_PDF extends Helper_Abstract_Model {
 							'entry_id'    => $entry['id'],
 							'pdf_id'      => $settings['id'],
 							'url'         => $url,
+							'protocol'    => $protocol, /* Logged to a plain text file */
+							'domain'      => $domain, /* Logged to a plain text file */
+							'request_uri' => $request, /* Logged to a plain text file */
+						]
+					);
+				} else {
+					$this->log->warning(
+						'Invalid PDF Signing Request',
+						[
+							'entry_id'    => $entry['id'],
+							'pdf_id'      => $settings['id'],
+							'url'         => $url,
+							'protocol'    => $protocol, /* Logged to a plain text file */
 							'domain'      => $domain, /* Logged to a plain text file */
 							'request_uri' => $request, /* Logged to a plain text file */
 						]


### PR DESCRIPTION
## Description

Fixes https://github.com/GravityPDF/gravity-pdf/issues/1534

Also, instead of throwing an exception that stops the process, we'll regenerate the secret key if we ever detect it has been corrupted.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
