### PR TITLE
Compatibilty for Background Processing Library Update

### DIFF
--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -244,14 +244,9 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 		foreach ( $this->form_async_notifications as $notification ) {
 			$tasks = $this->get_queue_tasks( $entry, $form, [ $notification ] );
 
-			/* if older version of Gravity Forms group tasks together */
-			if ( version_compare( \GFCommon::$version, '2.9.7', '<' ) ) {
-				$this->queue->push_to_queue( $tasks );
-			} else {
-				/* if newer version of Gravity Forms, push each task individually */
-				foreach ( $tasks as $task ) {
-					$this->queue->push_to_queue( [ $task ] );
-				}
+			/* Push each task individually for forwards compatibility with new Background Processing update */
+			foreach ( $tasks as $task ) {
+				$this->queue->push_to_queue( [ $task ] );
 			}
 		}
 	}
@@ -350,10 +345,9 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 
 		foreach ( $pdfs as $pdf ) {
 			$pdf_queue_data = [
-				'id'            => 'create-pdf-' . $this->get_queue_id( $form, $entry, $pdf ),
-				'func'          => '\GFPDF\Statics\Queue_Callbacks::create_pdf',
-				'args'          => [ $entry['id'], $pdf['id'] ],
-				'unrecoverable' => true,
+				'id'   => 'create-pdf-' . $this->get_queue_id( $form, $entry, $pdf ),
+				'func' => '\GFPDF\Statics\Queue_Callbacks::create_pdf',
+				'args' => [ $entry['id'], $pdf['id'] ],
 			];
 
 			/* Check if we need to save the PDF due to a filter */

--- a/src/Helper/Helper_Pdf_Queue.php
+++ b/src/Helper/Helper_Pdf_Queue.php
@@ -42,6 +42,15 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 	protected $action = 'gravitypdf';
 
 	/**
+	 * Restrict object instantiation when using unserialize.
+	 *
+	 * @since 2.9.7
+	 *
+	 * @var bool|array
+	 */
+	protected $allowed_batch_data_classes = false;
+
+	/**
 	 * Helper_Pdf_Queue constructor.
 	 *
 	 * @param LoggerInterface $log
@@ -51,8 +60,7 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 	public function __construct( LoggerInterface $log ) {
 		parent::__construct();
 
-		$this->log                        = $log;
-		$this->allowed_batch_data_classes = false;
+		$this->log = $log;
 	}
 
 	/**
@@ -82,8 +90,6 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 		if ( ! isset( $callback['id'], $callback['func'] ) ) {
 			$this->log->critical( 'PDF queue ran with invalid queue item', [ 'callbacks' => $callbacks ] );
 
-			$this->cancel_process();
-
 			return false;
 		}
 
@@ -103,8 +109,6 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 					'callbacks' => $callbacks,
 				]
 			);
-
-			$this->cancel_process();
 
 			return false;
 		}
@@ -127,9 +131,9 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 				]
 			);
 
-			/* Add back to our queue to retry (up to a grand total of three times) */
-			if ( empty( $callback['retry'] ) || $callback['retry'] < 2 ) {
-				$callback['retry'] = isset( $callback['retry'] ) ? $callback['retry'] + 1 : 1;
+			/* Add back to our queue to retry once */
+			if ( empty( $callback['retry'] ) ) {
+				$callback['retry'] = 1;
 				array_unshift( $callbacks, $callback );
 			} else {
 				$this->log->error(
@@ -138,19 +142,6 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 						$callback['id']
 					)
 				);
-
-				if ( $callback['unrecoverable'] ?? false ) {
-					$this->log->critical(
-						'Cancel async queue due to retry limit reached on unrecoverable callback.',
-						[
-							'callbacks' => $callbacks,
-						]
-					);
-
-					$this->cancel_process();
-
-					$callbacks = [];
-				}
 			}
 		}
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -213,7 +213,9 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 				require_once GFCommon::get_base_path() . '/includes/async/class-gf-background-process.php';
 			}
 
-			class_alias( \Gravity_Forms\Gravity_Forms\Async\GF_Background_Process::class, 'GF_Background_Process', false );
+			if ( ! class_exists( 'GF_Background_Process' ) ) {
+				class_alias( \Gravity_Forms\Gravity_Forms\Async\GF_Background_Process::class, 'GF_Background_Process', false );
+			}
 		} elseif ( ! class_exists( 'WP_Async_Request' ) ) {
 				require_once GFCommon::get_base_path() . '/includes/libraries/wp-async-request.php';
 		}

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
@@ -115,16 +115,16 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test our queue attempts to run up to three times when a function throws an exception
+	 * Test our queue attempts to run up to two times when a function throws an exception
 	 *
 	 * @since 5.0
 	 */
 	public function test_failed_queue_tasks() {
 		$mock = $this->getMockBuilder( 'stdClass' )
-					 ->setMethods( [ 'callback' ] )
+					 ->addMethods( [ 'callback' ] )
 					 ->getMock();
 
-		$mock->expects( $this->exactly( 3 ) )
+		$mock->expects( $this->exactly( 2 ) )
 			 ->method( 'callback' )
 			 ->will( $this->throwException( new Exception ) );
 


### PR DESCRIPTION
## Description

Update PDF Background Processing to be compatible with updated background processing library

Rather than dispatch a bunch of individual queues, traditionally, Gravity PDF has treated a queue as a bunch of mini queues. In a new GF update, retry support has been added if a queue returns anything besides `false`, which caused big delays processing the mini queues in Gravity PDF.

Rewriting Gravity PDF to convert the mini queues into individual queues would be a breaking change and a lot of development time. Instead, we'll merge all the mini queues together to be processed sequentially.

Along with this adjustment, the retry logic has been reduced from 3 to 1. This allows for faster processing of a queue when an error does occur, since there will only be one extra timeout period instead of three.

The unrecoverable error has also been removed, as this would prevent any other PDFs from generating or Notification emails being sent. The benefit to this is the Notification emails will still be sent out, even if a PDF isn't attached.

The deprecation notice from GF 2.9.7 was addressed in 062f3e4c3f7e5eb8d5255a6df55c9c307531288d

## Testing instructions
1. Enable PDF Background Processing
2. Setup a Notification + PDF Attachment
3. Submit form

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
