### PR TITLE
REST API: Differentiate between checkbox and toggles

### DIFF
--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -338,7 +338,7 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 						'desc2'      => esc_html__( 'Add rules to dynamically enable or disable the PDF. When disabled, PDFs do not show up in the admin area, cannot be viewed, and will not be attached to notifications.', 'gravity-forms-pdf-extended' ),
 						'schema'     => [
 							'type'   => 'boolean',
-							'format' => 'yes_no',
+							'format' => 'yes-no',
 						],
 					],
 
@@ -636,7 +636,7 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 							'description' => __( 'Force the PDF to be temporarily saved to the filesystem during form submission (deprecated). Use the gfpdf_post_save_pdf hook instead.', 'gravity-forms-pdf-extended' ),
 							'default'     => false,
 							'required'    => false,
-							'format'      => 'yes_no',
+							'format'      => 'yes-no',
 							'arg_options' => [
 								'sanitize_callback' => 'rest_sanitize_request_arg',
 							],

--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -347,7 +347,7 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 						'desc2'      => esc_html__( 'Add rules to dynamically enable or disable the PDF. When disabled, PDFs do not show up in the admin area, cannot be viewed, and will not be attached to notifications.', 'gravity-pdf' ),
 						'schema'     => [
 							'type'   => 'boolean',
-							'format' => 'yes_no',
+							'format' => 'yes-no',
 						],
 					],
 
@@ -645,7 +645,7 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 							'description' => __( 'Force the PDF to be temporarily saved to the filesystem during form submission (deprecated). Use the gfpdf_post_save_pdf hook instead.', 'gravity-pdf' ),
 							'default'     => false,
 							'required'    => false,
-							'format'      => 'yes_no',
+							'format'      => 'yes-no',
 							'arg_options' => [
 								'sanitize_callback' => 'rest_sanitize_request_arg',
 							],

--- a/src/Rest/Rest_Form_Settings.php
+++ b/src/Rest/Rest_Form_Settings.php
@@ -837,8 +837,13 @@ class Rest_Form_Settings extends WP_REST_Controller {
 			}
 
 			/* Handle Toggle values */
-			if ( $this->has_property_type( 'boolean', $property['type'] ) && ( $property['format'] ?? '' ) === 'yes_no' ) {
+			if ( $this->has_property_type( 'boolean', $property['type'] ) && ( $property['format'] ?? '' ) === 'yes-no' ) {
 				$value = $value === true ? 'Yes' : 'No';
+			}
+
+			/* Handle checkbox values */
+			if ( $this->has_property_type( 'boolean', $property['type'] ) && ( $property['format'] ?? '' ) === 'checkbox' ) {
+				$value = $value === true ? '1' : '';
 			}
 
 			$prepared_pdf[ $id ] = $value;
@@ -1092,9 +1097,15 @@ class Rest_Form_Settings extends WP_REST_Controller {
 					break;
 
 				case 'checkbox':
+					$schema[ $id ]['type']                             = 'boolean';
+					$schema[ $id ]['format']                           = 'checkbox';
+					$schema[ $id ]['default']                          = in_array( $default, [ 'Yes', '1', 1, 'true', true ], true );
+					$schema[ $id ]['arg_options']['sanitize_callback'] = 'rest_sanitize_request_arg';
+				break;
+
 				case 'toggle':
 					$schema[ $id ]['type']                             = 'boolean';
-					$schema[ $id ]['format']                           = 'yes_no';
+					$schema[ $id ]['format']                           = 'yes-no';
 					$schema[ $id ]['default']                          = in_array( $default, [ 'Yes', '1', 'true', true ], true );
 					$schema[ $id ]['arg_options']['sanitize_callback'] = 'rest_sanitize_request_arg';
 

--- a/src/Rest/Rest_Form_Settings.php
+++ b/src/Rest/Rest_Form_Settings.php
@@ -839,8 +839,13 @@ class Rest_Form_Settings extends WP_REST_Controller {
 			}
 
 			/* Handle Toggle values */
-			if ( $this->has_property_type( 'boolean', $property['type'] ) && ( $property['format'] ?? '' ) === 'yes_no' ) {
+			if ( $this->has_property_type( 'boolean', $property['type'] ) && ( $property['format'] ?? '' ) === 'yes-no' ) {
 				$value = $value === true ? 'Yes' : 'No';
+			}
+
+			/* Handle checkbox values */
+			if ( $this->has_property_type( 'boolean', $property['type'] ) && ( $property['format'] ?? '' ) === 'checkbox' ) {
+				$value = $value === true ? '1' : '';
 			}
 
 			$prepared_pdf[ $id ] = $value;
@@ -1094,12 +1099,17 @@ class Rest_Form_Settings extends WP_REST_Controller {
 					break;
 
 				case 'checkbox':
+					$schema[ $id ]['type']                             = 'boolean';
+					$schema[ $id ]['format']                           = 'checkbox';
+					$schema[ $id ]['default']                          = in_array( $default, [ 'Yes', '1', 1, 'true', true ], true );
+					$schema[ $id ]['arg_options']['sanitize_callback'] = 'rest_sanitize_request_arg';
+					break;
+
 				case 'toggle':
 					$schema[ $id ]['type']                             = 'boolean';
-					$schema[ $id ]['format']                           = 'yes_no';
+					$schema[ $id ]['format']                           = 'yes-no';
 					$schema[ $id ]['default']                          = in_array( $default, [ 'Yes', '1', 'true', true ], true );
 					$schema[ $id ]['arg_options']['sanitize_callback'] = 'rest_sanitize_request_arg';
-
 					break;
 			}
 

--- a/tests/phpunit/integration/Rest/Test_Rest_Form_Settings.php
+++ b/tests/phpunit/integration/Rest/Test_Rest_Form_Settings.php
@@ -822,7 +822,7 @@ class Test_Rest_Form_Settings extends Test_Rest {
 		$this->assertContains( 'landscape', $args['orientation']['enum'] );
 
 		$this->assertSame( 'boolean', $args['rtl']['type'] );
-		$this->assertSame( 'yes_no', $args['rtl']['format'] );
+		$this->assertSame( 'yes-no', $args['rtl']['format'] );
 
 		$this->assertContains( 'Standard', $args['format']['enum'] );
 		$this->assertContains( 'PDFX1A', $args['format']['enum'] );
@@ -1212,5 +1212,95 @@ class Test_Rest_Form_Settings extends Test_Rest {
 		$this->assertArrayNotHasKey( 'filename', $schema['properties'] );
 		$this->assertArrayNotHasKey( 'notification', $schema['properties'] );
 		$this->assertArrayNotHasKey( 'conditionalLogic', $schema['properties'] );
+	}
+
+	/**
+	 * Register an additional checkbox settings field so the REST schema generates a checkbox-format boolean.
+	 *
+	 * @param array $fields The existing advanced settings fields.
+	 *
+	 * @return array
+	 */
+	public function add_checkbox_field( $fields ) {
+		$fields['my_checkbox'] = [
+			'id'   => 'my_checkbox',
+			'name' => 'My Checkbox',
+			'type' => 'checkbox',
+			'std'  => false,
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Toggle and checkbox boolean fields must expose distinct schema formats so the API can serialise them
+	 * back to their respective storage values ('Yes'/'No' vs '1'/'').
+	 */
+	public function test_checkbox_and_toggle_schema_format() {
+		add_filter( 'gfpdf_form_settings_advanced', [ $this, 'add_checkbox_field' ] );
+
+		$schema = $this->api->get_item_schema();
+		$args   = $schema['properties'];
+
+		/* Toggle fields are flagged with the 'yes-no' format */
+		$this->assertSame( 'boolean', $args['rtl']['type'] );
+		$this->assertSame( 'yes-no', $args['rtl']['format'] );
+
+		/* Checkbox fields are flagged with the 'checkbox' format */
+		$this->assertSame( 'boolean', $args['my_checkbox']['type'] );
+		$this->assertSame( 'checkbox', $args['my_checkbox']['format'] );
+		$this->assertFalse( $args['my_checkbox']['default'] );
+	}
+
+	/**
+	 * A checkbox field stores '1' when enabled and '' when disabled, whereas a toggle field stores 'Yes'/'No'.
+	 */
+	public function test_checkbox_value_round_trip() {
+		add_filter( 'gfpdf_form_settings_advanced', [ $this, 'add_checkbox_field' ] );
+
+		/* Re-register the routes so the dispatched schema picks up the new checkbox field */
+		$this->api->register_routes();
+
+		wp_set_current_user( self::$admin_id );
+
+		/* Enabled checkbox is stored as '1', toggle as 'Yes' */
+		$request = new WP_REST_Request( 'POST', '/gravity-pdf/v1/form/' . $this->form_id );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params( [
+			'name'        => 'Label',
+			'template'    => 'rubix',
+			'rtl'         => true,
+			'my_checkbox' => true,
+		] );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertTrue( $data['my_checkbox'] );
+
+		$pdf = \GPDFAPI::get_pdf( $this->form_id, $data['id'] );
+		$this->assertSame( '1', $pdf['my_checkbox'] );
+		$this->assertSame( 'Yes', $pdf['rtl'] );
+
+		/* Disabled checkbox is stored as '', toggle as 'No' */
+		$request = new WP_REST_Request( 'POST', '/gravity-pdf/v1/form/' . $this->form_id );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params( [
+			'name'        => 'Label',
+			'template'    => 'rubix',
+			'rtl'         => false,
+			'my_checkbox' => false,
+		] );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertFalse( $data['my_checkbox'] );
+
+		$pdf = \GPDFAPI::get_pdf( $this->form_id, $data['id'] );
+		$this->assertSame( '', $pdf['my_checkbox'] );
+		$this->assertSame( 'No', $pdf['rtl'] );
 	}
 }

--- a/tests/phpunit/unit-tests/Rest/Test_Rest_Form_Settings.php
+++ b/tests/phpunit/unit-tests/Rest/Test_Rest_Form_Settings.php
@@ -819,7 +819,7 @@ class Test_Rest_Form_Settings extends Test_Rest {
 		$this->assertContains( 'landscape', $args['orientation']['enum'] );
 
 		$this->assertSame( 'boolean', $args['rtl']['type'] );
-		$this->assertSame( 'yes_no', $args['rtl']['format'] );
+		$this->assertSame( 'yes-no', $args['rtl']['format'] );
 
 		$this->assertContains( 'Standard', $args['format']['enum'] );
 		$this->assertContains( 'PDFX1A', $args['format']['enum'] );


### PR DESCRIPTION
## Description

The Form Settings REST endpoint treated all boolean settings the same way, but the two underlying field types serialise differently in storage: **toggle** settings are stored as `'Yes'`/`'No'`, whereas **checkbox** settings are stored as `'1'`/`''`. Mapping both to the same boolean format meant checkbox settings round-tripped incorrectly.

This differentiates the two:

- Adds a dedicated `checkbox` schema format with its own prepare handling — a `true`/`false` boolean serialises to `'1'`/`''`.
- Toggle settings keep the existing `'Yes'`/`'No'` serialisation.
- Renames the (unreleased) schema format string `yes_no` → `yes-no` for consistency with the existing `hex-color` format.

Changes:
- `src/Rest/Rest_Form_Settings.php` — split the `checkbox` and `toggle` cases when building the schema (checkbox → `format: 'checkbox'`, toggle → `format: 'yes-no'`), and add a prepare branch converting a checkbox boolean to `'1'`/`''`.
- `src/Helper/Helper_Options_Fields.php` — update the two hard-coded `yes_no` format strings to `yes-no`.
- `tests/phpunit/integration/Rest/Test_Rest_Form_Settings.php` — PHPUnit coverage for both the `yes-no` (toggle) and `checkbox` formats.

## Testing instructions

1. `GET` `/gravity-pdf/v1/form/{form_id}/{pdf_id}` and confirm checkbox-backed settings expose `format: "checkbox"` in the schema while toggle-backed settings expose `format: "yes-no"`.
2. `POST`/`PATCH` a checkbox setting as `true` and confirm it is stored as `'1'` (and `false` → `''`).
3. `POST`/`PATCH` a toggle setting as `true` and confirm it is stored as `'Yes'` (and `false` → `'No'`).

Or run the PHPUnit coverage:

```bash
yarn test:php -- --filter Test_Rest_Form_Settings
```

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
