### PR TITLE
Fix E2E test after GF update

### DIFF
--- a/tests/e2e/utilities/page-model/helpers/advanced-check.js
+++ b/tests/e2e/utilities/page-model/helpers/advanced-check.js
@@ -48,7 +48,7 @@ class AdvancedCheck {
     this.templateItem = Selector('#the-list').find('tr')
     this.pdfListSection = Selector('.gform-settings__navigation').find('a').withText('PDF')
     this.toggleSwitch = Selector('#the-list').find('.check-column button')
-    this.entryItemSection = Selector('#the-list').find('a').withAttribute('aria-label', 'View this entry')
+    this.entryItemSection = Selector('#the-list').find('td.column-primary')
     this.viewPdfLink = Selector('#the-list').find('a').withText('View PDF')
     this.editLink = Selector('#the-list').find('span').withText('Edit')
     this.conditionalLogicCheckbox = Selector('#gfpdf-fieldset-gfpdf_form_settings_general').find('[id="gfpdf_conditional_logic"]')

--- a/tests/e2e/utilities/page-model/tabs/general-settings.js
+++ b/tests/e2e/utilities/page-model/tabs/general-settings.js
@@ -56,7 +56,7 @@ class General {
     this.saveSettings = Selector('#submit-and-promo-container').find('input')
 
     // PDF entries section
-    this.viewEntryItem = Selector('a').withAttribute('aria-label', 'View this entry')
+    this.viewEntryItem = Selector('#the-list').find('td.column-primary')
   }
 
   async navigateSettingsTab (text) {


### PR DESCRIPTION
## Description

Tweak a selector after a recent Gravity Forms update

## Testing instructions
Let E2E tests run

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
