### PR TITLE
Make Conditional Logic Schema rule properties required

### DIFF
--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -371,14 +371,17 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 										'additionalProperties' => false,
 										'properties' => [
 											'fieldId'  => [
-												'type' => 'string',
+												'type'     => 'string',
+												'required' => true,
 											],
 											'operator' => [
-												'type' => 'string',
-												'enum' => [ 'is', 'isnot', '<>', 'not in', 'in', '>', '<', 'contains', 'starts_with', 'ends_with', 'like', '>=', '<=' ],
+												'type' =>     'string',
+												'enum' =>     [ 'is', 'isnot', '<>', 'not in', 'in', '>', '<', 'contains', 'starts_with', 'ends_with', 'like', '>=', '<=' ],
+												'required' => true,
 											],
 											'value'    => [
-												'type' => 'string',
+												'type'     => 'string',
+												'required' => true,
 											],
 										],
 									],

--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -380,14 +380,17 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 										'additionalProperties' => false,
 										'properties' => [
 											'fieldId'  => [
-												'type' => 'string',
+												'type'     => 'string',
+												'required' => true,
 											],
 											'operator' => [
-												'type' => 'string',
-												'enum' => [ 'is', 'isnot', '<>', 'not in', 'in', '>', '<', 'contains', 'starts_with', 'ends_with', 'like', '>=', '<=' ],
+												'type'     => 'string',
+												'enum'     => [ 'is', 'isnot', '<>', 'not in', 'in', '>', '<', 'contains', 'starts_with', 'ends_with', 'like', '>=', '<=' ],
+												'required' => true,
 											],
 											'value'    => [
-												'type' => 'string',
+												'type'     => 'string',
+												'required' => true,
 											],
 										],
 									],

--- a/tests/phpunit/integration/Rest/Test_Rest_Form_Settings.php
+++ b/tests/phpunit/integration/Rest/Test_Rest_Form_Settings.php
@@ -811,6 +811,12 @@ class Test_Rest_Form_Settings extends Test_Rest {
 		$this->assertArrayHasKey( 'logicType', $args['conditionalLogic']['properties'] );
 		$this->assertArrayHasKey( 'rules', $args['conditionalLogic']['properties'] );
 
+		/* Each conditional logic rule property should be flagged as required in the schema */
+		$rule_properties = $args['conditionalLogic']['properties']['rules']['items']['properties'];
+		$this->assertTrue( $rule_properties['fieldId']['required'] );
+		$this->assertTrue( $rule_properties['operator']['required'] );
+		$this->assertTrue( $rule_properties['value']['required'] );
+
 		$this->assertContains( 'A4', $args['pdf_size']['enum'] );
 		$this->assertContains( 'CUSTOM', $args['pdf_size']['enum'] );
 
@@ -943,6 +949,35 @@ class Test_Rest_Form_Settings extends Test_Rest {
 		$this->assertSame( 'rest_property_required', $data['data']['details']['conditionalLogic']['code'] );
 		$this->assertSame( 'rest_invalid_type', $data['data']['details']['font_size']['code'] );
 		$this->assertSame( 'rest_invalid_hex_color', $data['data']['details']['font_colour']['code'] );
+	}
+
+	/**
+	 * Check the REST API rejects conditional logic rules that are missing a required property
+	 */
+	public function test_input_validation_conditional_logic_rule_required() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/gravity-pdf/v1/form/' . $this->form_id );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+
+		/* The single rule omits the required "value" property */
+		$request->set_body_params( [
+			'name'             => 'Label',
+			'template'         => 'rubix',
+			'conditionalLogic' => [
+				'actionType' => 'show',
+				'logicType'  => 'any',
+				'rules'      => [
+					[ 'fieldId' => '7', 'operator' => 'is' ],
+				],
+			],
+		] );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_property_required', $data['data']['details']['conditionalLogic']['code'] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

The Form Settings REST endpoint accepted conditional logic rules that were missing properties, so a rule could be persisted with, e.g., a `fieldId` and `operator` but no `value`. This flags the three nested rule properties — `fieldId`, `operator`, and `value` — as `required` in the REST schema for `conditionalLogic.rules.items`, so the API now rejects incomplete rules with a `400 rest_property_required` error instead of silently storing a malformed rule.

Changes:
- `src/Helper/Helper_Options_Fields.php` — add `'required' => true` to the `fieldId`, `operator`, and `value` properties of the conditional logic rule schema.
- `tests/phpunit/integration/Rest/Test_Rest_Form_Settings.php` — assert the schema marks each rule property required, and add a test confirming a POST with a rule missing `value` is rejected with `400 rest_property_required`.

## Testing instructions

1. `POST` to `/gravity-pdf/v1/form/{form_id}` with a `conditionalLogic` payload whose `rules` entry omits one of `fieldId`, `operator`, or `value`, e.g.:
   ```json
   {
     "name": "Label",
     "template": "rubix",
     "conditionalLogic": {
       "actionType": "show",
       "logicType": "any",
       "rules": [ { "fieldId": "7", "operator": "is" } ]
     }
   }
   ```
2. Confirm the response is `400` with code `rest_property_required` for `conditionalLogic` (previously this was accepted).
3. Confirm a complete rule (all three properties present) is still accepted.

Or run the PHPUnit coverage:

```bash
yarn test:php -- --filter test_input_validation_conditional_logic_rule_required
```

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
