### PR TITLE
Tweak logged in user authentication check

### DIFF
--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -426,7 +426,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	}
 
 	/**
-	 * Check the "Restrict Logged Out User" global setting and validate it against the current user
+	 * If the owner is restricted and the user is not logged in, prompt to log in
 	 *
 	 * @param boolean|object $action
 	 * @param array          $entry    The Gravity Forms Entry
@@ -442,7 +442,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		/* ensure another middleware filter hasn't already done validation */
 		if ( ! is_wp_error( $action ) ) {
 			/* get the setting */
-			$owner_restriction = ( isset( $settings['restrict_owner'] ) ) ? $settings['restrict_owner'] : 'No';
+			$owner_restriction = $settings['restrict_owner'] ?? 'No';
 
 			if ( $owner_restriction === 'Yes' && ! is_user_logged_in() ) {
 
@@ -635,7 +635,10 @@ class Model_PDF extends Helper_Abstract_Model {
 	}
 
 	/**
-	 * Check the "User Restriction" global setting and validate it against the current user
+	 * Verify the logged-in user can view the PDF
+	 *
+	 * If owner restrictions are enabled, check if the user as correct capability to view
+	 * If owner restrictions are disabled, check if the user is the entry owner
 	 *
 	 * @param boolean|object $action
 	 * @param array          $entry    The Gravity Forms Entry
@@ -649,15 +652,17 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		if ( ! is_wp_error( $action ) ) {
 			/* check if the user is logged in but is not the current owner */
-			if ( is_user_logged_in() &&
-				 ( ( $this->options->get_option( 'limit_to_admin', 'No' ) === 'Yes' ) || ( $this->is_current_pdf_owner( $entry, 'logged_in' ) === false ) )
-			) {
-				$access = $this->can_user_view_pdf_with_capabilities();
+			$owner_restriction = $settings['restrict_owner'] ?? 'No';
 
-				/* throw error if no access granted */
-				if ( ! $access ) {
-					return new WP_Error( 'access_denied', esc_html__( 'You do not have access to view this PDF.', 'gravity-pdf' ) );
-				}
+			if (
+				is_user_logged_in() &&
+				! $this->can_user_view_pdf_with_capabilities() &&
+				(
+					$owner_restriction === 'Yes' ||
+					$this->is_current_pdf_owner( $entry, 'logged_in' ) === false
+				)
+			) {
+				return new WP_Error( 'access_denied', esc_html__( 'You do not have access to view this PDF.', 'gravity-pdf' ) );
 			}
 		}
 

--- a/tests/phpunit/unit-tests/Model/Test_Model_Pdf.php
+++ b/tests/phpunit/unit-tests/Model/Test_Model_Pdf.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace GFPDF\Model;
+
+use GF_UnitTest_Factory;
+use GFPDF\Controller\Controller_PDF;
+use GFPDF\Helper\Helper_Url_Signer;
+use GFPDF\View\View_PDF;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2024, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_Model_PDF
+ *
+ * @package   GFPDF\Model
+ *
+ * @group     model
+ * @group     pdfs
+ */
+class Test_Model_PDF extends WP_UnitTestCase {
+
+	/**
+	 * @var Controller_PDF
+	 */
+	public $controller;
+
+	/**
+	 * @var Model_PDF
+	 */
+	public $model;
+
+	/**
+	 * @var View_PDF
+	 */
+	public $view;
+
+	public function set_up() {
+		global $gfpdf;
+
+		parent::set_up();
+
+		/* Setup our test classes */
+		$this->model = new Model_PDF( $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices, $gfpdf->templates, new Helper_Url_Signer() );
+
+		$this->view = new View_PDF( [], $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->templates );
+
+		$this->controller = new Controller_PDF( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->misc );
+	}
+
+	public function test_middleware() {
+		/* setup data */
+		$factory = new GF_UnitTest_Factory();
+		$form    = $factory->form->create_and_get();
+		$entry   = $factory->entry->create_and_get( [ 'form_id' => $form['id'], 'ip' => '10.0.0.1', ] );
+		$factory->pdf->set_form_id( $form['id'] );
+		$pdf = $factory->pdf->create_and_get( [ 'public_access' => 'No' ] );
+
+		$this->controller->init();
+
+		/* Check unauthorized access */
+		$this->assertInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		/* Check public access */
+		$this->controller->init();
+
+		$pdf['public_access'] = 'Yes';
+		$this->assertNotInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		/* Check Signing Request */
+		$this->controller->init();
+
+		$pdf['public_access'] = 'No';
+
+		// fail
+		$_SERVER['REQUEST_URI'] = '/';
+		$this->assertInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		// pass
+		$url                    = do_shortcode( sprintf( '[gravitypdf id="%s" entry="%d" raw="1" signed="1"]', $pdf['id'], $entry['id'] ) );
+		$_SERVER['HTTP_HOST']   = str_replace( [ 'http://', 'http://' ], '', home_url() );
+		$_GET['expires']        = '';
+		$_GET['signature']      = '';
+		$_SERVER['REQUEST_URI'] = str_replace( home_url(), '', $url );
+
+		$this->assertNotInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		$_SERVER['REQUEST_URI'] = '';
+		unset( $_GET['expires'], $_GET['signature'] );
+
+		/* logged out IP-matching */
+		$this->controller->init();
+
+		// fail
+		$_SERVER['REMOTE_ADDR'] = '10.0.0.2';
+		$this->assertInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		// pass
+		$_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+		$this->assertNotInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		/* Logged out IP-timeout */
+		$default_timeout = 60 * 20;
+		$entry           = $factory->entry->create_and_get( [ 'form_id' => $form['id'], 'date_created' => time() - $default_timeout ] );
+
+		$this->assertInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		/* Logged-in owner */
+		$subscriber1 = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$subscriber2 = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$entry       = $factory->entry->create_and_get( [ 'form_id' => $form['id'], 'created_by' => $subscriber1 ] );
+
+		// fail
+		wp_set_current_user( $subscriber2 );
+		$this->assertInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		// pass
+		wp_set_current_user( $subscriber1 );
+		$this->assertNotInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		/* Restrict Owner */
+		$pdf['restrict_owner'] = 'Yes';
+		$this->assertInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		/* Give entry owner `gravityforms_view_entries` capability */
+		global $current_user;
+		$user = get_user_by( 'id', $subscriber1 );
+		$user->add_cap( 'gravityforms_view_entries' );
+		$current_user = $user;
+
+		$this->assertNotInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		/* Disable PDF */
+		$pdf['active'] = false;
+		$this->assertInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		/* Fail Conditional Logic */
+		$pdf['active'] = true;
+
+		// pass
+		$pdf['conditionalLogic'] = [
+			'actionType' => 'show',
+			'logicType'  => 'all',
+			'rules'      => [
+				[
+					'fieldId'  => '1',
+					'operator' => 'is',
+					'value'    => '',
+				],
+			],
+		];
+
+		$this->assertNotInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+		// fail
+		$pdf['conditionalLogic'] = [
+			'actionType' => 'show',
+			'logicType'  => 'all',
+			'rules'      => [
+				[
+					'fieldId'  => '1',
+					'operator' => 'isnot',
+					'value'    => '',
+				],
+			],
+		];
+
+		$this->assertInstanceOf( 'WP_Error', apply_filters( 'gfpdf_pdf_middleware', false, $entry, $pdf ) );
+
+	}
+
+
+}

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -655,7 +655,7 @@ class Test_PDF extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Check if our logged in user has access to our PDF
+	 * Check if our logged-in user has access to our PDF
 	 *
 	 * @since 4.0
 	 */
@@ -665,11 +665,19 @@ class Test_PDF extends WP_UnitTestCase {
 
 		/* create subscriber and test access */
 		$user_id = $this->factory->user->create();
-		$this->assertIsInt( $user_id );
 		wp_set_current_user( $user_id );
 
 		/* get the results */
 		$results = $this->model->middle_user_capability( true, [ 'id' => 0,  'created_by' => 0 ], [ 'id' => '', ] );
+
+		$this->assertTrue( is_wp_error( $results ) );
+		$this->assertEquals( 'access_denied', $results->get_error_code() );
+
+		/* make subscriber owner of the entry and test access */
+		$this->assertTrue( $this->model->middle_user_capability( true, [ 'id' => 0,  'created_by' => $user_id ], [ 'id' => '', ] ) );
+
+		/* make subscriber owner, but turn on the owner restrict setting and test access */
+		$results = $this->model->middle_user_capability( true, [ 'id' => 0,  'created_by' => $user_id ], [ 'id' => '', 'restrict_owner' => 'Yes' ] );
 
 		$this->assertTrue( is_wp_error( $results ) );
 		$this->assertEquals( 'access_denied', $results->get_error_code() );
@@ -679,9 +687,9 @@ class Test_PDF extends WP_UnitTestCase {
 		$user->remove_role( 'subscriber' );
 		$user->add_role( 'administrator' );
 
-		$this->assertTrue( $this->model->middle_user_capability( true, [ 'id' => 0, 'created_by' => 0 ], [ 'id' => '', ] ) );
+		$this->assertTrue( $this->model->middle_user_capability( true, [ 'id' => 0, 'created_by' => 0 ], [ 'id' => '', 'restrict_owner' => 'Yes'  ] ) );
 
-		/* Remove elevated user privilages and set the default capability 'gravityforms_view_entries' */
+		/* Remove elevated user privileges and set the default capability 'gravityforms_view_entries' */
 		$user->remove_role( 'administrator' );
 		$user->add_role( 'subscriber' );
 


### PR DESCRIPTION
## Description

Update middleware to correctly show an error if the entry owner tries viewing a PDF with the Restrict owner setting enabled and they don't have appropriate capabilities.

## Testing instructions
1. Create PDF on form and turn on Restrict Owner security setting
2. Create new subscriber user on site
3. Login as subscriber 
4. Submit Gravity Form
5. Try view PDF as subscriber (access denied)
6. Turn off Restrict Owner security setting
7. Try view PDF as subscriber again (can see PDF)
8. Logout 
9. Submit form as logged out user
10. Try view PDF as logged out user (access denied)
11. Login as administrator
12. Try view first and second PDFs (can see PDFs)
13. Submit form as administrator
14. Try view PDF (can see PDF)

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
