### PR TITLE
Add get_pdf_filename() to API

### DIFF
--- a/api.php
+++ b/api.php
@@ -352,6 +352,48 @@ final class GPDFAPI {
 	}
 
 	/**
+	 * Retrieve the filename of the PDF document
+	 * The .pdf extension is not returned by default (pass true to the 3rd param)
+	 *
+	 * See https://docs.gravitypdf.com/v6/developers/api/get_pdf_filename/ for more information about this method
+	 *
+	 * @param int    $entry_id          The Gravity Form entry ID
+	 * @param string $pdf_id            The Gravity PDF ID number (the pid number in the URL when viewing a setting in the admin area)
+	 * @param bool   $include_extension Whether to include the .pdf extension in the filename
+	 *
+	 * @return string|WP_Error   Return the filename of the PDF, or a WP_Error on failure
+	 *
+	 * @return string|WP_Error
+	 *
+	 * @since 6.12
+	 */
+	public static function get_pdf_filename( $entry_id, $pdf_id, bool $include_extension ) {
+		$form_class = static::get_form_class();
+
+		/* Get our entry */
+		$entry = $form_class->get_entry( $entry_id );
+		if ( is_wp_error( $entry ) ) {
+			return new WP_Error( 'invalid_entry', esc_html__( 'Make sure to pass in a valid Gravity Forms Entry ID', 'gravity-forms-pdf-extended' ) );
+		}
+
+		/* Get our settings */
+		$setting = static::get_pdf( $entry['form_id'], $pdf_id );
+		if ( is_wp_error( $setting ) ) {
+			return new WP_Error( 'invalid_pdf_setting', esc_html__( 'Could not located the PDF Settings. Ensure you pass in a valid PDF ID.', 'gravity-forms-pdf-extended' ) );
+		}
+
+		/** @var \GFPDF\Model\Model_PDF $pdf */
+		$pdf = static::get_mvc_class( 'Model_PDF' );
+
+		$filename = $pdf->get_pdf_name( $setting, $entry );
+		if ( $include_extension ) {
+			$filename .= '.pdf';
+		}
+
+		return $filename;
+	}
+
+	/**
 	 * Retrieve an array of the global Gravity PDF settings (this doesn't include individual form configuration details - see GPDFAPI::get_form_pdfs)
 	 *
 	 * See https://docs.gravitypdf.com/v6/developers/api/get_plugin_settings/ for more information about this method

--- a/api.php
+++ b/api.php
@@ -352,6 +352,46 @@ final class GPDFAPI {
 	}
 
 	/**
+	 * Retrieve the filename of the PDF document
+	 * The .pdf extension is not returned by default (pass true to the 3rd param)
+	 *
+	 * See https://docs.gravitypdf.com/developers/api/get_pdf_filename/ for more information about this method
+	 *
+	 * @param int    $entry_id          The Gravity Form entry ID
+	 * @param string $pdf_id            The Gravity PDF ID number (the pid number in the URL when viewing a setting in the admin area)
+	 * @param bool   $include_extension Whether to include the .pdf extension in the filename
+	 *
+	 * @return string|WP_Error   Return the filename of the PDF, or a WP_Error on failure
+	 *
+	 * @since 7.0
+	 */
+	public static function get_pdf_filename( $entry_id, $pdf_id, bool $include_extension = false ) {
+		$form_class = self::get_form_class();
+
+		/* Get our entry */
+		$entry = $form_class->get_entry( $entry_id );
+		if ( is_wp_error( $entry ) ) {
+			return new WP_Error( 'invalid_entry', esc_html__( 'Make sure to pass in a valid Gravity Forms Entry ID', 'gravity-pdf' ) );
+		}
+
+		/* Get our settings */
+		$setting = self::get_pdf( $entry['form_id'], $pdf_id );
+		if ( is_wp_error( $setting ) ) {
+			return new WP_Error( 'invalid_pdf_setting', esc_html__( 'Could not located the PDF Settings. Ensure you pass in a valid PDF ID.', 'gravity-pdf' ) );
+		}
+
+		/** @var \GFPDF\Model\Model_PDF $pdf */
+		$pdf = self::get_mvc_class( 'Model_PDF' );
+
+		$filename = $pdf->get_pdf_name( $setting, $entry );
+		if ( $include_extension ) {
+			$filename .= '.pdf';
+		}
+
+		return $filename;
+	}
+
+	/**
 	 * Retrieve an array of the global Gravity PDF settings (this doesn't include individual form configuration details - see GPDFAPI::get_form_pdfs)
 	 *
 	 * See https://docs.gravitypdf.com/v6/developers/api/get_plugin_settings/ for more information about this method

--- a/tests/phpunit/integration/Test_Api.php
+++ b/tests/phpunit/integration/Test_Api.php
@@ -384,4 +384,34 @@ class Test_API extends TestCase {
 
 		$this->assertSame( 'My Single Line Response', $results['field'][1] );
 	}
+
+	/**
+	 * Check we can retrieve the PDF filename, with and without the extension, and that the
+	 * WP_Error paths are returned for invalid entry IDs and invalid PDF IDs.
+	 *
+	 * @since 7.0
+	 */
+	public function test_get_pdf_filename() {
+		$entry_id = $this->entry( 'all-form-fields' )['id'];
+		$pdf_id   = '555ad84787d7e';
+
+		/* The extension is excluded by default */
+		$this->assertSame( 'test', GPDFAPI::get_pdf_filename( $entry_id, $pdf_id ) );
+
+		/* Explicitly excluding the extension matches the default */
+		$this->assertSame( 'test', GPDFAPI::get_pdf_filename( $entry_id, $pdf_id, false ) );
+
+		/* The extension is included when requested */
+		$this->assertSame( 'test.pdf', GPDFAPI::get_pdf_filename( $entry_id, $pdf_id, true ) );
+
+		/* An invalid entry ID returns a WP_Error */
+		$invalid_entry = GPDFAPI::get_pdf_filename( '', $pdf_id );
+		$this->assertInstanceOf( \WP_Error::class, $invalid_entry );
+		$this->assertSame( 'invalid_entry', $invalid_entry->get_error_code() );
+
+		/* A valid entry with an invalid PDF ID returns a WP_Error */
+		$invalid_pdf = GPDFAPI::get_pdf_filename( $entry_id, 'does-not-exist' );
+		$this->assertInstanceOf( \WP_Error::class, $invalid_pdf );
+		$this->assertSame( 'invalid_pdf_setting', $invalid_pdf->get_error_code() );
+	}
 }


### PR DESCRIPTION
## Description

Adds a new public API method, `GPDFAPI::get_pdf_filename()`, for retrieving the generated filename of a PDF without having to render or fetch the document itself.

```php
GPDFAPI::get_pdf_filename( int $entry_id, string $pdf_id, bool $include_extension = false );
```

- Resolves the entry, then the PDF settings for that entry's form, and returns the filename via `Model_PDF::get_pdf_name()` (which applies the configured filename merge tags).
- The `.pdf` extension is omitted by default; pass `true` as the third argument to include it.
- Returns a `WP_Error` for an invalid entry ID (`invalid_entry`) or an invalid/unknown PDF ID (`invalid_pdf_setting`).

## Testing instructions

```php
// Without extension
$name = GPDFAPI::get_pdf_filename( $entry_id, $pdf_id );

// With .pdf extension
$name = GPDFAPI::get_pdf_filename( $entry_id, $pdf_id, true );

// Error paths
GPDFAPI::get_pdf_filename( 0, $pdf_id );        // WP_Error: invalid_entry
GPDFAPI::get_pdf_filename( $entry_id, 'nope' ); // WP_Error: invalid_pdf_setting
```

Confirm the returned filename matches the name produced when the PDF is downloaded/viewed for that entry, and that the merge-tag-based filename settings are reflected.

Or run the PHPUnit coverage:

```bash
yarn test:php -- --filter test_get_pdf_filename
```

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
