### PR TITLE
Only mask license if needed

### DIFF
--- a/gravity-pdf-updater.php
+++ b/gravity-pdf-updater.php
@@ -52,7 +52,7 @@ add_action(
 		$logger = \GPDFAPI::get_log_class();
 
 		$request_body = $parsed_args['body'] ?? [];
-		if ( isset( $request_body['license'] ) ) {
+		if ( isset( $request_body['license'] ) && is_string( $request_body['license'] ) && strlen( $request_body['license'] ) > 2 ) {
 			/* mask the license key, if exists */
 			$license                 = $request_body['license'];
 			$request_body['license'] = substr( $license, 0, 1 ) . str_repeat( '*', strlen( $license ) - 2 ) . substr( $license, -1, 1 );


### PR DESCRIPTION
## Description

Fix PHP error from occurring during license check if no license present (affects extensions).

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
