### PR TITLE
Extra checks for valid data processing File Upload fields

### DIFF
--- a/src/Helper/Fields/Field_Fileupload.php
+++ b/src/Helper/Fields/Field_Fileupload.php
@@ -141,10 +141,14 @@ class Field_Fileupload extends Helper_Abstract_Fields {
 		$files = [];
 
 		if ( ! empty( $value ) ) {
-			$paths = ( $this->field->multipleFiles ) ? json_decode( $value ) : [ $value ];
+			$paths = $this->field->multipleFiles ? json_decode( $value, true ) : [ $value ];
 
 			if ( is_array( $paths ) && count( $paths ) > 0 ) {
 				foreach ( $paths as $path ) {
+					if ( ! is_string( $path ) ) {
+						continue;
+					}
+
 					$files[] = esc_url( $path );
 				}
 			}


### PR DESCRIPTION
## Description

User reported a fatal error was occurring when processing a file upload with Hebrew in the filename:

```
[10-Jun-2025 15:57:32 UTC] PHP Fatal error: Uncaught TypeError: ltrim(): Argument #1 ($string) must be of type string, stdClass given in /wp-includes/formatting.php:4476

Stack trace:

#0 /wp-includes/formatting.php(4476): ltrim()
#1 /wp-content/plugins/gravity-forms-pdf-extended/src/Helper/Fields/Field_Fileupload.php(148): esc_url()
#2 /wp-content/plugins/gravity-forms-pdf-extended/src/Helper/Fields/Field_Fileupload.php(62): GFPDF\Helper\Fields\Field_Fileupload->value()

```

These changes add extra checks to ensure only valid data is processed.

## Testing instructions
1. Add both a single and multi File Upload field to a form
2. Upload a file with Hebrew in the name and submit the form
3. View a Core PDF
4. Verify there are no errors

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->

Wasn't able to personally replicate this, but the changes should fix the problem.