### PR TITLE
Improve PDF Preview Support

### DIFF
--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -945,7 +945,7 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 				'id'   => 'background_color',
 				'name' => esc_html__( 'Background Color', 'gravity-forms-pdf-extended' ),
 				'type' => 'color',
-				'std'  => '#FFF',
+				'std'  => '#ffffff',
 				'desc' => __( 'Set the background color for all pages.', 'gravity-forms-pdf-extended' ),
 			]
 		);

--- a/src/assets/js/react/utilities/PdfSettings/formSettings.js
+++ b/src/assets/js/react/utilities/PdfSettings/formSettings.js
@@ -50,11 +50,21 @@ export function getCurrentPdfSettingsForApi (schema) {
           }
           break
 
-        case 'string':
         case 'number':
         case 'integer':
+          formData.set(key, input.value)
+
+          break
+
+        case 'string':
+
           // skip checkbox or radio fields that are not checked
           if (['checkbox', 'radio'].includes(input.type) && !input.checked) {
+            continue
+          }
+
+          // if field should be a hex color and is empty
+          if (property.format === 'hex-color' && input.value.length === 0) {
             continue
           }
 

--- a/tests/phpunit/unit-tests/Rest/Test_Rest_Form_Settings.php
+++ b/tests/phpunit/unit-tests/Rest/Test_Rest_Form_Settings.php
@@ -327,7 +327,7 @@ class Test_Rest_Form_Settings extends Test_Rest {
 		$this->assertFalse( $data['show_section_content'] );
 		$this->assertFalse( $data['show_empty'] );
 		$this->assertTrue( $data['enable_conditional'] );
-		$this->assertSame( '#FFF', $data['background_color'] );
+		$this->assertSame( '#ffffff', $data['background_color'] );
 		$this->assertSame( $template_pdf_config['background_image'], $data['background_image'] );
 		$this->assertSame( $template_pdf_config['header'], $data['header'] );
 		$this->assertSame( $template_pdf_config['first_header'], $data['first_header'] );


### PR DESCRIPTION
## Description

Fix error when a color field has no value and is not required

## Testing instructions
1. Open Form PDF Settings
2. Add new PDF
3. Delete the Font Color
4. Use the PDF Preview button

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
