### PR TITLE
Improve PDF Form Settings input sanitation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -110,6 +110,8 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 = 6.11.0 =
 * Housekeeping: Remove downgrade notice to unsupported Gravity PDF v5.0 if minimum system requirements are not met for v6.0
 * Housekeeping: Improve log messages when creating and validating a Signed PDF URL
+* Housekeeping: Improve input sanitation for textarea, number, and custom paper size fields when saving the PDF Form Settings
+* Bug: Enforce a 1pt minimum value for the Default Font Size and Font Size settings
 * Bug: Self-heal the PDF signing secret key if it becomes invalid
 * Bug: Prevent the page reloading when selecting a tooltip on PDF settings pages
 

--- a/src/Controller/Controller_Form_Settings.php
+++ b/src/Controller/Controller_Form_Settings.php
@@ -160,6 +160,9 @@ class Controller_Form_Settings extends Helper_Abstract_Controller implements Hel
 		add_filter( 'gfpdf_form_settings_sanitize', [ $this->options, 'sanitize_all_fields' ], 10, 4 );
 		add_filter( 'gfpdf_form_settings_sanitize_text', [ $this->model, 'parse_filename_extension' ], 15, 2 );
 		add_filter( 'gfpdf_form_settings_sanitize_text', [ $this->options, 'sanitize_trim_field' ], 15, 2 );
+		add_filter( 'gfpdf_form_settings_sanitize_textarea', [ $this->options, 'sanitize_trim_field' ] );
+		add_filter( 'gfpdf_form_settings_sanitize_number', [ $this->options, 'sanitize_number_field' ], 10, 4 );
+		add_filter( 'gfpdf_form_settings_sanitize_paper_size', [ $this->options, 'sanitize_paper_size' ] );
 		add_filter( 'gfpdf_form_settings_sanitize_hidden', [ $this->model, 'decode_json' ], 10, 2 );
 
 		add_filter( 'gfpdf_skip_highlight_errors', [ $this->model, 'check_custom_size_error_highlighting' ], 10, 3 );

--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -167,7 +167,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 
 		add_filter( 'gfpdf_settings_sanitize_text', [ $this, 'sanitize_trim_field' ] );
 		add_filter( 'gfpdf_settings_sanitize_textarea', [ $this, 'sanitize_trim_field' ] );
-		add_filter( 'gfpdf_settings_sanitize_number', [ $this, 'sanitize_number_field' ] );
+		add_filter( 'gfpdf_settings_sanitize_number', [ $this, 'sanitize_number_field' ], 10, 4 );
 		add_filter( 'gfpdf_settings_sanitize_paper_size', [ $this, 'sanitize_paper_size' ] );
 	}
 
@@ -1207,14 +1207,29 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 	/**
 	 * Sanitize number fields
 	 *
-	 * @param string $input The field value
+	 * @param mixed $value The field's user input value
+	 * @param string $key The settings key
+	 * @param array $input All user fields
+	 * @param array $settings The field settings
 	 *
 	 * @return string $input Sanitized value
 	 * @since 4.0
-	 *
+	 * @since 6.11 Force minimum and maximum values
 	 */
-	public function sanitize_number_field( $input ) {
-		return (int) $input;
+	public function sanitize_number_field( $value, $key = '', $input = [], $settings = [] ) {
+		$value = (int) $value;
+
+		/* If number less than the minimum, set to the minimum */
+		if ( ! empty( $settings['min'] ) && $value < $settings['min'] ) {
+			$value = $settings['min'];
+		}
+
+		/* If number more than the maximum, set to the maximum */
+		if ( ! empty( $settings['max'] ) && $value > $settings['max'] ) {
+			$value = $settings['max'];
+		}
+
+		return $value;
 	}
 
 	/**

--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -114,6 +114,7 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 						'type'  => 'number',
 						'size'  => 'small',
 						'std'   => 10,
+						'min'   => 1,
 					],
 
 					'default_font_colour'     => [
@@ -352,6 +353,7 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 						'desc2' => 'pt',
 						'type'  => 'number',
 						'size'  => 'small',
+						'min'   => 1,
 						'std'   => $this->get_option( 'default_font_size', 10 ),
 						'class' => 'gfpdf_font_size',
 					],

--- a/tests/phpunit/unit-tests/test-form-settings.php
+++ b/tests/phpunit/unit-tests/test-form-settings.php
@@ -524,8 +524,8 @@ class Test_Form_Settings extends WP_UnitTestCase {
 
 		$values = $this->model->settings_sanitize( $input );
 
-		foreach ( $values as $v ) {
-			$this->assertEquals( 'global input value', $v );
+		foreach ( $values as $k => $v ) {
+			$this->assertContains( $v, [ 'global input value', 0, 1 ] );
 		}
 
 		remove_all_filters( 'gfpdf_form_settings_sanitize' );
@@ -553,7 +553,7 @@ class Test_Form_Settings extends WP_UnitTestCase {
 		/* loop through array and check results */
 		foreach ( $input as $id => $field ) {
 			if ( isset( $values[ $id ] ) ) {
-				$this->assertTrue( in_array( $values[ $id ], $types, true ) );
+				$this->assertContains( $values[ $id ], $types );
 			}
 		}
 

--- a/tests/phpunit/unit-tests/test-options-api.php
+++ b/tests/phpunit/unit-tests/test-options-api.php
@@ -909,6 +909,30 @@ class Test_Options_API extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check the min/max number setting is respected
+	 *
+	 * @return void
+	 *
+	 * @since 6.11
+	 */
+	public function test_sanitize_number_field_min_max() {
+		$this->assertSame( 5, $this->options->sanitize_number_field( 0, '', [], [ 'min' => 5 ] ) );
+		$this->assertSame( 5, $this->options->sanitize_number_field( 4, '', [], [ 'min' => 5 ] ) );
+		$this->assertSame( 5, $this->options->sanitize_number_field( -6, '', [], [ 'min' => 5 ] ) );
+		$this->assertSame( 5, $this->options->sanitize_number_field( 5, '', [], [ 'min' => 5 ] ) );
+		$this->assertSame( 6, $this->options->sanitize_number_field( 6, '', [], [ 'min' => 5 ] ) );
+		$this->assertSame( 120, $this->options->sanitize_number_field( 120, '', [], [ 'min' => 5 ] ) );
+
+		$this->assertSame( -6, $this->options->sanitize_number_field( -6, '', [], [ 'max' => 5 ] ) );
+		$this->assertSame( 0, $this->options->sanitize_number_field( 0, '', [], [ 'max' => 5 ] ) );
+		$this->assertSame( 4, $this->options->sanitize_number_field( 4, '', [], [ 'max' => 5 ] ) );
+		$this->assertSame( 5, $this->options->sanitize_number_field( 5, '', [], [ 'max' => 5 ] ) );
+		$this->assertSame( 5, $this->options->sanitize_number_field( 6, '', [], [ 'max' => 5 ] ) );
+		$this->assertSame( 5, $this->options->sanitize_number_field( 10, '', [], [ 'max' => 5 ] ) );
+		$this->assertSame( 5, $this->options->sanitize_number_field( 120, '', [], [ 'max' => 5 ] ) );
+	}
+
+	/**
 	 * Test the paper size sanitization function
 	 *
 	 * @param array $expected


### PR DESCRIPTION
## Description

When saving the PDF Form Settings, the following extra sanitation occurs:

1. Textarea fields are run through the trim() function
2. Number fields are passed through (int) and then forced to be within the min and max range defined (if any)
3. Custom Paper Size width and height are run through (float) and abs()
4. Minimum value of 1 has been set for the Font Size settings

When saving the Global PDF Settings the minimum value of the Default Font Size field is now 1

Resolves #1526

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
