### PR TITLE
Field_List: Reset the list array keys after filtering

### DIFF
--- a/src/Helper/Fields/Field_List.php
+++ b/src/Helper/Fields/Field_List.php
@@ -102,7 +102,7 @@ class Field_List extends Helper_Abstract_Fields {
 
 		/* get out field value */
 		$value   = $this->value();
-		$columns = is_array( $value[0] );
+		$columns = is_array( $value[0] ?? '' );
 
 		/* Start buffer and generate a list table */
 		ob_start();
@@ -191,7 +191,7 @@ class Field_List extends Helper_Abstract_Fields {
 	 *
 	 * @since 4.0
 	 */
-	private function remove_empty_list_rows( $list_array ) {
+	protected function remove_empty_list_rows( $list_array ) {
 
 		/* if list field empty return early */
 		if ( ! is_array( $list_array ) || count( $list_array ) === 0 ) {
@@ -218,12 +218,19 @@ class Field_List extends Helper_Abstract_Fields {
 					}
 				}
 
+				unset( $col );
+
 				/* Remove row from list */
 				if ( $empty ) {
 					unset( $list_array[ $id ] );
 				}
 			}
+
+			unset( $row );
 		}
+
+		/* Reset the array structure */
+		$list_array = array_values( $list_array );
 
 		return $list_array;
 	}

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_List.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_List.php
@@ -1,0 +1,69 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Fields;
+
+use GF_Field_List;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2025, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   helper
+ * @group   fields
+ */
+class Test_Field_List extends WP_UnitTestCase {
+
+	public function test_value_single_column() {
+		$field = new GF_Field_List( [
+			'id' => 1,
+		] );
+
+		$entry = [
+			'form_id' => 0,
+			'1'       => serialize( [ '', 'Row 2', '', 'Row 3' ] ),
+		];
+
+		$pdf_field = new Field_List( $field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+
+		$value = $pdf_field->value();
+		$this->assertCount( 2, $value );
+		$this->assertEquals( 'Row 2', $value[0] );
+		$this->assertEquals( 'Row 3', $value[1] );
+	}
+
+	public function test_value_multi_column() {
+		$field = new GF_Field_List( [
+			'id'      => 1,
+			'choices' => [
+				[ 'text' => 'Column 1' ],
+				[ 'text' => 'Column 2' ],
+			],
+		] );
+
+		$entry = [
+			'form_id' => 0,
+			'1'       => serialize( [
+				[ 'Column 1' => '', 'Column 2' => '' ],
+				[ 'Column 1' => 'Row 2 a', 'Column 2' => 'Row 2 b' ],
+				[ 'Column 1' => 'Row 3 a', 'Column 2' => 'Row 3 b' ],
+				[ 'Column 1' => '', 'Column 2' => '' ],
+			] ),
+		];
+
+		$pdf_field = new Field_List( $field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+
+		$value = $pdf_field->value();
+
+		$this->assertCount( 2, $value );
+		$this->assertEquals( 'Row 2 a', $value[0]['Column 1'] );
+		$this->assertEquals( 'Row 2 b', $value[0]['Column 2'] );
+		$this->assertEquals( 'Row 3 a', $value[1]['Column 1'] );
+		$this->assertEquals( 'Row 3 b', $value[1]['Column 2'] );
+	}
+}


### PR DESCRIPTION
## Description

Fixes display issues and PHP notice in Core/Universal PDF templates due to array key issues.

Resolves #1600 

## Testing instructions
1. Add a single-column and multi-column List field to a form and save
2. Fill out the form, add multiple rows to each list field, but leave the first row blank
3. Setup a Core PDF on the form and view

If you've PHP errors enabled, you'll see multiple notices in the PDF and the multi-column List field won't display correctly.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
