### PR TITLE
Fix Website display when empty

### DIFF
--- a/src/Helper/Fields/Field_Website.php
+++ b/src/Helper/Fields/Field_Website.php
@@ -61,9 +61,12 @@ class Field_Website extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = $this->value();
+		$value  = $this->value();
+		$output = '';
 
-		$output = GFCommon::is_valid_url( $value ) ? '<a href="' . esc_url( $value ) . '" target="_blank">' . esc_html( $value ) . '</a>' : esc_html( $value );
+		if ( ! empty( $value ) ) {
+			$output = GFCommon::is_valid_url( $value ) ? '<a href="' . esc_url( $value ) . '" target="_blank">' . esc_html( $value ) . '</a>' : esc_html( $value );
+		}
 
 		return parent::html( $output );
 	}


### PR DESCRIPTION
## Description

If the Show Empty Fields option is enabled, and a Website field is not completed, ensure a non-breaking space is added to the value so it displays correctly in the PDF.

## Testing instructions
1. Create form with Website field and one other field
2. Submit test entry, leaving Website blank
3. Add Core PDF to form with _Show Empty Fields_ setting enabled
4. View PDF

Verify the website field includes a blank line below the label.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
