### PR TITLE
Fix truncated merge tags in HTML attribute when included in PDF setting Rich Text fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://gravitypdf.com/donate-to-plugin/
 Tags: gravity forms, form, contact form, pdf, email
 Requires at least: 5.3
 Tested up to: 6.6
-Stable tag: 6.11.2
+Stable tag: 6.11.3
 Requires PHP: 7.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl.txt
@@ -106,6 +106,9 @@ Gravity PDF can be run on most modern shared web hosting without any issues. It 
 16. A bunch of paid PDF designs are available, as well as additional functionality.
 
 == Changelog ==
+
+= 6.11.3 =
+* Bug: Fix truncated merge tags in HTML attribute when included in PDF setting Rich Text fields
 
 = 6.11.2 =
 * Bug: Resolve race condition by skipping PDF cleanup at the end of form submission process if PDF Background Processing is enabled

--- a/pdf.php
+++ b/pdf.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Gravity PDF
-Version: 6.11.2
+Version: 6.11.3
 Description: Automatically generate highly customizable PDF documents using Gravity Forms.
 Author: Blue Liquid Designs
 Author URI: https://blueliquiddesigns.com.au
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /*
  * Set base constants we'll use throughout the plugin
  */
-define( 'PDF_EXTENDED_VERSION', '6.11.2' ); /* the current plugin version */
+define( 'PDF_EXTENDED_VERSION', '6.11.3' ); /* the current plugin version */
 define( 'PDF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); /* plugin directory path */
 define( 'PDF_PLUGIN_URL', plugin_dir_url( __FILE__ ) ); /* plugin directory url */
 define( 'PDF_PLUGIN_BASENAME', plugin_basename( __FILE__ ) ); /* the plugin basename */

--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -1286,10 +1286,10 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 					 * When outputting rich text, it is important that the merge tags get processed first and then the output
 					 * run through Kses::parse() or Kses::output() to ensure the HTML safe.
 					 */
-					$pattern = '{[^{]*?:(\d+(\.\d+)?)(:(.*?))?}';
-					$value   = preg_replace( "/$pattern/mi", 'telnet://$0', $value );
+					$pattern = '([^{]*?})';
+					$value   = preg_replace( "/=\"\{$pattern\"/mi", '="telnet://$1"', $value );
 					$value   = Kses::parse( $value );
-					$value   = preg_replace( "/telnet:\/\/($pattern)/mi", '$1', $value );
+					$value   = preg_replace( "/=\"telnet:\/\/$pattern\"/mi", '="{$1"', $value );
 				} else {
 					/* Don't encode/decode merge tag before sanitizing */
 					$value = Kses::parse( $value );

--- a/tests/e2e/utilities/page-model/helpers/advanced-check.js
+++ b/tests/e2e/utilities/page-model/helpers/advanced-check.js
@@ -48,7 +48,7 @@ class AdvancedCheck {
     this.templateItem = Selector('#the-list').find('tr')
     this.pdfListSection = Selector('.gform-settings__navigation').find('a').withText('PDF')
     this.toggleSwitch = Selector('#the-list').find('.check-column button')
-    this.entryItemSection = Selector('#the-list').find('a').withAttribute('aria-label', 'View this entry')
+    this.entryItemSection = Selector('#the-list').find('td.column-primary')
     this.viewPdfLink = Selector('#the-list').find('a').withText('View PDF')
     this.editLink = Selector('#the-list').find('span').withText('Edit')
     this.conditionalLogicCheckbox = Selector('#gfpdf-fieldset-gfpdf_form_settings_general').find('[id="gfpdf_conditional_logic"]')

--- a/tests/e2e/utilities/page-model/tabs/general-settings.js
+++ b/tests/e2e/utilities/page-model/tabs/general-settings.js
@@ -56,7 +56,7 @@ class General {
     this.saveSettings = Selector('#submit-and-promo-container').find('input')
 
     // PDF entries section
-    this.viewEntryItem = Selector('a').withAttribute('aria-label', 'View this entry')
+    this.viewEntryItem = Selector('#the-list').find('td.column-primary')
   }
 
   async navigateSettingsTab (text) {

--- a/tests/phpunit/unit-tests/test-options-api.php
+++ b/tests/phpunit/unit-tests/test-options-api.php
@@ -998,14 +998,26 @@ class Test_Options_API extends WP_UnitTestCase {
 
 			[
 				'rich_editor',
-				'<a href="{Field:1}">Link</a> and this {Business Name::2} is another <a class="{Field:3}" href="{pdf:12345789:signed,download}">link</a>',
-				'<a href="{Field:1}">Link</a> and this {Business Name::2} is another <a class="{Field:3}" href="{pdf:12345789:signed,download}">link</a>',
+				'<a href="{Field:1}">Link</a> and this {Business Name::2} is another <a class="{Field:3}" href="{pdf:12345789ABC:signed,download}">link</a>',
+				'<a href="{Field:1}">Link</a> and this {Business Name::2} is another <a class="{Field:3}" href="{pdf:12345789ABC:signed,download}">link</a>',
 			],
 
 			[
 				'rich_editor',
 				'<a href="telnet://{Field:1}">Link</a>',
 				'<a href="telnet://{Field:1}">Link</a>',
+			],
+
+			[
+				'rich_editor',
+				'<a href="{user:user_meta}">Link</a> and this {Business Name::2}',
+				'<a href="{user:user_meta}">Link</a> and this {Business Name::2}',
+			],
+
+			[
+				'rich_editor',
+				'<a href="{embed_url}">Link</a> and this {Business Name::2}',
+				'<a href="{embed_url}">Link</a> and this {Business Name::2}',
 			],
 
 			[


### PR DESCRIPTION
## Description

Only field merge tags were being matched during rich text sanitizing. This adjustment now matches any merge tag with opening and closing `{}`, provided it is the only content included in a HTML attribute.

## Testing instructions
1. Add `<img src="{user:user_profile_picture}" />` to Footer HTML field
2. Save PDF settings
3. Verify the merge tag hasn't been truncated

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
