### PR TITLE
Fix Notification bug during PDF Background Processing

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -107,6 +107,9 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 
 == Changelog ==
 
+= 6.11.1 =
+* Bug: Only process enabled notifications during form submission when using PDF Background Processing. Notifications are enabled if they are active and have conditional logic that passes.
+
 = 6.11.0 =
 * Housekeeping: Limit pages admin notices are displayed on to reduce notice fatigue
 * Housekeeping: Add specific check for the PHP extension `Ctype` when the plugin loads

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
@@ -190,13 +190,55 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 				$entry
 			)
 		);
+
+		/* Test we skip inactive notifications */
+		$this->assertFalse(
+			$this->controller->maybe_disable_submission_notifications(
+				false,
+				$form['notifications']['54bca349732b8'],
+				$form,
+				$entry
+			)
+		);
+
+		$form['notifications']['54bca349732b8']['isActive'] = true;
+
 		$this->assertTrue(
 			$this->controller->maybe_disable_submission_notifications(
 				false,
+				$form['notifications']['54bca349732b8'],
+				$form,
+				$entry
+			)
+		);
+
+		/* Test we skip notifications that do not pass conditional logic */
+		$form['notifications']['54bca349732b8']['conditionalLogic'] = [
+			'logicType' => 'any',
+			'rules'     => [
 				[
-					'id'    => '54bca349732b8',
-					'event' => 'form_submission',
+					'fieldId'  => 1,
+					'operator' => 'isnot',
+					'value'    => 'My Single Line Response',
 				],
+			],
+		];
+
+		$this->assertFalse(
+			$this->controller->maybe_disable_submission_notifications(
+				false,
+				$form['notifications']['54bca349732b8'],
+				$form,
+				$entry
+			)
+		);
+
+		$form['notifications']['54bca349732b8']['conditionalLogic']['rules'][0]['operator'] = 'is';
+
+		$this->assertTrue(
+			$this->controller->maybe_disable_submission_notifications(
+				false,
+				$form['notifications']['54bca349732b8'],
 				$form,
 				$entry
 			)
@@ -219,10 +261,7 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 		$this->assertFalse(
 			$this->controller->maybe_disable_submission_notifications(
 				false,
-				[
-					'id'    => '54bca349732b8',
-					'event' => 'form_submission',
-				],
+				$form['notifications']['54bca349732b8'],
 				$form,
 				$entry
 			)


### PR DESCRIPTION
## Description

A bug was introduced in 6.11 that skipped the enabled notification checks when using PDF Background Processing. This update reintroduces these checks to verify a notification is active and any conditional logic passes.

Fixes #1554

## Testing instructions
1. Enable PDF Background processing in global PDF settings
2. Setup two Notifications on a form and set one to inactive
3. Configure PDF on the form and attach the PDF to both notifications
4. Submit the form
5. Verify only one notification email is sent

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
