### PR TITLE
Performance: Add temporary PDF cache

### DIFF
--- a/api.php
+++ b/api.php
@@ -448,19 +448,21 @@ final class GPDFAPI {
 	}
 
 	/**
-	 * When provided the Gravity Form entry ID and PDF ID, this method will correctly generate the PDF, save it to disk,
-	 * trigger appropriate actions and return the absolute path to the PDF.
+	 * Generate a PDF, save it to disk, and return the absolute path to the document
 	 *
 	 * See https://docs.gravitypdf.com/v6/developers/api/create_pdf/ for more information about this method
 	 *
-	 * @param  integer $entry_id The Gravity Form entry ID
-	 * @param  string  $pdf_id   The Gravity PDF ID number (the pid number in the URL when viewing a setting in the admin area)
+	 * @param int    $entry_id     The Gravity Form entry ID
+	 * @param string $pdf_id       The Gravity PDF ID number (the pid number in the URL when viewing a setting in the admin area)
+	 * @param bool   $bypass_cache Force a new PDF to be generated
 	 *
-	 * @return mixed            Return the full path to the PDF, or a WP_Error on failure
+	 * @return string|WP_Error   Return the full path to the PDF, or a WP_Error on failure
 	 *
 	 * @since 4.0
+	 * @since 6.12 All PDFs are cached on disk for ~1 hour, but are auto-purged if the form, entry, or PDF settings change
+	 *        Re-running the method will return the cached PDF if it exists, unless $bypass_cache = true
 	 */
-	public static function create_pdf( $entry_id, $pdf_id ) {
+	public static function create_pdf( $entry_id, $pdf_id, $bypass_cache = false ) {
 
 		$form_class = static::get_form_class();
 
@@ -478,16 +480,19 @@ final class GPDFAPI {
 			return new WP_Error( 'invalid_pdf_setting', esc_html__( 'Could not located the PDF Settings. Ensure you pass in a valid PDF ID.', 'gravity-forms-pdf-extended' ) );
 		}
 
-		$pdf  = static::get_mvc_class( 'Model_PDF' );
-		$form = $form_class->get_form( $entry['form_id'] );
+		if ( $bypass_cache ) {
+			add_filter( 'gfpdf_override_pdf_bypass', '__return_true', 9999 );
+		}
 
-		add_filter( 'gfpdf_override_pdf_bypass', '__return_true' );
-		do_action( 'gfpdf_pre_generate_and_save_pdf', $form, $entry, $setting );
-		$filename = $pdf->generate_and_save_pdf( $entry, $setting );
-		do_action( 'gfpdf_post_generate_and_save_pdf', $form, $entry, $setting );
-		remove_filter( 'gfpdf_override_pdf_bypass', '__return_true' );
+		/** @var \GFPDF\Model\Model_PDF $pdf */
+		$pdf         = static::get_mvc_class( 'Model_PDF' );
+		$path_to_pdf = $pdf->generate_and_save_pdf( $entry, $setting );
 
-		return $filename;
+		if ( $bypass_cache ) {
+			remove_filter( 'gfpdf_override_pdf_bypass', '__return_true', 9999 );
+		}
+
+		return $path_to_pdf;
 	}
 
 	/**

--- a/pdf.php
+++ b/pdf.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Gravity PDF
-Version: 6.11.1
+Version: 6.12.0
 Description: Automatically generate highly customizable PDF documents using Gravity Forms.
 Author: Blue Liquid Designs
 Author URI: https://blueliquiddesigns.com.au
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /*
  * Set base constants we'll use throughout the plugin
  */
-define( 'PDF_EXTENDED_VERSION', '6.11.1' ); /* the current plugin version */
+define( 'PDF_EXTENDED_VERSION', '6.12.0' ); /* the current plugin version */
 define( 'PDF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); /* plugin directory path */
 define( 'PDF_PLUGIN_URL', plugin_dir_url( __FILE__ ) ); /* plugin directory url */
 define( 'PDF_PLUGIN_BASENAME', plugin_basename( __FILE__ ) ); /* the plugin basename */

--- a/src/Controller/Controller_Install.php
+++ b/src/Controller/Controller_Install.php
@@ -202,6 +202,8 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 	 * Determine if we should be saving the PDF settings
 	 *
 	 * @since 4.0
+	 *
+	 * @deprecated 6.0
 	 */
 	public function maybe_uninstall() {
 		_doing_it_wrong( __METHOD__, 'This method has been moved to Controller_Uninstall::uninstall_addon()', '6.0' );

--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -7,13 +7,12 @@ use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Abstract_Model;
 use GFPDF\Helper\Helper_Abstract_View;
 use GFPDF\Helper\Helper_Form;
-use GFPDF\Helper\Helper_Interface_Actions;
-use GFPDF\Helper\Helper_Interface_Filters;
 use GFPDF\Helper\Helper_Misc;
+use GFPDF\Helper\Helper_PDF;
 use GFPDF\Model\Model_PDF;
+use GFPDF\Statics\Debug;
 use GFPDF\View\View_PDF;
 use Psr\Log\LoggerInterface;
-use SiteGround_Optimizer\Minifier\Minifier;
 
 /**
  * @package     Gravity PDF
@@ -30,9 +29,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Controller_PDF
  * Handles the PDF display and authentication
  *
+ * @property View_PDF $view
+ * @property Model_PDF $model
+ *
  * @since 4.0
  */
-class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interface_Actions, Helper_Interface_Filters {
+class Controller_PDF extends Helper_Abstract_Controller {
 
 	/**
 	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
@@ -89,69 +91,65 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	}
 
 	/**
-	 * Initialise our class defaults
-	 *
 	 * @return void
 	 * @since 4.0
-	 *
 	 */
 	public function init() {
-		/*
-		 * Tell Gravity Forms to add our form PDF settings pages
-		 */
 		$this->add_actions();
 		$this->add_filters();
 
 		/* Add scheduled tasks */
 		if ( ! wp_next_scheduled( 'gfpdf_cleanup_tmp_dir' ) ) {
-			wp_schedule_event( time(), 'twicedaily', 'gfpdf_cleanup_tmp_dir' );
+			wp_schedule_event( time(), 'hourly', 'gfpdf_cleanup_tmp_dir' );
 		}
 	}
 
 	/**
-	 * Apply any actions needed for the settings page
-	 *
 	 * @return void
 	 * @since 4.0
-	 *
 	 */
 	public function add_actions() {
 		/* Process PDF if needed */
 		add_action( 'parse_request', [ $this, 'process_legacy_pdf_endpoint' ] ); /* legacy PDF endpoint */
 		add_action( 'parse_request', [ $this, 'process_pdf_endpoint' ] ); /* new PDF endpoint */
 
-		/* Allow custom PDF tags / CSS */
+		/* Set up pre- and post-generation PDF hooks */
 		add_action( 'gfpdf_pre_pdf_generation', [ $this, 'add_pre_pdf_hooks' ] );
 		add_action( 'gfpdf_post_pdf_generation', [ $this, 'remove_pre_pdf_hooks' ] );
+
+		/* Set up pre generation hooks when streaming PDF to the browser */
+		$add_pre_view_or_download_pdf_hooks = function( $form, $entry, $settings ) {
+			$this->add_pre_view_or_download_pdf_hooks( $form, $entry, $settings );
+		};
+
+		add_action( 'gfpdf_view_or_download_pdf', $add_pre_view_or_download_pdf_hooks, 10, 3 );
 
 		/* Display PDF links in Gravity Forms Admin Area */
 		add_action( 'gform_entries_first_column_actions', [ $this->model, 'view_pdf_entry_list' ], 10, 4 );
 		add_action( 'gravityflow_workflow_detail_sidebar', [ $this->model, 'view_pdf_gravityflow_inbox' ], 10, 4 );
 
-		/* Add save PDF actions */
+		/* Add hooks to save PDF to disk, or run right after a PDF is saved to disk */
 		add_action( 'gform_after_submission', [ $this->model, 'maybe_save_pdf' ], 10, 2 );
 		add_action( 'gfpdf_post_pdf_generation', [ $this->model, 'trigger_post_save_pdf' ], 10, 4 );
 
-		/* Clean-up actions */
-		add_action( 'gform_after_submission', [ $this->model, 'cleanup_pdf' ], 9999, 2 );
-		add_action( 'gform_after_update_entry', [ $this->model, 'cleanup_pdf_after_submission' ], 9999, 2 );
+		/* Scheduled clean-up actions */
 		add_action( 'gfpdf_cleanup_tmp_dir', [ $this->model, 'cleanup_tmp_dir' ] );
 
-		/* Add Gravity Perk Population Anything Support */
-		if ( function_exists( 'gp_populate_anything' ) ) {
-			add_action( 'gfpdf_pre_pdf_generation', [ $this->model, 'enable_gp_populate_anything' ] );
-			add_action( 'gfpdf_pre_pdf_generation_output', [ $this->model, 'disable_gp_populate_anything' ] );
+		/* Remove legacy Gravity Perk Population Anything Support */
+		if ( class_exists( '\GPPA_Compatibility_GravityPDF' ) ) {
+			$gp_pdf_compat = \GPPA_Compatibility_GravityPDF::get_instance();
+			remove_action( 'gfpdf_pre_view_or_download_pdf', [ $gp_pdf_compat, 'hydrate_form_hook_for_pdf_view_or_download' ] );
+			remove_action( 'gfpdf_pre_generate_and_save_pdf_notification', [ $gp_pdf_compat, 'hydrate_form_hook' ] );
+			remove_action( 'gfpdf_pre_generate_and_save_pdf', [ $gp_pdf_compat, 'hydrate_form_hook' ] );
+		}
 
-			/* register preferred hydration method */
-			add_filter( 'gfpdf_current_form_object', [ $this->model, 'gp_populate_anything_hydrate_form' ], 5, 2 );
+		/* Gravity Wiz Nested Forms support */
+		if ( function_exists( 'gp_nested_forms' ) ) {
+			$included_nested_forms_in_cache_hash = function( $data, $form, $entry, $pdf_settings ) {
+				return $this->included_nested_forms_in_cache_hash( $data, $form, $entry, $pdf_settings );
+			};
 
-			/* remove legacy filters */
-			if ( class_exists( '\GPPA_Compatibility_GravityPDF' ) ) {
-				$gp_pdf_compat = \GPPA_Compatibility_GravityPDF::get_instance();
-				remove_action( 'gfpdf_pre_view_or_download_pdf', [ $gp_pdf_compat, 'hydrate_form_hook_for_pdf_view_or_download' ] );
-				remove_action( 'gfpdf_pre_generate_and_save_pdf_notification', [ $gp_pdf_compat, 'hydrate_form_hook' ] );
-				remove_action( 'gfpdf_pre_generate_and_save_pdf', [ $gp_pdf_compat, 'hydrate_form_hook' ] );
-			}
+			add_filter( 'gfpdf_cache_hash_array', $included_nested_forms_in_cache_hash, 10, 4 );
 		}
 
 		/* Add Legal Signature support */
@@ -163,11 +161,8 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	}
 
 	/**
-	 * Apply any filters needed for the settings page
-	 *
 	 * @return void
 	 * @since 4.0
-	 *
 	 */
 	public function add_filters() {
 		/* PDF authentication middleware */
@@ -188,16 +183,8 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_filter( 'gfpdf_field_middleware', [ $this->model, 'field_middle_page' ], 10, 5 );
 		add_filter( 'gfpdf_field_middleware', [ $this->model, 'field_middle_blacklist' ], 10, 7 );
 
-		/* Tap into GF notifications */
-		add_filter(
-			'gform_notification',
-			[
-				$this->model,
-				'notifications',
-			],
-			9999,
-			3
-		); /* ensure Gravity PDF is one of the last filters to be applied */
+		/* Gravity Forms PDF Attachments */
+		add_filter( 'gform_notification', [ $this->model, 'notifications' ], 9999, 3 );
 
 		/* Change mPDF settings */
 		add_filter( 'mpdf_font_data', [ $this->model, 'register_custom_font_data_with_mPDF' ] );
@@ -205,10 +192,16 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_filter( 'gfpdf_mpdf_init_class', [ $this->model, 'set_watermark_font' ], 10, 4 );
 
 		/* Process mergetags and shortcodes in PDF */
+		add_filter( 'gfpdf_pdf_core_template_html_output', [ $this->gform, 'process_tags' ], 10, 3 );
 		add_filter( 'gfpdf_pdf_html_output', [ $this->gform, 'process_tags' ], 10, 3 );
 		add_filter( 'gfpdf_pdf_html_output', 'do_shortcode' );
 
-		add_filter( 'gfpdf_pdf_core_template_html_output', [ $this->gform, 'process_tags' ], 10, 3 );
+		/* Add support for ?html=1 helper parameter */
+		$add_view_html_debugger = function( $html, $form, $entry, $pdf_settings, $helper_pdf ) {
+			return $this->add_view_html_debugger( $html, $form, $entry, $pdf_settings, $helper_pdf );
+		};
+
+		add_filter( 'gfpdf_pdf_html_output', $add_view_html_debugger, 9999, 5 );
 
 		/* Backwards compatibility for our Tier 2 plugin */
 		add_filter( 'gfpdfe_pre_load_template', [ 'PDFRender', 'prepare_ids' ], 1, 8 );
@@ -217,33 +210,42 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_filter( 'gfpdf_template_args', [ $this->model, 'preprocess_template_arguments' ] );
 		add_filter( 'gfpdf_pdf_html_output', [ $this->view, 'autoprocess_core_template_options' ], 5, 4 );
 
-		/* Cleanup filters */
-		add_filter( 'gform_before_resend_notifications', [ $this->model, 'resend_notification_pdf_cleanup' ], 10, 2 );
-
-		/* Third Party Conflict Fixes */
-		add_filter( 'gfpdf_pre_view_or_download_pdf', [ $this, 'sgoptimizer_html_minification_fix' ] );
-		add_filter( 'gfpdf_legacy_pre_view_or_download_pdf', [ $this, 'sgoptimizer_html_minification_fix' ] );
-		add_filter(
-			'gfpdf_pre_pdf_generation_output',
-			function() {
-				add_filter( 'weglot_active_translation', '__return_false' );
-			}
-		);
-
 		/* Meta boxes */
 		add_filter( 'gform_entry_detail_meta_boxes', [ $this->model, 'register_pdf_meta_box' ], 10, 3 );
 
-		/* Page field support */
-		add_filter( 'gfpdf_current_form_object', [ $this->model, 'register_page_fields' ] );
+		/* Manipulate the form object (array) when generating PDFs */
+		$add_current_form_object_hooks = function( $form, $entry, $source ) {
+			return $this->add_current_form_object_hooks( $form, $entry, $source );
+		};
+
+		add_filter( 'gfpdf_current_form_object', $add_current_form_object_hooks, 10, 3 );
+
+		/* Manipulate the PDF settings object (array) when generating PDFs */
+		$add_current_pdf_settings_object_hooks = function( $pdf_settings, $form, $entry ) {
+			return $this->add_current_pdf_settings_object_hooks( $pdf_settings, $form, $entry );
+		};
+
+		add_filter( 'gfpdf_current_pdf_settings_object', $add_current_pdf_settings_object_hooks, 10, 3 );
 	}
 
 	/**
-	 * Determines if we should process the PDF at this stage
-	 * Fires just before the main WP_Query is executed (we don't need it)
+	 * Processes the View/Download PDF Endpoint
+	 *
+	 * Endpoint URLs:
+	 *
+	 * example format -> https://example.com/pdf/{pdfId}/{entryId}/
+	 *
+	 * view -> https://example.com/pdf/66307560bcdf4/2403/
+	 * download -> https://example.com/pdf/66307560bcdf4/2403/download/
+	 * add print dialog -> https://example.com/pdf/66307560bcdf4/2403/?print=1
+	 *
+	 * Recommend you generate the URL with a shortcode or merge tag
+	 * See https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags
+	 *
+	 * This method runs just before the main WP_Query class is executed
 	 *
 	 * @return void
 	 * @since 4.0
-	 *
 	 */
 	public function process_pdf_endpoint() {
 
@@ -251,8 +253,6 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		if ( empty( $GLOBALS['wp']->query_vars['gpdf'] ) || empty( $GLOBALS['wp']->query_vars['pid'] ) || empty( $GLOBALS['wp']->query_vars['lid'] ) ) {
 			return null;
 		}
-
-		$this->prevent_index();
 
 		$pid    = $GLOBALS['wp']->query_vars['pid'];
 		$lid    = (int) $GLOBALS['wp']->query_vars['lid'];
@@ -283,7 +283,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	 *
 	 * @return void
 	 * @since 4.0
-	 *
+	 * @deprecated 4.0 Added for backwards compatibility with v3 PDF links, but ideally should not be used
 	 */
 	public function process_legacy_pdf_endpoint() {
 
@@ -292,7 +292,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 			return null;
 		}
 
-		$this->prevent_index();
+		_doing_it_wrong( __METHOD__, 'Legacy PDF URLs are deprecated. Replace with the [gravitypdf] shortcode or PDF merge tags. See https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags for usage instructions.', '4.0' );
 
 		$config = [
 			'lid'      => (int) explode( ',', $_GET['lid'] )[0],
@@ -302,13 +302,6 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 			'action'   => isset( $_GET['download'] ) ? 'download' : 'view',
 		];
 		/* phpcs:enable */
-
-		$this->log->notice(
-			'Processing Legacy PDF endpoint.',
-			[
-				'config' => $config,
-			]
-		);
 
 		/* Attempt to find a valid config */
 		$pid = $this->model->get_legacy_config( $config );
@@ -321,6 +314,16 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		$GLOBALS['wp']->query_vars['gpdf'] = 1;
 		$GLOBALS['wp']->query_vars['pid']  = $pid;
 		$GLOBALS['wp']->query_vars['lid']  = $config['lid'];
+
+		$this->log->notice(
+			'Processing Legacy PDF endpoint.',
+			[
+				'config' => $config,
+				'pid'    => $pid,
+			]
+		);
+
+		$this->log->warning( 'Legacy PDF URLs are deprecated. Replace with the [gravitypdf] shortcode or PDF merge tags. See https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags for usage instructions.' );
 
 		/* Send to our model to handle validation / authentication */
 		do_action( 'gfpdf_legacy_pre_view_or_download_pdf', $config['lid'], $pid, $config['action'] );
@@ -338,6 +341,13 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	public function add_pre_pdf_hooks() {
 		add_filter( 'wp_kses_allowed_html', [ $this->view, 'allow_pdf_html' ] );
 		add_filter( 'safe_style_css', [ $this->view, 'allow_pdf_css' ] );
+
+		$this->misc->maybe_load_gf_entry_detail_class(); /* Backwards compatible for legacy templates */
+
+		/* Gravity Wiz Populate Anything support */
+		if ( function_exists( 'gp_populate_anything' ) ) {
+			$this->model->enable_gp_populate_anything();
+		}
 	}
 
 	/**
@@ -346,16 +356,38 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	public function remove_pre_pdf_hooks() {
 		remove_filter( 'wp_kses_allowed_html', [ $this->view, 'allow_pdf_html' ] );
 		remove_filter( 'safe_style_css', [ $this->view, 'allow_pdf_css' ] );
+
+		/* Gravity Wiz Populate Anything support */
+		if ( function_exists( 'gp_populate_anything' ) ) {
+			$this->model->disable_gp_populate_anything();
+		}
 	}
 
 	/**
-	 * Prevent the PDF Endpoints being indexed
+	 * Actions / hooks to run prior to streaming PDF to the browser
+	 * These hooks will not be run when sending notifications, using GPDFAPI::create_pdf(),
 	 *
-	 * @since 5.2
+	 * @return void
+	 *
+	 * @since 6.12
 	 */
-	public function prevent_index() {
-		if ( ! headers_sent() ) {
-			header( 'X-Robots-Tag: noindex, nofollow', true );
+	protected function add_pre_view_or_download_pdf_hooks( $form, $entry, $settings ) {
+		$this->prevent_index();
+
+		/*
+		 * Support ?data=1 helper parameter
+		 * See https://docs.gravitypdf.com/v6/developers/helper-parameters#data1
+		 */
+		if ( $this->view->maybe_view_form_data() ) {
+			$this->view->view_form_data( \GPDFAPI::get_form_data( $entry['id'] ) );
+		}
+
+		/*
+		 * Support ?html=1 helper parameter
+		 * See https://docs.gravitypdf.com/v6/developers/helper-parameters#html1
+		 */
+		if ( rgget( 'html' ) && Debug::is_enabled_and_can_view() ) {
+			add_filter( 'gfpdf_override_pdf_bypass', '__return_true' );
 		}
 	}
 
@@ -363,30 +395,131 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	 * Disables the Siteground HTML Minifier when generating PDFs for the browser
 	 *
 	 * @since 5.1.5
-	 *
-	 * @see   https://github.com/GravityPDF/gravity-pdf/issues/863
+	 * @see https://github.com/GravityPDF/gravity-pdf/issues/863
+	 * @deprecated 6.12 All buffers are auto-closed before a PDF is sent to the browser
 	 */
 	public function sgoptimizer_html_minification_fix() {
-		if ( class_exists( '\SiteGround_Optimizer\Minifier\Minifier' ) ) {
+		_doing_it_wrong( __METHOD__, 'This method has been removed and no alternative is available.', '6.12' );
+	}
 
-			/* Remove the shutdown buffer and manually close an open buffers */
-			$minifier = Minifier::get_instance();
-			remove_action( 'shutdown', [ $minifier, 'end_html_minifier_buffer' ] );
+	/**
+	 * Modify the form object specifically for the PDF request
+	 *
+	 * @param array $form
+	 * @param array $entry
+	 * @param string $source
+	 *
+	 * @return array
+	 *
+	 * @since 6.12
+	 */
+	protected function add_current_form_object_hooks( $form, $entry, $source ) {
+		if ( ! isset( $form['id'] ) ) {
+			return $form;
+		}
 
-			while ( ob_get_level() > 0 ) {
-				ob_end_clean();
-			}
+		/* Make Page fields first class citizens in the form object */
+		$form = $this->model->register_page_fields( $form );
+
+		/* Gravity Perks Conditional Logic Date Fields support */
+		if ( method_exists( 'GWConditionalLogicDateFields', 'convert_conditional_logic_date_field_values' ) ) {
+			$form = \GWConditionalLogicDateFields::convert_conditional_logic_date_field_values( $form );
+		}
+
+		/* Gravity Perks Populate Anything support */
+		if ( function_exists( 'gp_populate_anything' ) ) {
+			$form = $this->model->gp_populate_anything_hydrate_form( $form, $entry );
+		}
+
+		return $form;
+	}
+
+	/**
+	 * Modify the PDF settings specifically for the PDF request
+	 *
+	 * @param array $pdf_settings
+	 * @param array $form
+	 * @param array $entry
+	 *
+	 * @return array
+	 *
+	 * @since 6.12
+	 */
+	protected function add_current_pdf_settings_object_hooks( $pdf_settings, $form, $entry ) {
+		$pdf_settings = $this->model->apply_backwards_compatibility_filters( $pdf_settings, $entry );
+
+		return $pdf_settings;
+	}
+
+	/**
+	 * A debugging tool that will output the HTML mark-up for the PDF to the browser
+	 *
+	 * Use ?html=1 to active when the website is in development/staging mode and the current logged-in
+	 * user has appropriate capabilities. To easily see the raw source code on screen use ?html=1&raw=1
+	 *
+	 * @param string     $html
+	 * @param array      $form
+	 * @param array      $entry
+	 * @param array      $pdf_settings
+	 * @param Helper_PDF $helper_pdf
+	 *
+	 * @return string
+	 *
+	 * @since    6.12
+	 *
+	 * @internal was originally included in \GFPDF\Helper\Helper_PDF::maybe_display_raw_html()
+	 * @link https://docs.gravitypdf.com/v6/developers/helper-parameters#html1
+	 */
+	protected function add_view_html_debugger( $html, $form, $entry, $pdf_settings, $helper_pdf ) {
+		if ( ! is_string( $html ) ) {
+			return $html;
+		}
+
+		if ( ! rgget( 'html' ) ) {
+			return $html;
+		}
+
+		if ( ! Debug::is_enabled_and_can_view() ) {
+			return $html;
+		}
+
+		$html = apply_filters( 'gfpdf_pre_html_browser_output', $html, $pdf_settings, $entry, $form, $helper_pdf );
+
+		if ( rgget( 'raw' ) ) {
+			echo '<pre><code>';
+			echo htmlspecialchars( $html ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */
+			echo '</code></pre>';
+		} else {
+			echo $html; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */
+		}
+
+		exit;
+	}
+
+	/**
+	 * Try to prevent the PDF being indexed or cached by the web server
+	 *
+	 * @since 5.2
+	 * @since 6.12 Set DONOTCACHEPAGE constant (brought forward in the request cycle)
+	 */
+	public function prevent_index() {
+		if ( ! headers_sent() ) {
+			header( 'X-Robots-Tag: noindex, nofollow', true );
+		}
+
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
 		}
 	}
 
 	/**
-	 * Output PDF error to user
+	 * Display appropriate error to user when PDF cannot be display
 	 *
-	 * @param Object $error The WP_Error object
+	 * @param \WP_Error $error The WP_Error object
 	 *
 	 * @since 4.0
 	 */
-	private function pdf_error( $error ) {
+	protected function pdf_error( $error ) {
 
 		$this->log->error(
 			'PDF Generation Error.',
@@ -421,7 +554,41 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		if ( $this->gform->has_capability( 'gravityforms_view_settings' ) || in_array( $error->get_error_code(), $whitelist_errors, true ) ) {
 			wp_die( esc_html( $error->get_error_message() ), $status_code ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} else {
-			wp_die( esc_html__( 'There was a problem generating your PDF', 'gravity-forms-pdf-extended' ), $status_code ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			wp_die( esc_html__( 'There was a problem creating the PDF', 'gravity-forms-pdf-extended' ), $status_code ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
+	}
+
+	/**
+	 * If Nested Form fields are included in the form, include the child entries in the cache hash.
+	 * This will auto-invalidate the parent PDF when the child entry is modified
+	 *
+	 * @param array $data Data to hash
+	 * @param array $form Form object
+	 * @param array $entry Entry object
+	 * @param array $pdf_settings PDF object
+	 *
+	 * @return array
+	 *
+	 * @since 6.12
+	 */
+	protected function included_nested_forms_in_cache_hash( $data, $form, $entry, $pdf_settings ) {
+		if ( empty( $entry['id'] ) ) {
+			return $data;
+		}
+
+		if ( ! class_exists( '\GPNF_Entry' ) ) {
+			return $data;
+		}
+
+		$parent_entry  = new \GPNF_Entry( $entry );
+		$child_entries = $parent_entry->get_child_entries();
+
+		if ( empty( $child_entries ) ) {
+			return $data;
+		}
+
+		$data['nested_form_entries'] = $child_entries;
+
+		return $data;
 	}
 }

--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -54,6 +54,11 @@ class Controller_Upgrade_Routines {
 			$this->update_background_processing_values();
 			$this->upgrade_custom_fonts();
 		}
+
+		/* Remove scheduled event(s) so the event can be reregistered with a new frequency */
+		if ( version_compare( $current_version, '6.12.0', '>=' ) && version_compare( $old_version, '6.12.0', '<' ) ) {
+			wp_clear_scheduled_hook( 'gfpdf_cleanup_tmp_dir' );
+		}
 	}
 
 	/**

--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -721,12 +721,11 @@ class Helper_Misc {
 	 * @return void
 	 *
 	 * @since 4.0
+	 *
+	 * @deprecated 6.12 compatibility code no longer required
 	 */
 	public function maybe_add_multicurrency_support() {
-		if ( class_exists( 'GFMultiCurrency' ) && method_exists( 'GFMultiCurrency', 'admin_pre_render' ) ) {
-			$currency = GFMultiCurrency::init();
-			add_filter( 'gform_form_post_get_meta', [ $currency, 'admin_pre_render' ] );
-		}
+		_doing_it_wrong( __METHOD__, 'This method has been removed and no alternative is available.', '6.12' );
 	}
 
 	/**

--- a/src/Model/Model_Install.php
+++ b/src/Model/Model_Install.php
@@ -303,23 +303,20 @@ class Model_Install extends Helper_Abstract_Model {
 					$this->notices->add_error( sprintf( esc_html__( 'Gravity PDF does not have write permission to the %s directory. Contact your web hosting provider to fix the issue.', 'gravity-forms-pdf-extended' ), '<code>' . $this->misc->relative_path( $dir ) . '</code>' ) );
 				}
 			}
-		}
 
-		/* create blank index file in all folders to prevent web servers listing the entire directory */
-		if ( is_dir( $this->data->template_location ) && ! is_file( $this->data->template_location . 'index.html' ) ) {
-			GFCommon::recursive_add_index_file( $this->data->template_location );
+			/* create blank index file in all folders to prevent web servers listing the entire directory */
+			if ( ! is_file( trailingslashit( $dir ) . 'index.html' ) ) {
+				file_put_contents( trailingslashit( $dir ) . 'index.html', '' );
+			}
 		}
 
 		/* create deny htaccess file to prevent direct access to files */
-		if ( is_dir( $this->data->template_tmp_location ) ) {
-			if ( ! is_file( $this->data->template_tmp_location . 'index.html' ) ) {
-				GFCommon::recursive_add_index_file( $this->data->template_tmp_location );
-			}
-
-			if ( ! is_file( $this->data->template_tmp_location . '.htaccess' ) ) {
-				$this->log->notice( 'Create Apache .htaccess Security file' );
-				file_put_contents( $this->data->template_tmp_location . '.htaccess', 'deny from all' );
-			}
+		if (
+			is_dir( $this->data->template_tmp_location ) &&
+			! is_file( $this->data->template_tmp_location . '.htaccess' )
+		) {
+			$this->log->notice( 'Create Apache .htaccess Security file' );
+			file_put_contents( $this->data->template_tmp_location . '.htaccess', 'deny from all' );
 		}
 	}
 

--- a/src/Model/Model_Shortcodes.php
+++ b/src/Model/Model_Shortcodes.php
@@ -44,10 +44,10 @@ class Model_Shortcodes extends Helper_Abstract_Pdf_Shortcode {
 	 *
 	 * @since    4.0
 	 *
-	 * @internal Deprecated in 5.2. Use self::process()
+	 * @internal Deprecated in 5.2. Use Model_Shortcodes::process()
 	 */
 	public function gravitypdf( $attributes ) {
-		_doing_it_wrong( __METHOD__, esc_html__( 'This method has been superseded by self::process()', 'gravity-forms-pdf-extended' ), '5.2' );
+		_doing_it_wrong( __METHOD__, 'This method has been replaced by Model_Shortcodes::process()', '5.2' );
 
 		return $this->process( $attributes );
 	}

--- a/src/Statics/Cache.php
+++ b/src/Statics/Cache.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace GFPDF\Statics;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages the directory structure for the temporary PDF cache
+ *
+ * @since 6.12.0
+ */
+class Cache {
+
+	/**
+	 * @var string|null Holds the cache directory path
+	 * @since 6.12.0
+	 */
+	protected static $template_tmp_location = null;
+
+	/**
+	 * Get the unique directory path for the current PDF
+	 *
+	 * @param array $form         The form object
+	 * @param array $entry        The entry object
+	 * @param array $pdf_settings The PDF object/settings
+	 *
+	 * @return string
+	 *
+	 * @since 6.12.0
+	 */
+	public static function get_path( $form, $entry, $pdf_settings ) {
+		return static::get_basepath() . static::get_hash( $form, $entry, $pdf_settings ) . '/';
+	}
+
+	/**
+	 * Get and set the cache directory basepath
+	 *
+	 * @return string
+	 * @since 6.12.0
+	 */
+	protected static function get_basepath() {
+		if ( static::$template_tmp_location !== null ) {
+			return static::$template_tmp_location;
+		}
+
+		$data      = \GPDFAPI::get_data_class();
+		$base_path = $data->template_tmp_location;
+		if ( is_multisite() ) {
+			$base_path .= get_current_blog_id();
+		}
+
+		static::$template_tmp_location = trailingslashit( $base_path ) . 'cache/';
+
+		/* Create directory on disk if it does not exist */
+		if ( ! is_dir( static::$template_tmp_location ) ) {
+			if ( wp_mkdir_p( static::$template_tmp_location ) ) {
+				file_put_contents( static::$template_tmp_location . 'index.html', '' );
+			}
+		}
+
+		return static::$template_tmp_location;
+	}
+
+	/**
+	 * Calculate a unique hash based on the form/entry/pdf objects
+	 *
+	 * @param array $form         The form object
+	 * @param array $entry        The entry object
+	 * @param array $pdf_settings The PDF object/settings
+	 *
+	 * @return string
+	 *
+	 * @internal if $form, $entry, $pdf_settings, user ID, site ID, or template files are changed a new hash and PDF will be generated
+	 *
+	 * @since    6.12.0
+	 */
+	public static function get_hash( $form, $entry, $pdf_settings ) {
+
+		/*
+		 * Standardize field properties that may be added dynamically when fields are processed
+		 * for the first run of a PDF. When Gravity Forms accesses properties that don't exist
+		 * in a GF_Field object, it adds the value automatically and sets it to an empty string.
+		 */
+		array_map(
+			function( $field ) {
+				/** @var \GF_Field $field */
+				/* Set when accessing \GFCommon::selection_display() */
+				if ( in_array( $field->get_input_type(), [ 'checkbox', 'radio', 'select' ], true ) ) {
+					$field->enablePrice;
+				}
+
+				/* Set when accessing \GF_Fields::get_allowable_tags() */
+				if ( $field->get_input_type() === 'section' ) {
+					$field->form_id;
+				}
+
+				/* Set the `use_admin_label` context for all fields */
+				$field->set_context_property( 'use_admin_label', $field->get_context_property( 'use_admin_label' ) );
+			},
+			$form['fields']
+		);
+
+		/*
+		 * Ignore specific entry meta that is considered unimportant to PDFs
+		 */
+		$ignored_entry_meta = apply_filters( 'gfpdf_cache_hash_ignored_entry_meta', [ 'is_read', 'is_starred', 'is_approved', 'status', 'source_url', 'user_agent' ], $form, $entry, $pdf_settings );
+		foreach ( $ignored_entry_meta as $meta ) {
+			unset( $entry[ $meta ] );
+		}
+
+		/* Add last modified date of template files to hash */
+		$template    = \GPDFAPI::get_templates_class();
+		$template_id = $pdf_settings['template'] ?? '';
+
+		try {
+			$template_path       = $template->get_template_path_by_id( $template_id );
+			$template_timestamps = filemtime( $template_path );
+		} catch ( \Exception $e ) {
+			$template_timestamps = 0;
+		}
+
+		/* Include config template timestamp if it exists */
+		try {
+			$template_config_path = $template->get_config_path_by_id( $template_id );
+			$template_timestamps .= filemtime( $template_config_path );
+		} catch ( \Exception $e ) {
+			/* do nothing */
+		}
+
+		/* Build an array of unique data relevant to the current PDF */
+		$unique_array = apply_filters(
+			'gfpdf_cache_hash_array',
+			[
+				'site_id'               => get_current_blog_id(),
+				'user_id'               => get_current_user_id(),
+				'fields'                => $form['fields'],
+				'entry'                 => $entry,
+				'pdf_settings'          => $pdf_settings,
+				'template_last_updated' => $template_timestamps,
+			],
+			$form,
+			$entry,
+			$pdf_settings
+		);
+
+		/* Generate the hash based on that unique data */
+		$hash_prefix = static::get_hash_prefix( $form, $entry, $pdf_settings );
+		$hash        = wp_hash( wp_json_encode( $unique_array ) );
+
+		return sprintf( '%s-%s', $hash_prefix, $hash );
+	}
+
+	/**
+	 * Gets the easily-identifiable prefix to add before the hash
+	 *
+	 * @param array $form         The form object
+	 * @param array $entry        The entry object
+	 * @param array $pdf_settings The PDF object/settings
+	 *
+	 * @return string
+	 *
+	 * @since 6.12
+	 */
+	protected static function get_hash_prefix( $form, $entry, $pdf_settings ) {
+		return sprintf(
+			's%1$d-f%2$d-e%3$d-p%4$s',
+			get_current_blog_id(),
+			$form['id'] ?? 0,
+			$entry['id'] ?? 0,
+			$pdf_settings['id'] ?? '',
+		);
+	}
+}

--- a/src/Statics/Debug.php
+++ b/src/Statics/Debug.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace GFPDF\Statics;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @since 6.12.0
+ */
+class Debug {
+
+	/**
+	 * Checks if the WP site is in debug mode
+	 *
+	 * Currently, debug mode is considered on if the PDF Debug Mode setting is explicitly enabled
+	 * or the WP environment is not set to production
+	 *
+	 * @return bool
+	 *
+	 * @since 6.12
+	 */
+	public static function is_enabled(): bool {
+		$options = \GPDFAPI::get_options_class();
+
+		$pdf_debug_mode            = $options->get_option( 'debug_mode', 'No' ) === 'Yes';
+		$wp_production_environment = ! function_exists( 'wp_get_environment_type' ) || wp_get_environment_type() === 'production';
+
+		return $pdf_debug_mode || ! $wp_production_environment;
+	}
+
+	/**
+	 * Check the logged-in user has a specific capability which can view the log info
+	 *
+	 * @return bool
+	 *
+	 * @since 6.12
+	 */
+	public static function can_view(): bool {
+		$gform = \GPDFAPI::get_form_class();
+
+		return $gform->has_capability( 'gravityforms_logging' );
+
+	}
+
+	/**
+	 * Verify debug mode is enabled and the user can view the log info
+	 *
+	 * @return bool
+	 *
+	 * @since 6.12
+	 */
+	public static function is_enabled_and_can_view(): bool {
+		return static::is_enabled() && static::can_view();
+	}
+}

--- a/src/Statics/Queue_Callbacks.php
+++ b/src/Statics/Queue_Callbacks.php
@@ -31,20 +31,26 @@ class Queue_Callbacks {
 	/**
 	 * Generate and save a PDF to disk
 	 *
-	 * @param $entry_id
-	 * @param $pdf_id
+	 *  @param int    $entry_id Entry ID to process
+	 *  @param string $pdf_id   PDF ID to process
+	 *  @param int    $user_id  User ID who triggered the queue
 	 *
 	 * @throws Exception
 	 *
 	 * @since 5.0
 	 */
-	public static function create_pdf( $entry_id, $pdf_id ) {
+	public static function create_pdf( $entry_id, $pdf_id, $user_id = 0 ) {
 		$log = GPDFAPI::get_log_class();
 
+		/* Masquerade as the user ID who scheduled the queue so caching and the {user} merge tag works correctly */
+		$backup_user_id = get_current_user_id();
+		wp_set_current_user( $user_id );
+
 		/* For performance, only generate the PDF if it does not currently exist on disk */
-		add_filter( 'gfpdf_override_pdf_bypass', '__return_false', 20 );
 		$pdf = GPDFAPI::create_pdf( $entry_id, $pdf_id );
-		remove_filter( 'gfpdf_override_pdf_bypass', '__return_false', 20 );
+
+		/* Reset existing user */
+		wp_set_current_user( $backup_user_id );
 
 		if ( is_wp_error( $pdf ) ) {
 			$log->error(
@@ -64,14 +70,15 @@ class Queue_Callbacks {
 	/**
 	 * Send a Gravity Forms notification
 	 *
-	 * @param int   $form_id
-	 * @param int   $entry_id
-	 * @param array $notification
+	 * @param int    $entry_id     Entry ID to process
+	 * @param string $pdf_id       PDF ID to process
+	 * @param array  $notification Gravity Forms Notification to send
+	 * @param int    $user_id      User ID who triggered the queue
 	 *
 	 * @throws Exception
 	 * @since 5.0
 	 */
-	public static function send_notification( $form_id, $entry_id, $notification ) {
+	public static function send_notification( $form_id, $entry_id, $notification, $user_id = 0 ) {
 		$log   = GPDFAPI::get_log_class();
 		$gform = GPDFAPI::get_form_class();
 
@@ -96,7 +103,14 @@ class Queue_Callbacks {
 			throw new Exception();
 		}
 
+		/* Masquerade as the user ID who scheduled the queue so caching and the {user} merge tag works correctly */
+		$backup_user_id = get_current_user_id();
+		wp_set_current_user( $user_id );
+
 		GFCommon::send_notification( $notification, $form, $entry );
+
+		/* Reset existing user */
+		wp_set_current_user( $backup_user_id );
 	}
 
 	/**
@@ -108,13 +122,13 @@ class Queue_Callbacks {
 	 * @throws Exception
 	 *
 	 * @since 5.0
+	 * @deprecated 6.12 Caching layer + auto-purge added
 	 */
 	public static function cleanup_pdfs( $form_id, $entry_id ) {
-		$gform     = GPDFAPI::get_form_class();
-		$data      = GPDFAPI::get_data_class();
-		$misc      = GPDFAPI::get_misc_class();
-		$templates = GPDFAPI::get_templates_class();
-		$log       = GPDFAPI::get_log_class();
+		_doing_it_wrong( __METHOD__, 'This method is deprecated and no alternative is available. The temporary cache is automatically cleaned every hour using the WP Cron.', '6.12' );
+
+		$gform = GPDFAPI::get_form_class();
+		$log   = GPDFAPI::get_log_class();
 
 		/** @var Model_PDF $model_pdf */
 		$model_pdf = GPDFAPI::get_mvc_class( 'Model_PDF' );

--- a/src/deprecated.php
+++ b/src/deprecated.php
@@ -680,7 +680,7 @@ class GFPDF_Core_Model extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function gfpdfe_save_pdf( $entry, $form ) {
-		$pdfs = GPDFAPI::get_form_pdfs( $form['id'] );
+		$pdfs = GPDFAPI::get_entry_pdfs( $entry['id'] );
 
 		if ( ! is_wp_error( $pdfs ) ) {
 			foreach ( $pdfs as $pdf ) {

--- a/tests/e2e/advanced-checks/confirmation-shortcode.test.js
+++ b/tests/e2e/advanced-checks/confirmation-shortcode.test.js
@@ -41,7 +41,7 @@ test('should check shortcode confirmation type TEXT is working correctly', async
 
   // Assertions
   await t
-    .expect(downloadLogger.contains(r => r.response.headers['content-disposition'] === 'attachment; filename="Sample.pdf"')).ok()
+    .expect(downloadLogger.contains(r => r.response.headers['content-disposition'] === 'attachment; filename="Sample.pdf"; filename*=utf-8\'\'Sample.pdf')).ok()
     .expect(downloadLogger.contains(r => r.response.headers['content-type'] === 'application/pdf')).ok()
 })
 
@@ -96,7 +96,7 @@ test('should check if the shortcode confirmation type PAGE is working correctly'
 
   // Assertions
   await t
-    .expect(downloadLogger.contains(r => r.response.headers['content-disposition'] === 'attachment; filename="Sample.pdf"')).ok()
+    .expect(downloadLogger.contains(r => r.response.headers['content-disposition'] === 'attachment; filename="Sample.pdf"; filename*=utf-8\'\'Sample.pdf')).ok()
     .expect(downloadLogger.contains(r => r.response.headers['content-type'] === 'application/pdf')).ok()
 })
 
@@ -125,7 +125,7 @@ test('should check if the shortcode confirmation type REDIRECT download is worki
 
   // Assertions
   await t
-    .expect(downloadLogger.contains(r => r.response.headers['content-disposition'] === 'attachment; filename="Sample.pdf"')).ok()
+    .expect(downloadLogger.contains(r => r.response.headers['content-disposition'] === 'attachment; filename="Sample.pdf"; filename*=utf-8\'\'Sample.pdf')).ok()
     .expect(downloadLogger.contains(r => r.response.headers['content-type'] === 'application/pdf')).ok()
 })
 

--- a/tests/e2e/utilities/page-model/helpers/page.js
+++ b/tests/e2e/utilities/page-model/helpers/page.js
@@ -36,7 +36,7 @@ class Page {
       .click(this.addBlockIcon)
       .typeText(this.searchBlock, 'paragraph', { paste: true })
       .click(this.paragraphButton)
-      .typeText(Selector('p.is-selected'), 'Content', { paste: true })
+      .typeText(Selector('.is-root-container p:last-of-type'), 'Content', { paste: true })
       .click(this.publishButton)
       .click(this.confirmPublishButton)
   }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -7,6 +7,9 @@ if ( function_exists( 'xdebug_disable' ) ) {
 	xdebug_disable();
 }
 
+/* Use different DB tables for unit tests, so we don't mess with the E2E environment */
+putenv( 'WORDPRESS_TABLE_PREFIX=phpunit_' );
+
 /**
  * Override certain pluggable functions so we can unit test them correctly
  *

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
@@ -5,6 +5,7 @@ namespace GFPDF\Tests;
 use Exception;
 use GFPDF\Controller\Controller_Pdf_Queue;
 use GFPDF\Helper\Helper_Pdf_Queue;
+use GFPDF\Statics\Cache;
 use GFPDF\Statics\Queue_Callbacks;
 use WP_UnitTestCase;
 
@@ -278,28 +279,26 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 		$results                             = $this->create_form_and_entries();
 		$entry                               = $results['entry'];
 		$form                                = $results['form'];
-		$form['notifications']['1254123223'] = $form['notifications']['54bca349732b8'];
+
+		/* Set up active and inactive notification */
+		$form['notifications']['1254123223'] = [ 'id' => '1254123223', 'isActive' => true, 'event' => 'form_submission' ];
+		$form['notifications']['2222222222'] = [ 'id' => '2222222222', 'isActive' => false, 'event' => 'form_submission' ];
+		$form['gfpdf_form_settings']['556690c67856b']['notification'][] = '1254123223';
+
 		$form['notifications']['54bca349732b8']['isActive'] = true;
 
-		foreach( $form['notifications'] as $notification ) {
+		foreach ( $form['notifications'] as $notification ) {
 			$this->controller->maybe_disable_submission_notifications( false, $notification, $form, $entry );
 		}
-		
+
 		$this->controller->queue_async_form_submission_tasks( $entry, $form );
 
 		$queue = $this->queue_mock->get_data();
 
-		$this->assertCount( 3, $queue[0] );
-		$this->assertCount( 3, $queue[1] );
-		$this->assertCount( 1, $queue[2] );
-
-		$actions = [ 'create_pdf', 'create_pdf', 'send_notification' ];
-		for ( $i = 0; $i < 3; $i++ ) {
-			$this->assertStringContainsString( $actions[ $i ], $queue[0][ $i ]['func'] );
-			$this->assertStringContainsString( $actions[ $i ], $queue[1][ $i ]['func'] );
-		}
-
-		$this->assertStringContainsString( 'cleanup_pdfs', $queue[2][0]['func'] );
+		$this->assertStringContainsString( 'create_pdf', $queue[0][0]['func'] );
+		$this->assertStringContainsString( 'create_pdf', $queue[0][1]['func'] );
+		$this->assertStringContainsString( 'send_notification', $queue[0][2]['func'] );
+		$this->assertStringContainsString( 'send_notification', $queue[0][3]['func'] );
 	}
 
 	/**
@@ -322,14 +321,11 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 		$queue = $this->queue_mock->get_data();
 
 		$this->assertCount( 3, $queue[0] );
-		$this->assertCount( 1, $queue[1] );
 
 		$actions = [ 'create_pdf', 'create_pdf', 'send_notification' ];
 		for ( $i = 0; $i < 3; $i++ ) {
 			$this->assertStringContainsString( $actions[ $i ], $queue[0][ $i ]['func'] );
 		}
-
-		$this->assertStringContainsString( 'cleanup_pdfs', $queue[1][0]['func'] );
 	}
 
 	/**
@@ -343,12 +339,13 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 						 ->method( 'dispatch' )
 						 ->willReturn( $this->queue_mock );
 
-		$this->controller->queue_dispatch_resend_notification_tasks( [ 'id' => 0 ], [ 'id' => 0 ] );
+
+		$this->controller->queue_dispatch_resend_notification_tasks( [ 'id' => 0 ], [ 'id' => 0, 'form_id' => 0 ] );
 
 		$this->assertSame( 0, $spy->getInvocationCount() );
 
 		$this->queue_mock->push_to_queue( 'item' );
-		$this->controller->queue_dispatch_resend_notification_tasks( [ 'id' => 0 ], [ 'id' => 0 ]);
+		$this->controller->queue_dispatch_resend_notification_tasks( [ 'id' => 0 ], [ 'id' => 0, 'form_id' => 0 ]);
 
 		$this->assertSame( 1, $spy->getInvocationCount() );
 	}
@@ -359,21 +356,26 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 	 * @since 5.0
 	 */
 	public function test_cleanup_pdfs() {
-		global $gfpdf;
+		$this->setExpectedIncorrectUsage( 'GFPDF\Statics\Queue_Callbacks::cleanup_pdfs');
+		$this->setExpectedIncorrectUsage( 'GFPDF\Model\Model_PDF::cleanup_pdf');
+
+		$form_class = \GPDFAPI::get_form_class();
 
 		$results = $this->create_form_and_entries();
 		$entry   = $results['entry'];
-		$form    = $results['form'];
+		$form    = $form_class->get_form( $results['form']['id'] );  /* get from the database so the date created is accurate */
 
-		$path = $gfpdf->data->template_tmp_location . $entry['form_id'] . $entry['id'] . '556690c67856b/';
+		$path = Cache::get_path( $form, $entry, $form['gfpdf_form_settings']['556690c67856b'] );
+		$file   = "test-{$form['id']}.pdf";
+
 		wp_mkdir_p( $path );
-		$test_file = $path . 'file';
-		touch( $test_file );
-		$this->assertFileExists( $test_file );
+		touch( $path . $file );
+
+		$this->assertFileExists( $path . $file );
 
 		Queue_Callbacks::cleanup_pdfs( $form['id'], $entry['id'] );
 
-		$this->assertFileDoesNotExist( $test_file );
+		$this->assertFileDoesNotExist( $path . $file );
 		$this->assertFileDoesNotExist( $path );
 	}
 }

--- a/tests/phpunit/unit-tests/Statics/Test_Cache.php
+++ b/tests/phpunit/unit-tests/Statics/Test_Cache.php
@@ -1,0 +1,74 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Statics;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group     statics
+ */
+class Test_Cache extends WP_UnitTestCase {
+
+	public function test_get_hash() {
+		$results = $this->create_form_and_entries();
+
+		$form  = $results['form'];
+		$entry = $results['entry'];
+
+		$pdf_settings             = $form['gfpdf_form_settings']['555ad84787d7e'];
+		$pdf_settings['template'] = 'zadani';
+
+		/* Verify the hash is the same when called multiple times with the same inputs */
+		$hash1 = Cache::get_hash( $form, $entry, $pdf_settings );
+		$hash2 = Cache::get_hash( $form, $entry, $pdf_settings );
+
+		$this->assertEquals( $hash1, $hash2 );
+
+		/* Verify the hash changes when the input changes */
+		$pdf_settings['active'] = false;
+
+		$hash3 = Cache::get_hash( $form, $entry, $pdf_settings );
+
+		$this->assertNotEquals( $hash3, $hash2 );
+	}
+
+	protected function create_form_and_entries() {
+		global $gfpdf;
+
+		$form  = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+
+		$gfpdf->data->form_settings                = [];
+		$gfpdf->data->form_settings[ $form['id'] ] = $form['gfpdf_form_settings'];
+
+		return [
+			'form'  => $form,
+			'entry' => $entry,
+		];
+	}
+
+	public function test_get_path() {
+		$results = $this->create_form_and_entries();
+
+		$form  = $results['form'];
+		$entry = $results['entry'];
+
+		$pdf_settings             = $form['gfpdf_form_settings']['555ad84787d7e'];
+		$pdf_settings['template'] = 'zadani';
+
+		$hash1 = Cache::get_hash( $form, $entry, $pdf_settings );
+		$path  = Cache::get_path( $form, $entry, $pdf_settings );
+
+		$this->assertStringEndsWith( '/' . $hash1 . '/', $path );
+		$this->assertStringStartsWith( ABSPATH, $path );
+	}
+
+}


### PR DESCRIPTION
## Description

Automatically save PDFs to disk for up to 1 hour, and return the cached copy on subsequent requests (if it exists). This is a smart cache that auto-detects if the form, entry, or PDF settings have been modified and will generate a new PDF if that's the case. 

Manually flushing the cache will be handled in a separate PR, alongside https://github.com/GravityPDF/gravity-pdf/issues/1527

This PR standardizes the PDF generation system so all PDF generation processes (view/download/notification/preview/bulk generate/API) flow through the same set of functions/methods to create the documents and save them to the temporary cache:

```
1. Model_PDF::generate_and_save_pdf()
2. Model_PDF::process_and_save_pdf()
3. Helper_PDF::generate()
4. Helper_PDF::save_pdf()
```

The calling function/method to `Model_PDF::generate_and_save_pdf()` will then determine what to do with the saved PDF. When viewing/downloading documents, the PDF will be read from disk and streamed to the browser with appropriate browser caching headers. When sending notifications, the absolute path to the PDF is passed to wp_mail() as an attachment, when using the API the absolute path is returned etc.

The `View_PDF::generate_pdf()` workflow to view/download PDFs is deprecated and should no longer be used directly, but for backwards compatibility will still work correctly.

## Testing instructions

This is a critical application path and should be thoroughly tested under all conditions to verify everything works as expected:

- [x] Viewing and Downloading PDF
- [x] Receive cached PDF when viewing and downloading PDF again
- [x] Updating form and viewing/downloading PDF for fresh copy
- [x] Updating entry and viewing/downloading PDF for fresh copy
- [x] Updating form PDF settings and viewing/downloading PDF for fresh copy
- [x] ?data=1 helper param
- [x] ?html=1 helper param
- [x] ?print=1 helper param
- [x] All view/download caching and URL options (above) with deprecated legacy PDF endpoint (from v3.0)
- [x] Set up multiple PDFs on a form and attach to multiple notifications. Verify cached copy is used when attaching the same PDF to 2+ notifications
- [x] Resend Notification feature uses cached PDFs when running multiple times
- [x] Resend Notification feature generates new PDFs if the form/entry/PDF settings are modified
- [x] New PDF generated after editing an entry via GravityView / Gravity Wiz / Gravity Flow
- [x] The `gfpdf_post_save_pdf` hook works as expected on form submission
- [x] The `gfpdf_override_pdf_bypass` hook bypasses the cache
- [x] The legacy `save` option works as expected on form submission
- [x] GPDFAPI::create_pdf() API leaves the cache intact when running
- [x] GPDFAPI::create_pdf() API uses cached copy on subsequent requests
- [x] Developer Toolkit PDFs view/download PDF 
- [x] Developer Toolkit PDFs support view/download caching and URL options (above)
- [x] Set up multiple Developer Toolkit PDFs on a form and attach to multiple notifications. Verify cached copy is used when attaching the same PDF to 2+ notifications
- [x] Developer Toolkit Legacy PDFs (with `advanced_template` option on): view/download + notifications (as above)
- [x] PDF Background Processing queue with standard and Developer Toolkit PDFs. Verify cached copy is used when attaching the same PDF to 2+ notifications
- [x] Manually calling `View_PDF::generate_pdf()` will view/download PDF as expected (including all URL params)
- [x] Legacy `gfpdfe_pdf_output_type` filter works
- [x] WP External Links plugin conflict: https://github.com/GravityPDF/gravity-pdf/issues/386
- [x] Weglot plugin conflict: https://github.com/GravityPDF/gravity-pdf/pull/1505
- [x] Siteground Optimizer minification conflict: https://github.com/GravityPDF/gravity-pdf/issues/863
- [x] Auto-purge PDF if associated template/config is updated
- [x] https://github.com/GravityPDF/gravity-pdf/issues/1403
- [x] https://github.com/GravityPDF/gravity-pdf/issues/1370
- [x] Gravity Perks Conditional Logic Date support on product fields
- [x] Gravity Perks Populate Anything support (live merge tags)
- [x] PDF Cached auto-cleaned up every hour by WordPress cron task
- [x] Async email sending e.g. WP Offload SES
- [x] Core Booster - Entry Notes
- [x] Gravity Perks Nested Forms - changes to nested form entries
- [x] PDF for GravityView works as expected
- [x] Enhanced Downloader
- [x] Bulk Generator works as expected
- [x] Previewer works as expected
- [x] PDF to Images works as expected

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
