### PR TITLE
Add queue cleanup when Background Processing toggled

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -956,6 +956,28 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		$this->singleton->add_class( $queue );
 		$this->singleton->add_class( $class );
+
+		/**
+		 * Clear our any items in the queue when the feature is toggled on/off
+		 *
+		 * Needs to be outside the controller class so it works when the feature is toggled on and off.
+		 *
+		 * @param string $new_value The value being saved for the Background Processing setting
+		 *
+		 * @since 6.12.6
+		 */
+		$gfpdf_settings_sanitize = function ( $new_value, $key ) use ( $queue ) {
+			if ( $key === 'background_processing' ) {
+				$current_value = \GPDFAPI::get_plugin_option( 'background_processing' );
+				if ( $current_value !== $new_value ) {
+					$queue->clear_queue();
+				}
+			}
+
+			return $new_value;
+		};
+
+		add_filter( 'gfpdf_settings_sanitize', $gfpdf_settings_sanitize, 10, 2 );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
@@ -4,6 +4,7 @@ namespace GFPDF\Tests;
 
 use Exception;
 use GFPDF\Controller\Controller_Pdf_Queue;
+use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Pdf_Queue;
 use GFPDF\Statics\Queue_Callbacks;
 use WP_UnitTestCase;
@@ -368,5 +369,44 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 
 		$this->assertFileDoesNotExist( $test_file );
 		$this->assertFileDoesNotExist( $path );
+	}
+
+	/**
+	 * Verify any scheduled queues are cleaned up when the queue setting is toggled
+	 *
+	 * @since 6.12.6
+	 */
+	public function test_queue_cleanup() {
+		global $gfpdf;
+
+		/* setup page */
+		$_POST['option_page'] = 'gfpdf_settings';
+		$_POST['_wp_http_referer'] = '/';
+
+		$queue = new Helper_Pdf_Queue( $gfpdf->log );
+
+		/* Create queue and verify  */
+		$queue->push_to_queue( 'item1' )->save();
+		$queue->push_to_queue( 'item2' )->save();
+
+		$this->assertCount( 2, $queue->get_batches() );
+
+		/* Toggle the settings and verify */
+		/** @var Helper_Abstract_Options $options */
+		$options = $gfpdf->options;
+
+		$options->update_option( 'background_processing', 'Yes' );
+		$options->update_settings( [ 'background_processing' => 'No' ] );
+
+		$this->assertCount( 0, $queue->get_batches() );
+
+		/* Add new queue items, update the settings without toggling and verify the queue remains */
+		$queue->push_to_queue( 'item1' )->save();
+		$queue->push_to_queue( 'item2' )->save();
+
+		$this->assertCount( 2, $queue->get_batches() );
+
+		$options->update_settings( [ 'background_processing' => 'No' ] );
+		$this->assertCount( 2, $queue->get_batches() );
 	}
 }


### PR DESCRIPTION
## Description

Currently queues aren't removed when the feature is toggled on/off, so it is possible to:

1. Have the Background Processing feature enabled
2. Queue a bunch of background tasks
3. Disable the feature before the queue is run
4. At some point in the future re-enable the Background Processing feature
5. Have the old queue items processed, resulting in a bunch of old entry notifications sent

This update will automatically flush the queue when Background Processing is enabled/disabled.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
