### PR TITLE
Typecast enum values in Rest API Schema

### DIFF
--- a/src/Rest/Rest_Form_Settings.php
+++ b/src/Rest/Rest_Form_Settings.php
@@ -1037,13 +1037,21 @@ class Rest_Form_Settings extends WP_REST_Controller {
 					}
 
 					$schema[ $id ]['arg_options']['sanitize_callback'] = 'rest_sanitize_request_arg';
+
+					/* If there's a default number value cast to int/float */
+					if ( ! is_null( $default ) ) {
+						$schema[ $id ]['default'] = is_numeric( $default ) ? $default + 0 : null;
+					}
+
 					break;
 
 				case 'multicheck':
 					$schema[ $id ]['type']                             = 'array';
 					$schema[ $id ]['items']                            = [
 						'type' => 'string',
-						'enum' => $this->misc->flatten_array( $value['options'] ?? [] ),
+
+						/* cast all values to a string to prevent a type validation error */
+						'enum' => array_map( 'strval', $this->misc->flatten_array( $value['options'] ?? [] ) ),
 					];
 					$schema[ $id ]['arg_options']['sanitize_callback'] = 'rest_sanitize_request_arg';
 					break;
@@ -1052,15 +1060,18 @@ class Rest_Form_Settings extends WP_REST_Controller {
 				case 'select':
 					$schema[ $id ]['arg_options']['sanitize_callback'] = 'rest_sanitize_request_arg';
 
+					/* cast all values to a string to prevent a type validation error */
+					$enum = array_map( 'strval', $this->misc->flatten_array( $value['options'] ?? [] ) );
+
 					if ( ! empty( $value['multiple'] ) ) {
 						/* multiselect field */
 						$schema[ $id ]['type']  = 'array';
 						$schema[ $id ]['items'] = [
 							'type' => 'string',
-							'enum' => $this->misc->flatten_array( $value['options'] ?? [] ),
+							'enum' => $enum,
 						];
 					} else {
-						$schema[ $id ]['enum'] = $this->misc->flatten_array( $value['options'] ?? [] );
+						$schema[ $id ]['enum'] = $enum;
 					}
 					break;
 


### PR DESCRIPTION
## Description

Fix validation error when enum values are integers but the expected type is a string

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
