### PR TITLE
Add PDF Download endpoint

### DIFF
--- a/src/Helper/Helper_Interface_Url_Signer.php
+++ b/src/Helper/Helper_Interface_Url_Signer.php
@@ -42,4 +42,13 @@ interface Helper_Interface_Url_Signer {
 	 * @since 5.2
 	 */
 	public function verify( $url );
+
+	/**
+	 * Verify the signature on the URL of the current request
+	 *
+	 * @return bool
+	 *
+	 * @since 7.0
+	 */
+	public function verify_current_request();
 }

--- a/src/Helper/Helper_Url_Signer.php
+++ b/src/Helper/Helper_Url_Signer.php
@@ -131,6 +131,21 @@ class Helper_Url_Signer implements Helper_Interface_Url_Signer {
 	}
 
 	/**
+	 * Verify the signature on the URL of the current request
+	 *
+	 * @return bool
+	 *
+	 * @since 7.0
+	 */
+	public function verify_current_request() {
+		$protocol = isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://';
+		$domain   = isset( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '';
+		$request  = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+
+		return $this->verify( esc_url_raw( $protocol . $domain . $request ) );
+	}
+
+	/**
 	 * Validate the URL and return the results
 	 *
 	 * @param string $url

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -2453,7 +2453,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @since 5.0
 	 */
 	public function set_watermark_font( $mpdf, $form, $entry, $settings ) {
-		$mpdf->watermark_font = ( isset( $settings['watermark_font'] ) ) ? $settings['watermark_font'] : $settings['font'];
+		$mpdf->watermark_font = $settings['watermark_font'] ?? $settings['font'] ?? $this->options->get_option( 'default_font', 'dejavusanscondensed' );
 
 		return $mpdf;
 	}

--- a/src/Rest/Rest_Download_Pdf.php
+++ b/src/Rest/Rest_Download_Pdf.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace GFPDF\Rest;
+
+use GFPDF\Helper\Helper_Data;
+use GFPDF\Helper\Helper_Form;
+use GFPDF\Model\Model_PDF;
+use GPDFAPI;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @since 6.12
+ */
+class Rest_Download_Pdf {
+
+	/**
+	 * @var string
+	 * @since 6.12
+	 */
+	public const NAMESPACE = Helper_Data::REST_API_BASENAME . 'v1';
+
+	/**
+	 * @var string
+	 * @since 6.12
+	 */
+	public const API_BASE = '/download';
+
+	/**
+	 * @var string[]
+	 * @since 6.12
+	 */
+	public static $endpoints = [
+		'download-pdf' => self::API_BASE . '/(?P<entry>[\d]+)/(?P<pdf>[a-fA-F0-9]{13})',
+	];
+
+	/**
+	 * @var Helper_Form
+	 * @since 6.12
+	 */
+	protected $gform;
+
+	/**
+	 * @param Helper_Form $gform
+	 *
+	 * @since 6.12
+	 */
+	public function __construct( $gform ) {
+		$this->gform = $gform;
+	}
+
+	/**
+	 * @return void
+	 * @since 6.12
+	 */
+	public function init() {
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+	}
+
+	/**
+	 * Register the routes for the API
+	 *
+	 * @return void
+	 * @since 6.12
+	 */
+	public function register_routes() {
+
+		/*
+		 * Routes to list all form PDF settings, or create a new one
+		 */
+		register_rest_route(
+			static::NAMESPACE,
+			static::$endpoints['download-pdf'],
+			[
+				'args' => [
+					'entry' => [
+						'description'       => __( 'The unique identifier for the Gravity Forms entry.', 'gravity-forms-pdf-extended' ),
+						'type'              => 'integer',
+						'required'          => true,
+						'validate_callback' => function( $param, $request ) {
+							$entry = $this->gform->get_entry( $param );
+
+							if ( ! is_wp_error( $entry ) ) {
+								return true;
+							}
+
+							return new WP_Error(
+								'rest_invalid_param',
+								sprintf( __( 'Invalid entry ID %d provided.', 'gravity-forms-pdf-extended' ), $param ),
+								[ 'status' => 400 ]
+							);
+						},
+					],
+
+					'pdf'   => [
+						'description'       => __( 'The identifier for the PDF', 'gravity-forms-pdf-extended' ),
+						'type'              => 'string',
+						'required'          => true,
+						'validate_callback' => function( $param, $request ) {
+
+							/* Get all active PDFs for the entry */
+							$pdfs = GPDFAPI::get_entry_pdfs( $request->get_param( 'entry' ) );
+
+							/* PDF ID is valid if in $pdfs array */
+							if ( isset( $pdfs[ $param ] ) ) {
+								return true;
+							}
+
+							/* translators: 1: Parameter, 2: List of valid values. */
+
+							return new WP_Error( 'rest_not_in_enum', wp_sprintf( __( '%1$s is not one of %2$l.', 'default' ), $param, ! is_wp_error( $pdfs ) ? array_keys( $pdfs ) : '""' ) );
+						},
+					],
+				],
+
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+				],
+			],
+		);
+	}
+
+	/**
+	 * Generate and return PDF
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$path_to_pdf = \GPDFAPI::create_pdf( $request->get_param( 'entry' ), $request->get_param( 'pdf' ) );
+
+		if ( is_wp_error( $path_to_pdf ) ) {
+			/*
+			 * Both entry and PDF IDs have been validated by this point.
+			 * If an error occurred it was in the PDF generator, and why the 500 server error.
+			 */
+			$path_to_pdf->add_data( [ 'status' => 500 ] );
+
+			return $path_to_pdf;
+		}
+
+		$response = new WP_REST_Response(
+			[
+				'filename' => wp_basename( $path_to_pdf ),
+				'size'     => filesize( $path_to_pdf ),
+				'data'     => base64_encode( file_get_contents( $path_to_pdf ) ), //phpcs:ignore
+			]
+		);
+
+		$response->add_links( $this->prepare_links( $request ) );
+
+		return $response;
+	}
+
+	/**
+	 * Add links for PDF
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return array[]
+	 *
+	 * @since 6.12.0
+	 */
+	protected function prepare_links( $request ) {
+
+		$pdf_id   = $data['id'] ?? $request->get_param( 'pdf' );
+		$entry_id = $data['entry'] ?? $request->get_param( 'entry' );
+
+		$entry   = $this->gform->get_entry( $entry_id );
+		$form_id = $entry['form_id'];
+
+		$links = [
+			'self' => [
+				'href' => rest_url( sprintf( '%s/%d/%s', static::get_route_basepath(), $entry_id, $pdf_id ) ),
+			],
+
+			'pdf'  => [
+				'href'       => rest_url( sprintf( '%s/%d/%s', Rest_Form_Settings::get_route_basepath(), $form_id, $pdf_id ) ),
+				'embeddable' => true,
+			],
+		];
+
+		if ( ! class_exists( 'GFWebAPI' ) ) {
+			return $links;
+		}
+
+		/* If GF REST API enabled, include direct links to form endpoint */
+		$gfwebapi = \GFWebAPI::get_instance();
+		if ( ! $gfwebapi->is_v2_enabled( $gfwebapi->get_plugin_settings() ) ) {
+			return $links;
+		}
+
+		$links['form'] = [
+			'href'       => rest_url( sprintf( 'gf/v2/forms/%d', $form_id ) ),
+			'embeddable' => true,
+		];
+
+		if ( ! empty( $entry_id ) ) {
+			$links['entry'] = [
+				'href'       => rest_url( sprintf( 'gf/v2/entries/%d', $entry_id ) ),
+				'embeddable' => true,
+			];
+		}
+
+		return $links;
+	}
+
+	/**
+	 * @return string
+	 *
+	 * @since 6.12
+	 */
+	public static function get_route_basepath() {
+		return static::NAMESPACE . static::API_BASE;
+	}
+
+	/**
+	 * Ensure current user is allowed to access PDF
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return bool
+	 */
+	public function get_item_permissions_check( $request ) {
+		/* Check if the current user has appropriate capability to view document */
+		/** @var Model_PDF $model_pdf */
+		$model_pdf = \GPDFAPI::get_pdf_class( 'model' );
+		if ( $model_pdf->can_user_view_pdf_with_capabilities() ) {
+			return true;
+		}
+
+		/* check if the current user is the owner and owner access is not disabled in the PDF settings */
+		$entry = $this->gform->get_entry( $request->get_param( 'entry' ) );
+		$pdf   = \GPDFAPI::get_pdf( $entry['form_id'] ?? 0, $request->get_param( 'pdf' ) );
+
+		$is_owner_restricted = $pdf['restrict_owner'] ?? 'No';
+		if ( $is_owner_restricted !== 'Yes' && (int) $entry['created_by'] === get_current_user_id() ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/Rest/Rest_Download_Pdf.php
+++ b/src/Rest/Rest_Download_Pdf.php
@@ -155,6 +155,8 @@ class Rest_Download_Pdf {
 			return $path_to_pdf;
 		}
 
+		/* @TODO - add "type" with enum "url" or "base64". If "url" generate standard signed PDF URL with 1 hour expiration and return as "url" */
+
 		$response = new WP_REST_Response(
 			[
 				'filename' => wp_basename( $path_to_pdf ),

--- a/src/Rest/Rest_Download_Pdf.php
+++ b/src/Rest/Rest_Download_Pdf.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace GFPDF\Rest;
+
+use GFPDF\Helper\Helper_Data;
+use GFPDF\Helper\Helper_Form;
+use GFPDF\Helper\Helper_Interface_Url_Signer;
+use GFPDF\Model\Model_PDF;
+use GPDFAPI;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @since 7.0
+ */
+class Rest_Download_Pdf {
+
+	/**
+	 * @var string
+	 * @since 7.0
+	 */
+	public const NAMESPACE = Helper_Data::REST_API_BASENAME . 'v1';
+
+	/**
+	 * @var string
+	 * @since 7.0
+	 */
+	public const API_BASE = '/download';
+
+	/**
+	 * @var string[]
+	 * @since 7.0
+	 */
+	public static $endpoints = [
+		'download-pdf' => self::API_BASE . '/(?P<entry>[\d]+)/(?P<pdf>[a-fA-F0-9]{13})',
+	];
+
+	/**
+	 * @var Helper_Form
+	 * @since 7.0
+	 */
+	protected $gform;
+
+	/**
+	 * @var Helper_Interface_Url_Signer
+	 * @since 7.0
+	 */
+	protected $url_signer;
+
+	/**
+	 * @param Helper_Form                 $gform
+	 * @param Helper_Interface_Url_Signer $url_signer
+	 *
+	 * @since 7.0
+	 */
+	public function __construct( $gform, Helper_Interface_Url_Signer $url_signer ) {
+		$this->gform      = $gform;
+		$this->url_signer = $url_signer;
+	}
+
+	/**
+	 * @return void
+	 * @since 7.0
+	 */
+	public function init() {
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+	}
+
+	/**
+	 * Register the routes for the API
+	 *
+	 * @return void
+	 * @since 7.0
+	 */
+	public function register_routes() {
+
+		/*
+		 * Route to generate and download a PDF for a specific entry
+		 */
+		register_rest_route(
+			static::NAMESPACE,
+			static::$endpoints['download-pdf'],
+			[
+				'args' => [
+					'entry' => [
+						'description'       => __( 'The unique identifier for the Gravity Forms entry.', 'gravity-forms-pdf-extended' ),
+						'type'              => 'integer',
+						'required'          => true,
+						'validate_callback' => function ( $param, $request ) {
+							$entry = $this->gform->get_entry( $param );
+
+							if ( ! is_wp_error( $entry ) ) {
+								return true;
+							}
+
+							return new WP_Error(
+								'rest_invalid_param',
+								sprintf( __( 'Invalid entry ID %d provided.', 'gravity-forms-pdf-extended' ), $param ),
+								[ 'status' => 400 ]
+							);
+						},
+					],
+
+					'pdf'   => [
+						'description'       => __( 'The identifier for the PDF', 'gravity-forms-pdf-extended' ),
+						'type'              => 'string',
+						'required'          => true,
+						'validate_callback' => function ( $param, $request ) {
+
+							/* Get all active PDFs for the entry */
+							$pdfs = GPDFAPI::get_entry_pdfs( $request->get_param( 'entry' ) );
+
+							/* PDF ID is valid if in $pdfs array */
+							if ( ! is_wp_error( $pdfs ) && isset( $pdfs[ $param ] ) ) {
+								return true;
+							}
+
+							/* translators: 1: Parameter, 2: List of valid values. */
+
+							return new WP_Error( 'rest_not_in_enum', wp_sprintf( __( '%1$s is not one of %2$l.', 'default' ), $param, ! is_wp_error( $pdfs ) ? array_keys( $pdfs ) : '""' ) );
+						},
+					],
+				],
+
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => [
+						'type'      => [
+							'description' => __( 'How to return the PDF: "base64" embeds the document in the response, "url" returns a signed proxy URL that streams it.', 'gravity-pdf' ),
+							'type'        => 'string',
+							'enum'        => [ 'base64', 'url' ],
+							'default'     => 'base64',
+						],
+
+						'urlExpiry' => [
+							'description' => __( 'How long a "url" type link remains valid, as a relative time string (e.g. "30 minutes", "2 hours"). Defaults to the global signed URL timeout.', 'gravity-pdf' ),
+							'type'        => 'string',
+							'required'    => false,
+						],
+					],
+				],
+
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'download_item' ],
+					'permission_callback' => [ $this, 'download_item_permissions_check' ],
+				],
+			],
+		);
+	}
+
+	/**
+	 * Generate the PDF and return it inline as base64 data, or as a signed proxy URL
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 *
+	 * @since 7.0
+	 */
+	public function get_item( $request ) {
+		$path_to_pdf = $this->generate_pdf( $request );
+
+		if ( is_wp_error( $path_to_pdf ) ) {
+			return $path_to_pdf;
+		}
+
+		$data = [
+			'filename' => wp_basename( $path_to_pdf ),
+			'size'     => filesize( $path_to_pdf ),
+		];
+
+		if ( $request->get_param( 'type' ) === 'url' ) {
+			$data['url'] = $this->get_signed_url( $request );
+		} else {
+			$data['data'] = base64_encode( file_get_contents( $path_to_pdf ) ); //phpcs:ignore
+		}
+
+		$response = new WP_REST_Response( $data );
+		$response->add_links( $this->prepare_links( $request ) );
+
+		return $response;
+	}
+
+	/**
+	 * Validate the signed URL and stream the entry's PDF to the browser
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_Error|void
+	 *
+	 * @since 7.0
+	 */
+	public function download_item( $request ) {
+		$path_to_pdf = $this->generate_pdf( $request );
+
+		if ( is_wp_error( $path_to_pdf ) ) {
+			return $path_to_pdf;
+		}
+
+		/** @var Model_PDF $model_pdf */
+		$model_pdf = \GPDFAPI::get_pdf_class( 'model' );
+
+		return $model_pdf->send_pdf_to_browser( $path_to_pdf, 'download' );
+	}
+
+	/**
+	 * Generate and save the entry's PDF, returning its path or a 500 error
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return string|WP_Error
+	 *
+	 * @since 7.0
+	 */
+	protected function generate_pdf( $request ) {
+		$path_to_pdf = \GPDFAPI::create_pdf( $request->get_param( 'entry' ), $request->get_param( 'pdf' ) );
+
+		if ( is_wp_error( $path_to_pdf ) ) {
+			/*
+			 * Both entry and PDF IDs have been validated by this point.
+			 * If an error occurred it was in the PDF generator, and why the 500 server error.
+			 */
+			$path_to_pdf->add_data( [ 'status' => 500 ] );
+		}
+
+		return $path_to_pdf;
+	}
+
+	/**
+	 * Build the download endpoint URL for an entry's PDF
+	 *
+	 * @param int    $entry_id
+	 * @param string $pdf_id
+	 *
+	 * @return string
+	 *
+	 * @since 7.0
+	 */
+	protected function get_download_url( $entry_id, $pdf_id ) {
+		return rest_url( sprintf( '%s/%d/%s', static::get_route_basepath(), $entry_id, $pdf_id ) );
+	}
+
+	/**
+	 * Build a signed proxy URL pointing at this endpoint's GET route
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return string
+	 *
+	 * @since 7.0
+	 */
+	protected function get_signed_url( $request ) {
+		$url = $this->get_download_url( $request->get_param( 'entry' ), $request->get_param( 'pdf' ) );
+
+		return $this->url_signer->sign( $url, (string) $request->get_param( 'urlExpiry' ) );
+	}
+
+	/**
+	 * Add links for PDF
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return array[]
+	 *
+	 * @since 7.0
+	 */
+	protected function prepare_links( $request ) {
+
+		$pdf_id   = $request->get_param( 'pdf' );
+		$entry_id = $request->get_param( 'entry' );
+
+		$entry   = $this->gform->get_entry( $entry_id );
+		$form_id = $entry['form_id'];
+
+		$links = [
+			'self' => [
+				'href' => $this->get_download_url( $entry_id, $pdf_id ),
+			],
+
+			'pdf'  => [
+				'href'       => rest_url( sprintf( '%s/%d/%s', Rest_Form_Settings::get_route_basepath(), $form_id, $pdf_id ) ),
+				'embeddable' => true,
+			],
+		];
+
+		if ( ! class_exists( 'GFWebAPI' ) ) {
+			return $links;
+		}
+
+		/* If GF REST API enabled, include direct links to form endpoint */
+		$gfwebapi = \GFWebAPI::get_instance();
+		if ( ! $gfwebapi->is_v2_enabled( $gfwebapi->get_plugin_settings() ) ) {
+			return $links;
+		}
+
+		$links['form'] = [
+			'href'       => rest_url( sprintf( 'gf/v2/forms/%d', $form_id ) ),
+			'embeddable' => true,
+		];
+
+		if ( ! empty( $entry_id ) ) {
+			$links['entry'] = [
+				'href'       => rest_url( sprintf( 'gf/v2/entries/%d', $entry_id ) ),
+				'embeddable' => true,
+			];
+		}
+
+		return $links;
+	}
+
+	/**
+	 * @return string
+	 *
+	 * @since 7.0
+	 */
+	public static function get_route_basepath() {
+		return static::NAMESPACE . static::API_BASE;
+	}
+
+	/**
+	 * Ensure current user is allowed to access PDF
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return bool
+	 */
+	public function get_item_permissions_check( $request ) {
+		/* Check if the current user has appropriate capability to view document */
+		/** @var Model_PDF $model_pdf */
+		$model_pdf = \GPDFAPI::get_pdf_class( 'model' );
+		if ( $model_pdf->can_user_view_pdf_with_capabilities() ) {
+			return true;
+		}
+
+		/* check if the current user is the owner and owner access is not disabled in the PDF settings */
+		$entry = $this->gform->get_entry( $request->get_param( 'entry' ) );
+		$pdf   = \GPDFAPI::get_pdf( $entry['form_id'] ?? 0, $request->get_param( 'pdf' ) );
+
+		$user_id             = get_current_user_id();
+		$is_owner_restricted = $pdf['restrict_owner'] ?? 'No';
+		if ( $user_id > 0 && $is_owner_restricted !== 'Yes' && (int) $entry['created_by'] === $user_id ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Authorise the GET route using the signed URL, which acts as a bearer token in place of a login
+	 *
+	 * @return bool|WP_Error
+	 *
+	 * @since 7.0
+	 */
+	public function download_item_permissions_check() {
+		if ( $this->url_signer->verify_current_request() ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'The PDF link is invalid or has expired.', 'gravity-pdf' ),
+			[ 'status' => 401 ]
+		);
+	}
+}

--- a/src/Rest/Rest_Form_Settings.php
+++ b/src/Rest/Rest_Form_Settings.php
@@ -176,15 +176,17 @@ class Rest_Form_Settings extends WP_REST_Controller {
 						'validate_callback' => function( $param, $request ) {
 							$pdf = GPDFAPI::get_pdf( $request->get_param( 'form' ), $param );
 
+							/* PDF found, PDF ID is valid */
 							if ( ! is_wp_error( $pdf ) ) {
 								return true;
 							}
 
+							/* Get list of valid IDs and include in error */
 							$pdfs = GPDFAPI::get_form_pdfs( $request->get_param( 'form' ) );
 
 							/* translators: 1: Parameter, 2: List of valid values. */
 
-							return new WP_Error( 'rest_not_in_enum', wp_sprintf( __( '%1$s is not one of %2$l.', 'default' ), $param, ! is_wp_error( $pdfs ) ? array_keys( $pdfs ) : '' ) );
+							return new WP_Error( 'rest_not_in_enum', wp_sprintf( __( '%1$s is not one of %2$l.', 'default' ), $param, ! is_wp_error( $pdfs ) ? array_keys( $pdfs ) : '""' ) );
 						},
 					],
 				],
@@ -371,7 +373,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 * @since 6.12.0
 	 */
 	public function check_entry_is_valid( $entry_id, $request ) {
-		$entry = \GFAPI::get_entry( $entry_id );
+		$entry = $this->gform->get_entry( $entry_id );
 		if ( is_wp_error( $entry ) ) {
 			return new WP_Error(
 				'rest_invalid_param',
@@ -890,7 +892,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 				'id'     => [
 					'description' => __( 'Unique identifier for the PDF.', 'gravity-forms-pdf-extended' ),
 					'type'        => 'string',
-					'context'     => [ 'edit' ],
+					'context'     => [ 'edit', 'embed' ],
 					'readonly'    => true,
 					'pattern'     => '[a-fA-F0-9]{13}',
 				],
@@ -898,7 +900,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 				'form'   => [
 					'description' => __( 'The Gravity Forms ID the PDF is configured on.', 'gravity-forms-pdf-extended' ),
 					'type'        => 'integer',
-					'context'     => [ 'edit' ],
+					'context'     => [ 'edit', 'embed' ],
 					'readonly'    => true,
 				],
 
@@ -906,7 +908,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 					'description' => __( 'The current state of the PDF.', 'gravity-forms-pdf-extended' ),
 					'type'        => 'boolean',
 					'default'     => true,
-					'context'     => [ 'edit' ],
+					'context'     => [ 'edit', 'embed' ],
 				],
 			],
 		];
@@ -1014,7 +1016,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 				'description' => ! empty( $value['desc'] ) ? wp_strip_all_tags( $value['desc'] ) : $generic_description,
 				'type'        => 'string',
 				'default'     => $default,
-				'context'     => [ 'edit', $group ],
+				'context'     => [ 'edit', 'embed', $group ],
 				'arg_options' => [
 					'sanitize_callback' => function( $param, $request, $key ) {
 						return is_array( $param ) ? array_map( 'sanitize_text_field', $param ) : sanitize_text_field( $param );

--- a/src/Rest/Rest_Form_Settings.php
+++ b/src/Rest/Rest_Form_Settings.php
@@ -176,15 +176,17 @@ class Rest_Form_Settings extends WP_REST_Controller {
 						'validate_callback' => function ( $param, $request ) {
 							$pdf = GPDFAPI::get_pdf( $request->get_param( 'form' ), $param );
 
+							/* PDF found, PDF ID is valid */
 							if ( ! is_wp_error( $pdf ) ) {
 								return true;
 							}
 
+							/* Get list of valid IDs and include in error */
 							$pdfs = GPDFAPI::get_form_pdfs( $request->get_param( 'form' ) );
 
 							/* translators: 1: Parameter, 2: List of valid values. */
 
-							return new WP_Error( 'rest_not_in_enum', wp_sprintf( __( '%1$s is not one of %2$l.', 'default' ), $param, ! is_wp_error( $pdfs ) ? array_keys( $pdfs ) : '' ) );
+							return new WP_Error( 'rest_not_in_enum', wp_sprintf( __( '%1$s is not one of %2$l.', 'default' ), $param, ! is_wp_error( $pdfs ) ? array_keys( $pdfs ) : '""' ) );
 						},
 					],
 				],
@@ -346,7 +348,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return true|WP_Error
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function check_form_is_valid( $form_id ) {
 		if ( is_array( $this->gform->get_form( $form_id ) ) ) {
@@ -368,10 +370,10 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return true|WP_Error
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function check_entry_is_valid( $entry_id, $request ) {
-		$entry = \GFAPI::get_entry( $entry_id );
+		$entry = $this->gform->get_entry( $entry_id );
 		if ( is_wp_error( $entry ) ) {
 			return new WP_Error(
 				'rest_invalid_param',
@@ -397,7 +399,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return true|WP_Error True if the request has read access, otherwise WP_Error object.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function get_items_permissions_check( $request ) {
 		return $this->get_item_permissions_check( $request );
@@ -410,7 +412,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function get_items( $request ) {
 		$entry_id = $request->get_param( 'entry' );
@@ -444,7 +446,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return true|WP_Error True if the request has read access for the item, otherwise WP_Error object.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function get_item_permissions_check( $request ) {
 		if ( $this->gform->has_capability( 'gravityforms_view_settings' ) ) {
@@ -465,7 +467,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return \WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function get_item( $request ) {
 		$pdf = \GPDFAPI::get_pdf( $request->get_param( 'form' ), $request->get_param( 'pdf' ) );
@@ -487,7 +489,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function create_item_permissions_check( $request ) {
 		if ( $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
@@ -508,7 +510,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function create_item( $request ) {
 		if ( ! empty( $request->get_param( 'pdf' ) ) ) {
@@ -567,7 +569,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return true|WP_Error True if the request has access to update the item, WP_Error object otherwise.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function update_item_permissions_check( $request ) {
 		return $this->create_item_permissions_check( $request );
@@ -580,7 +582,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function update_item( $request ) {
 		$form_id = $request->get_param( 'form' );
@@ -632,7 +634,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return true|WP_Error True if the request has access to delete the item, WP_Error object otherwise.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function delete_item_permissions_check( $request ) {
 		return $this->create_item_permissions_check( $request );
@@ -645,7 +647,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function delete_item( $request ) {
 		$pdf = \GPDFAPI::get_pdf( $request->get_param( 'form' ), $request->get_param( 'pdf' ) );
@@ -690,7 +692,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return \WP_REST_Response Response object.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		/* Restores the more descriptive, specific name for use within this method (PHP 8 fix). */
@@ -791,7 +793,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return array PDF settings
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	protected function prepare_item_for_database( $request ) {
 		$prepared_pdf = [];
@@ -859,7 +861,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return array Collection parameters.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function get_collection_params() {
 		return [
@@ -872,7 +874,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return array Item schema data.
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function get_item_schema() {
 		/* returned cached schema + additional fields */
@@ -890,7 +892,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 				'id'     => [
 					'description' => __( 'Unique identifier for the PDF.', 'gravity-pdf' ),
 					'type'        => 'string',
-					'context'     => [ 'edit' ],
+					'context'     => [ 'edit', 'embed' ],
 					'readonly'    => true,
 					'pattern'     => '[a-fA-F0-9]{13}',
 				],
@@ -898,7 +900,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 				'form'   => [
 					'description' => __( 'The Gravity Forms ID the PDF is configured on.', 'gravity-pdf' ),
 					'type'        => 'integer',
-					'context'     => [ 'edit' ],
+					'context'     => [ 'edit', 'embed' ],
 					'readonly'    => true,
 				],
 
@@ -906,7 +908,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 					'description' => __( 'The current state of the PDF.', 'gravity-pdf' ),
 					'type'        => 'boolean',
 					'default'     => true,
-					'context'     => [ 'edit' ],
+					'context'     => [ 'edit', 'embed' ],
 				],
 			],
 		];
@@ -991,7 +993,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return array
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	protected function get_section_schema( $settings, $group ) {
 		$generic_description = __( 'Content for the specific property.', 'gravity-pdf' );
@@ -1014,7 +1016,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 				'description' => ! empty( $value['desc'] ) ? wp_strip_all_tags( $value['desc'] ) : $generic_description,
 				'type'        => 'string',
 				'default'     => $default,
-				'context'     => [ 'edit', $group ],
+				'context'     => [ 'edit', 'embed', $group ],
 				'arg_options' => [
 					'sanitize_callback' => function ( $param, $request, $key ) {
 						return is_array( $param ) ? array_map( 'sanitize_text_field', $param ) : sanitize_text_field( $param );
@@ -1128,7 +1130,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return array[]
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	protected function prepare_links( $data, $request ) {
 
@@ -1189,7 +1191,7 @@ class Rest_Form_Settings extends WP_REST_Controller {
 	 *
 	 * @return string
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	protected function sanitize_rich_text( $html ) {
 		if ( strpos( $html, 'telnet://{' ) !== false ) {

--- a/src/Rest/Rest_Pdf_Preview.php
+++ b/src/Rest/Rest_Pdf_Preview.php
@@ -80,7 +80,7 @@ class Rest_Pdf_Preview extends Rest_Form_Settings {
 	 * @since 6.12
 	 */
 	public function create_item( $request ) {
-		$form  = \GFAPI::get_form( $request->get_param( 'form' ) );
+		$form  = $this->gform->get_form( $request->get_param( 'form' ) );
 		$entry = $this->get_entry( $request, $form );
 
 		/* Prepare request for previewing */
@@ -114,7 +114,7 @@ class Rest_Pdf_Preview extends Rest_Form_Settings {
 	protected function get_entry( $request, $form ) {
 		/* user requested a specific entry to preview */
 		if ( $request->get_param( 'entry' ) ) {
-			return \GFAPI::get_entry( $request->get_param( 'entry' ) );
+			return $this->gform->get_entry( $request->get_param( 'entry' ) );
 		}
 
 		/* try to get the last form submission */

--- a/src/Rest/Rest_Pdf_Preview.php
+++ b/src/Rest/Rest_Pdf_Preview.php
@@ -33,7 +33,7 @@ class Rest_Pdf_Preview extends Rest_Form_Settings {
 	 * Registers the routes for this endpoint
 	 *
 	 * @return void
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function register_routes() {
 
@@ -80,7 +80,7 @@ class Rest_Pdf_Preview extends Rest_Form_Settings {
 	 * @since 7.0
 	 */
 	public function create_item( $request ) {
-		$form  = \GFAPI::get_form( $request->get_param( 'form' ) );
+		$form  = $this->gform->get_form( $request->get_param( 'form' ) );
 		$entry = $this->get_entry( $request, $form );
 
 		/* Prepare request for previewing */
@@ -114,7 +114,7 @@ class Rest_Pdf_Preview extends Rest_Form_Settings {
 	protected function get_entry( $request, $form ) {
 		/* user requested a specific entry to preview */
 		if ( $request->get_param( 'entry' ) ) {
-			return \GFAPI::get_entry( $request->get_param( 'entry' ) );
+			return $this->gform->get_entry( $request->get_param( 'entry' ) );
 		}
 
 		/* try to get the last form submission */

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -702,9 +702,13 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$pdf_preview_controller = new Rest\Rest_Pdf_Preview( $this->options, $this->gform, $this->misc, $this->templates );
 		$pdf_preview_controller->init();
 
+		$download_pdf_controller = new Rest\Rest_Download_Pdf( $this->gform );
+		$download_pdf_controller->init();
+
 		/* Add to our singleton controller */
 		$this->singleton->add_class( $form_setting_controller );
 		$this->singleton->add_class( $pdf_preview_controller );
+		$this->singleton->add_class( $download_pdf_controller );
 
 		/* Log any errors for PDF endpoints */
 		$rest_request_after_callback = function( $response, $handle, $request ) {

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -715,7 +715,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	/**
 	 * Register Rest API
 	 *
-	 * @since 7.0.0
+	 * @since 7.0
 	 */
 	public function rest_api() {
 		$form_setting_controller = new Rest\Rest_Form_Settings( $this->options, $this->gform, $this->misc, $this->templates );
@@ -724,9 +724,13 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$pdf_preview_controller = new Rest\Rest_Pdf_Preview( $this->options, $this->gform, $this->misc, $this->templates );
 		$pdf_preview_controller->init();
 
+		$download_pdf_controller = new Rest\Rest_Download_Pdf( $this->gform, new Helper\Helper_Url_Signer() );
+		$download_pdf_controller->init();
+
 		/* Add to our singleton controller */
 		$this->singleton->add_class( $form_setting_controller );
 		$this->singleton->add_class( $pdf_preview_controller );
+		$this->singleton->add_class( $download_pdf_controller );
 
 		/* Log any errors for PDF endpoints */
 		$rest_request_after_callback = function ( $response, $handle, $request ) {

--- a/tests/phpunit/integration/Rest/Test_Rest_Download_Pdf.php
+++ b/tests/phpunit/integration/Rest/Test_Rest_Download_Pdf.php
@@ -1,0 +1,226 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Rest;
+
+use GFPDF\Helper\Helper_Url_Signer;
+use GFPDF\Rest\Rest_Download_Pdf;
+use WP_REST_Request;
+
+/**
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group api
+ * @group rest
+ */
+class Test_Rest_Download_Pdf extends Test_Rest {
+
+	/**
+	 * @var Rest_Download_Pdf
+	 */
+	protected $api;
+
+	public function set_up(): void {
+		global $gfpdf;
+
+		$this->api = new Rest_Download_Pdf( $gfpdf->gform, new Helper_Url_Signer() );
+
+		parent::set_up();
+
+		/* Configure mPDF with available fonts so the PDF generator can produce a document */
+		$config = static function ( $config ) {
+			return array_merge( $config, [
+				'fontDir'  => PDF_PLUGIN_DIR . '/tools/phpunit/data/fonts/',
+				'fontdata' => [
+					'dejavusans' => [
+						'R'          => 'DejaVuSans.ttf',
+						'useOTL'     => 0xff,
+						'useKashida' => 75,
+					],
+				],
+
+				'backupSubsFont' => [],
+				'backupSIPFont'  => '',
+				'BMPonly'        => [ 'dejavusans' ],
+			] );
+		};
+
+		add_filter( 'gfpdf_mpdf_class_config', $config );
+	}
+
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+
+		foreach ( $this->api::$endpoints as $route ) {
+			$this->assertArrayHasKey( '/' . $this->api::NAMESPACE . $route, $routes );
+		}
+	}
+
+	/**
+	 * Build the download route for a given entry and PDF ID
+	 *
+	 * @param int    $entry_id
+	 * @param string $pdf_id
+	 *
+	 * @return string
+	 */
+	protected function get_download_route( $entry_id, $pdf_id ) {
+		return '/' . $this->api::get_route_basepath() . '/' . $entry_id . '/' . $pdf_id;
+	}
+
+	public function test_get_item_permissions() {
+		$pdf_id   = $this->gf_factory()->pdf->create();
+		$entry_id = $this->gf_factory()->entry->create( [
+			'form_id'    => $this->form_id,
+			'created_by' => self::$admin_id,
+		] );
+
+		$request = new WP_REST_Request( 'POST', $this->get_download_route( $entry_id, $pdf_id ) );
+
+		/* Anonymous users cannot access the PDF */
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 401, $response->get_status() );
+
+		/* A logged-in user without the required capability (and who is not the entry owner) is forbidden */
+		wp_set_current_user( self::$editor_id );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_get_item_owner_permissions() {
+		/* The entry is owned by the editor */
+		$pdf_id   = $this->gf_factory()->pdf->create();
+		$entry_id = $this->gf_factory()->entry->create( [
+			'form_id'    => $this->form_id,
+			'created_by' => self::$editor_id,
+		] );
+
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'POST', $this->get_download_route( $entry_id, $pdf_id ) );
+		$request->set_url_params( [
+			'entry' => $entry_id,
+			'pdf'   => $pdf_id,
+		] );
+
+		$this->assertSame( true, $this->api->get_item_permissions_check( $request ) );
+
+		/* Owner access can be revoked at the PDF level via restrict_owner */
+		$pdf                   = \GPDFAPI::get_pdf( $this->form_id, $pdf_id );
+		$pdf['restrict_owner'] = 'Yes';
+		\GPDFAPI::update_pdf( $this->form_id, $pdf_id, $pdf );
+
+		$this->assertSame( false, $this->api->get_item_permissions_check( $request ) );
+	}
+
+	/**
+	 * @group slow
+	 */
+	public function test_get_item() {
+		$pdf_id   = $this->gf_factory()->pdf->create();
+		$entry_id = $this->gf_factory()->entry->create( [ 'form_id' => $this->form_id ] );
+
+		wp_set_current_user( self::$admin_id );
+
+		$request  = new WP_REST_Request( 'POST', $this->get_download_route( $entry_id, $pdf_id ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'filename', $data );
+		$this->assertArrayHasKey( 'size', $data );
+		$this->assertArrayHasKey( 'data', $data );
+
+		/* The returned payload is the base64-encoded PDF, so it should decode to a PDF document */
+		$this->assertSame( '%PDF', substr( (string) base64_decode( $data['data'] ), 0, 4 ) );
+
+		/* The self link points back at the download endpoint for this entry and PDF */
+		$links = $response->get_links();
+		$this->assertArrayHasKey( 'self', $links );
+	}
+
+	/**
+	 * @group slow
+	 */
+	public function test_get_item_url_type() {
+		$pdf_id   = $this->gf_factory()->pdf->create();
+		$entry_id = $this->gf_factory()->entry->create( [ 'form_id' => $this->form_id ] );
+
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', $this->get_download_route( $entry_id, $pdf_id ) );
+		$request->set_body_params( [ 'type' => 'url' ] );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		/* A "url" request returns a signed link instead of the base64 document */
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'url', $data );
+		$this->assertArrayNotHasKey( 'data', $data );
+
+		/* The link points at the download endpoint and carries a signature and expiry */
+		$this->assertStringContainsString( $this->api::get_route_basepath() . "/$entry_id/$pdf_id", $data['url'] );
+		$this->assertStringContainsString( 'expires=', $data['url'] );
+		$this->assertStringContainsString( 'signature=', $data['url'] );
+	}
+
+	public function test_download_item_permissions() {
+		$pdf_id   = $this->gf_factory()->pdf->create();
+		$entry_id = $this->gf_factory()->entry->create( [ 'form_id' => $this->form_id ] );
+
+		$url    = rest_url( $this->api::get_route_basepath() . "/$entry_id/$pdf_id" );
+		$signed = ( new Helper_Url_Signer() )->sign( $url, '10 minutes' );
+
+		$original_server = $_SERVER;
+
+		$parts                  = wp_parse_url( $signed );
+		$_SERVER['HTTP_HOST']   = $parts['host'] . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' );
+		$_SERVER['REQUEST_URI'] = $parts['path'] . '?' . $parts['query'];
+
+		/* Match the protocol the URL was signed with so verification doesn't depend on the test site's scheme */
+		if ( ( $parts['scheme'] ?? '' ) === 'https' ) {
+			$_SERVER['HTTPS'] = 'on';
+		} else {
+			unset( $_SERVER['HTTPS'] );
+		}
+
+		/* A correctly signed URL is authorised */
+		$this->assertSame( true, $this->api->download_item_permissions_check() );
+
+		/* A tampered signature is rejected */
+		$_SERVER['REQUEST_URI'] = (string) preg_replace( '/signature=[^&]+/', 'signature=tampered', $_SERVER['REQUEST_URI'] );
+		$this->assertWPError( $this->api->download_item_permissions_check() );
+
+		$_SERVER = $original_server;
+	}
+
+	public function test_get_item_with_invalid_entry() {
+		$pdf_id = $this->gf_factory()->pdf->create();
+
+		wp_set_current_user( self::$admin_id );
+
+		/* A non-existent entry ID fails validation */
+		$request  = new WP_REST_Request( 'POST', $this->get_download_route( 520, $pdf_id ) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_get_item_with_invalid_pdf() {
+		$entry_id = $this->gf_factory()->entry->create( [ 'form_id' => $this->form_id ] );
+
+		wp_set_current_user( self::$admin_id );
+
+		/* A PDF ID that is not configured on the entry fails validation (must still match the 13-hex pattern) */
+		$request  = new WP_REST_Request( 'POST', $this->get_download_route( $entry_id, '0123456789abc' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 400, $response->get_status() );
+	}
+}

--- a/tests/phpunit/integration/Rest/Test_Rest_Form_Settings.php
+++ b/tests/phpunit/integration/Rest/Test_Rest_Form_Settings.php
@@ -51,7 +51,7 @@ class Test_Rest_Form_Settings extends Test_Rest {
 
 		$this->assertSame( 'edit', $data['endpoints'][0]['args']['context']['default'] );
 
-		$contexts = [ 'advanced', 'appearance', 'edit', 'general', 'template' ];
+		$contexts = [ 'advanced', 'appearance', 'edit', 'embed', 'general', 'template' ];
 
 		$enum = $data['endpoints'][0]['args']['context']['enum'];
 		sort( $enum );


### PR DESCRIPTION
## Description

Adds a new REST endpoint that generates an entry's PDF on demand. The document can be returned inline (base64) or as a short-lived signed URL that streams the file — so integrations can fetch a finished PDF without going through the browser-based download links.

**Endpoint**

```
POST gravity-pdf/v1/download/<entry>/<pdf>
GET  gravity-pdf/v1/download/<entry>/<pdf>   (signed-URL proxy — see below)
```

- `<entry>` — the Gravity Forms entry ID (validated against the form database).
- `<pdf>` — the 13-character PDF ID (validated against the entry's active PDFs).

### POST — request the PDF

Body parameters:

| Param | Type | Default | Notes |
|-------|------|---------|-------|
| `type` | `base64` \| `url` | `base64` | How to return the document. |
| `urlExpiry` | string | global timeout | Only used for `type=url`. A relative time string (`"30 minutes"`, `"2 hours"`). Falls back to the global signed-URL timeout (`logged_out_timeout`) when omitted or invalid. |

**`type=base64`** (default) returns the document inline:

```json
{ "filename": "example.pdf", "size": 12345, "data": "<base64-encoded PDF>" }
```

**`type=url`** generates and caches the PDF, then returns a signed proxy URL instead of the bytes:

```json
{ "filename": "example.pdf", "size": 12345, "url": "https://site/wp-json/gravity-pdf/v1/download/<entry>/<pdf>?expires=…&signature=…" }
```

The response also includes HAL `_links` (`self`, `pdf`, and — when the Gravity Forms REST API v2 is enabled — direct `form` and `entry` links).

### GET — the signed-URL proxy

The `url` returned above points back at the same route via `GET`. The signature acts as the bearer token: the request is authorised purely by verifying the signature and expiry (reusing the same `Helper_Url_Signer` infrastructure as Gravity PDF's front-end signed PDF links), then the PDF is streamed to the browser as a download. No login is required, which is what makes the URL shareable.

### Access control (POST)

A request is authorised if either:
1. The current user has the capability to view PDFs, or
2. The current user is logged in, owns the entry (`created_by`), and owner access has not been disabled via the PDF's "Restrict Owner" setting.

Otherwise the request is rejected.

## Supporting changes

- **`Rest_Form_Settings`** — exposes the `id`, `form`, `active` and per-group setting fields in the `embed` context as well as `edit`, so the new endpoint's embedded `pdf` link returns useful data. Also switches a couple of direct `\GFAPI::` calls to the injected `$this->gform` helper for consistency and testability.
- **`Rest_Pdf_Preview`** — same `\GFAPI::` → `$this->gform` swap.
- **`Model_PDF::set_watermark_font()`** — falls back to the global default font when neither a watermark font nor a form font is set, instead of triggering an "undefined array key" warning during PDF generation.
- **`bootstrap.php`** — registers the new `Rest_Download_Pdf` controller (now also wired with `Helper_Url_Signer`).

## Testing instructions

1. Create a form with at least one active PDF and submit an entry.
2. **base64:** As a user with PDF-view capability, `POST` to `gravity-pdf/v1/download/<entry>/<pdf>` and confirm a JSON payload whose decoded `data` begins with `%PDF-`.
3. **url:** `POST` the same route with `{"type":"url"}` and confirm a `url` is returned containing `expires` and `signature`. Open it in a browser and confirm the PDF downloads. Wait past the expiry (or pass a short `urlExpiry` like `"1 second"`) and confirm the link is then rejected.
4. As the entry owner (non-admin), confirm `POST` succeeds — and fails once the PDF's "Restrict Owner" option is enabled.
5. As an anonymous / unrelated user, confirm `POST` is rejected, and that a tampered/expired signed URL is rejected on `GET`.
6. Invalid entry or PDF IDs should return a `400` validation error.

Automated coverage lives in `tests/phpunit/integration/Rest/Test_Rest_Download_Pdf.php` (route registration, the permission matrix, base64 + url generation, and signed-URL verification).

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation / docblocks.
