### PR TITLE
Prevent entry owner viewing PDF if Restrict Owner setting enabled

### DIFF
--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -638,7 +638,7 @@ class Test_PDF extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Check if our logged in user has access to our PDF
+	 * Check if our logged-in user has access to our PDF
 	 *
 	 * @since 4.0
 	 */
@@ -648,11 +648,19 @@ class Test_PDF extends WP_UnitTestCase {
 
 		/* create subscriber and test access */
 		$user_id = $this->factory->user->create();
-		$this->assertIsInt( $user_id );
 		wp_set_current_user( $user_id );
 
 		/* get the results */
 		$results = $this->model->middle_user_capability( true, [ 'id' => 0,  'created_by' => 0 ], [ 'id' => '', ] );
+
+		$this->assertTrue( is_wp_error( $results ) );
+		$this->assertEquals( 'access_denied', $results->get_error_code() );
+
+		/* make subscriber owner of the entry and test access */
+		$this->assertTrue( $this->model->middle_user_capability( true, [ 'id' => 0,  'created_by' => $user_id ], [ 'id' => '', ] ) );
+
+		/* make subscriber owner, but turn on the owner restrict setting and test access */
+		$results = $this->model->middle_user_capability( true, [ 'id' => 0,  'created_by' => $user_id ], [ 'id' => '', 'restrict_owner' => 'Yes' ] );
 
 		$this->assertTrue( is_wp_error( $results ) );
 		$this->assertEquals( 'access_denied', $results->get_error_code() );
@@ -662,9 +670,9 @@ class Test_PDF extends WP_UnitTestCase {
 		$user->remove_role( 'subscriber' );
 		$user->add_role( 'administrator' );
 
-		$this->assertTrue( $this->model->middle_user_capability( true, [ 'id' => 0, 'created_by' => 0 ], [ 'id' => '', ] ) );
+		$this->assertTrue( $this->model->middle_user_capability( true, [ 'id' => 0, 'created_by' => 0 ], [ 'id' => '', 'restrict_owner' => 'Yes'  ] ) );
 
-		/* Remove elevated user privilages and set the default capability 'gravityforms_view_entries' */
+		/* Remove elevated user privileges and set the default capability 'gravityforms_view_entries' */
 		$user->remove_role( 'administrator' );
 		$user->add_role( 'subscriber' );
 


### PR DESCRIPTION
## Description

Update middleware to correctly show an error if the entry owner tries viewing a PDF with the Restrict owner setting enabled and they don't have appropriate capabilities.

## Testing instructions
1. Create PDF on form and turn on Restrict Owner security setting
2. Create new subscriber user on site
3. Login as subscriber 
4. Submit Gravity Form
5. Try view PDF as subscriber (access denied)
6. Turn off Restrict Owner security setting
7. Try view PDF as subscriber again (can see PDF)
8. Logout 
9. Submit form as logged out user
10. Try view PDF as logged out user (access denied)
11. Login as administrator
12. Try view first and second PDFs (can see PDFs)
13. Submit form as administrator
14. Try view PDF (can see PDF)

## Checklist:
- [ ] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
