### PR TITLE
Improve column support when there is a spacer

### DIFF
--- a/src/Helper/Helper_Field_Container_Gf25.php
+++ b/src/Helper/Helper_Field_Container_Gf25.php
@@ -64,9 +64,14 @@ class Helper_Field_Container_Gf25 extends Helper_Field_Container {
 			$field->cssClass = trim( 'grid grid-' . $field->layoutGridColumnSpan . ' ' . $field->cssClass );
 		}
 
-		/* Mark as the end of this row */
+		/* Mark as the end of this row if Gravity Forms would insert a spacer */
 		if ( ! empty( $field->layoutSpacerGridColumnSpan ) ) {
-			$this->end_of_row = true;
+			$gform = \GPDFAPI::get_form_class();
+			$form  = $gform->get_form( $field->form_id );
+
+			if ( isset( $form['fields'] ) && ! empty( \GFFormDisplay::get_row_spacer( $field, $form ) ) ) {
+				$this->end_of_row = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Better calculate when Gravity Forms would insert a spacer into the form, so we can correctly end a row in the PDF.

## Testing instructions
1. Create a form with drag and drop columns
2. Set the width of a field in a column to only take up some of the space
3. Add additional rows and columns with a similar configuration
4. Add a PDF to the form
5. Preview the PDF

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
