### PR TITLE
Update Background Processing Queue

### DIFF
--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -242,7 +242,17 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	 */
 	public function queue_async_tasks( $form, $entry ) {
 		foreach ( $this->form_async_notifications as $notification ) {
-			$this->queue->push_to_queue( $this->get_queue_tasks( $entry, $form, [ $notification ] ) );
+			$tasks = $this->get_queue_tasks( $entry, $form, [ $notification ] );
+
+			/* if older version of Gravity Forms group tasks together */
+			if ( version_compare( \GFCommon::$version, '2.9.7', '<' ) ) {
+				$this->queue->push_to_queue( $tasks );
+			} else {
+				/* if newer version of Gravity Forms, push each task individually */
+				foreach ( $tasks as $task ) {
+					$this->queue->push_to_queue( [ $task ] );
+				}
+			}
 		}
 	}
 
@@ -340,7 +350,7 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 
 		foreach ( $pdfs as $pdf ) {
 			$pdf_queue_data = [
-				'id'            => $this->get_queue_id( $form, $entry, $pdf ),
+				'id'            => 'create-pdf-' . $this->get_queue_id( $form, $entry, $pdf ),
 				'func'          => '\GFPDF\Statics\Queue_Callbacks::create_pdf',
 				'args'          => [ $entry['id'], $pdf['id'] ],
 				'unrecoverable' => true,
@@ -388,7 +398,7 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 			foreach ( $pdfs as $pdf ) {
 				if ( $this->model_pdf->maybe_attach_to_notification( $notification, $pdf, $entry, $form ) ) {
 					$queue_data[] = [
-						'id'   => $this->get_queue_id( $form, $entry, $pdf ) . '-' . $notification['id'],
+						'id'   => 'send-notification-' . $this->get_queue_id( $form, $entry, $pdf ) . '-' . $notification['id'],
 						'func' => '\GFPDF\Statics\Queue_Callbacks::send_notification',
 						'args' => [ $form['id'], $entry['id'], $notification ],
 					];

--- a/src/Helper/Helper_Pdf_Queue.php
+++ b/src/Helper/Helper_Pdf_Queue.php
@@ -18,14 +18,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! class_exists( 'WP_Async_Request' ) ) {
-	require_once GFCommon::get_base_path() . '/includes/libraries/wp-async-request.php';
-}
-
-if ( ! class_exists( 'GF_Background_Process' ) ) {
-	require_once GFCommon::get_base_path() . '/includes/libraries/gf-background-process.php';
-}
-
 /**
  * Class Helper_Pdf_Queue
  *
@@ -59,7 +51,8 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 	public function __construct( LoggerInterface $log ) {
 		parent::__construct();
 
-		$this->log = $log;
+		$this->log                        = $log;
+		$this->allowed_batch_data_classes = false;
 	}
 
 	/**
@@ -88,6 +81,9 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 		/* Something went wrong so cancel queue */
 		if ( ! isset( $callback['id'], $callback['func'] ) ) {
 			$this->log->critical( 'PDF queue ran with invalid queue item', [ 'callbacks' => $callbacks ] );
+
+			$this->cancel_process();
+
 			return false;
 		}
 
@@ -107,6 +103,9 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 					'callbacks' => $callbacks,
 				]
 			);
+
+			$this->cancel_process();
+
 			return false;
 		}
 
@@ -147,6 +146,8 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 							'callbacks' => $callbacks,
 						]
 					);
+
+					$this->cancel_process();
 
 					$callbacks = [];
 				}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -207,6 +207,17 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 			$this->templates
 		);
 
+		/* Load Background Queue classes */
+		if ( version_compare( \GFCommon::$version, '2.9.7.2', '>=' ) ) {
+			if ( ! class_exists( '\Gravity_Forms\Gravity_Forms\Async\GF_Background_Process' ) ) {
+				require_once GFCommon::get_base_path() . '/includes/async/class-gf-background-process.php';
+			}
+
+			class_alias( \Gravity_Forms\Gravity_Forms\Async\GF_Background_Process::class, 'GF_Background_Process', false );
+		} elseif ( ! class_exists( 'WP_Async_Request' ) ) {
+				require_once GFCommon::get_base_path() . '/includes/libraries/wp-async-request.php';
+		}
+
 		/* Setup our Singleton object */
 		$this->singleton = new Helper_Singleton();
 

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
@@ -289,17 +289,15 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 
 		$queue = $this->queue_mock->get_data();
 
-		$this->assertCount( 3, $queue[0] );
-		$this->assertCount( 3, $queue[1] );
-		$this->assertCount( 1, $queue[2] );
+		$this->assertCount( 7, $queue );
 
-		$actions = [ 'create_pdf', 'create_pdf', 'send_notification' ];
-		for ( $i = 0; $i < 3; $i++ ) {
-			$this->assertStringContainsString( $actions[ $i ], $queue[0][ $i ]['func'] );
-			$this->assertStringContainsString( $actions[ $i ], $queue[1][ $i ]['func'] );
-		}
-
-		$this->assertStringContainsString( 'cleanup_pdfs', $queue[2][0]['func'] );
+		$this->assertStringContainsString( 'create_pdf', $queue[0][0]['func'] );
+		$this->assertStringContainsString( 'create_pdf', $queue[1][0]['func'] );
+		$this->assertStringContainsString( 'send_notification', $queue[2][0]['func'] );
+		$this->assertStringContainsString( 'create_pdf', $queue[3][0]['func'] );
+		$this->assertStringContainsString( 'create_pdf', $queue[4][0]['func'] );
+		$this->assertStringContainsString( 'send_notification', $queue[5][0]['func'] );
+		$this->assertStringContainsString( 'cleanup_pdfs', $queue[6][0]['func'] );
 	}
 
 	/**
@@ -321,15 +319,10 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 
 		$queue = $this->queue_mock->get_data();
 
-		$this->assertCount( 3, $queue[0] );
-		$this->assertCount( 1, $queue[1] );
-
-		$actions = [ 'create_pdf', 'create_pdf', 'send_notification' ];
-		for ( $i = 0; $i < 3; $i++ ) {
-			$this->assertStringContainsString( $actions[ $i ], $queue[0][ $i ]['func'] );
-		}
-
-		$this->assertStringContainsString( 'cleanup_pdfs', $queue[1][0]['func'] );
+		$this->assertStringContainsString( 'create_pdf', $queue[0][0]['func'] );
+		$this->assertStringContainsString( 'create_pdf', $queue[1][0]['func'] );
+		$this->assertStringContainsString( 'send_notification', $queue[2][0]['func'] );
+		$this->assertStringContainsString( 'cleanup_pdfs', $queue[3][0]['func'] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Make compatible with library updates included in Gravity Forms 2.9.7 and 2.9.8. Backwards compatible with < GF 2.9.7 too.

See https://github.com/gravityforms/gravityforms/pull/3208 
See https://github.com/gravityforms/gravityforms/pull/3196

## Testing instructions
1. Enable PDF Background Processing
2. Configure PDF on a form with Notification attachment
3. Submit form
4. Use Resend Notification feature

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
