### PR TITLE
Fix fatal error saving settings if the data is corrupted

### DIFF
--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -322,8 +322,12 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		$settings = $is_temp ? (array) $tmp_settings : get_option( 'gfpdf_settings', [] );
 
 		/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_get_settings/ for more details about this filter */
+		$settings = apply_filters( 'gfpdf_get_settings', $settings, $is_temp );
 
-		return apply_filters( 'gfpdf_get_settings', $settings, $is_temp );
+		/* Ensure $settings is an array and has not been corrupted somehow */
+		$settings = is_array( $settings ) ? $settings : [];
+
+		return $settings;
 	}
 
 	/**


### PR DESCRIPTION
## Description

Ensure the global settings array auto-heals if it ever becomes another type (string, bool etc).

Fixes #1182


## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
