### PR TITLE
Improve System Status Display

### DIFF
--- a/src/Controller/Controller_System_Report.php
+++ b/src/Controller/Controller_System_Report.php
@@ -65,12 +65,13 @@ class Controller_System_Report extends Helper_Abstract_Controller {
 	}
 
 	/**
-	 * Include the add-on table in the PHP Server Environment system status.
+	 * Add the Gravity PDF system report to the Gravity Forms report
 	 *
 	 * @param array $system_report
 	 *
 	 * @return array
 	 * @since 5.3
+	 * @since 6.12.6 Moved data to the end of the report
 	 */
 	public function system_report( $system_report ) {
 
@@ -78,7 +79,10 @@ class Controller_System_Report extends Helper_Abstract_Controller {
 			$gravitypdf_report = $this->model->build_gravitypdf_report();
 			$system_report     = $this->model->move_gravitypdf_active_plugins_to_gf_addons( $system_report );
 
-			array_splice( $system_report, 1, 0, $gravitypdf_report );
+			$system_report = array_merge(
+				$system_report,
+				$gravitypdf_report
+			);
 		}
 
 		return $system_report;

--- a/src/Model/Model_System_Report.php
+++ b/src/Model/Model_System_Report.php
@@ -175,6 +175,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 		$items[0] = [
 			'memory'            => [
 				'label'        => esc_html__( 'WP Memory', 'gravity-pdf' ),
+				'label_export' => 'WP Memory',
 				'value'        => $memory['value'],
 				'value_export' => $memory['value_export'],
 			],
@@ -186,53 +187,62 @@ class Model_System_Report extends Helper_Abstract_Model {
 			],
 
 			'default_charset'   => [
-				'label' => esc_html__( 'Default Charset', 'gravity-pdf' ),
-				'value' => ini_get( 'default_charset' ),
+				'label'        => esc_html__( 'Default Charset', 'gravity-pdf' ),
+				'label_export' => 'Default Charset',
+				'value'        => ini_get( 'default_charset' ),
 			],
 
 			'internal_encoding' => [
-				'label' => esc_html__( 'Internal Encoding', 'gravity-pdf' ),
-				'value' => ini_get( 'internal_encoding' ) ?: ini_get( 'default_charset' ), //phpcs:ignore Universal.Operators.DisallowShortTernary.Found
+				'label'        => esc_html__( 'Internal Encoding', 'gravity-pdf' ),
+				'label_export' => 'Internal Encoding',
+				'value'        => ini_get( 'internal_encoding' ) ?: ini_get( 'default_charset' ), //phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 			],
 		];
 
 		/* Directory and Permissions */
 		$items[1] = [
 			'pdf_working_directory'     => [
-				'label' => esc_html__( 'PDF Working Directory', 'gravity-pdf' ),
-				'value' => $this->templates->get_template_path(),
+				'label'        => esc_html__( 'PDF Working Directory', 'gravity-pdf' ),
+				'label_export' => 'PDF Working Directory',
+				'value'        => $this->templates->get_template_path(),
 			],
 
 			'pdf_working_directory_url' => [
-				'label' => esc_html__( 'PDF Working Directory URL', 'gravity-pdf' ),
-				'value' => $this->templates->get_template_url(),
+				'label'        => esc_html__( 'PDF Working Directory URL', 'gravity-pdf' ),
+				'label_export' => 'PDF Working Directory URL',
+				'value'        => $this->templates->get_template_url(),
 			],
 
 			'font_folder_location'      => [
-				'label' => esc_html__( 'Font Folder location', 'gravity-pdf' ),
-				'value' => $this->data->template_font_location,
+				'label'        => esc_html__( 'Font Folder location', 'gravity-pdf' ),
+				'label_export' => 'Font Folder location',
+				'value'        => $this->data->template_font_location,
 			],
 
 			'temp_folder_location'      => [
-				'label' => esc_html__( 'Temporary Folder location', 'gravity-pdf' ),
-				'value' => $this->data->template_tmp_location,
+				'label'        => esc_html__( 'Temporary Folder location', 'gravity-pdf' ),
+				'label_export' => 'Temporary Folder location',
+				'value'        => $this->data->template_tmp_location,
 			],
 
 			'temp_folder_permission'    => [
 				'label'        => esc_html__( 'Temporary Folder permissions', 'gravity-pdf' ),
+				'label_export' => 'Temporary Folder permissions',
 				'value'        => $temp_folder_permission['value'],
 				'value_export' => $temp_folder_permission['value_export'],
 			],
 
 			'temp_folder_protected'     => [
 				'label'        => esc_html__( 'Temporary Folder protected', 'gravity-pdf' ),
+				'label_export' => 'Temporary Folder protected',
 				'value'        => $temp_folder_protected['value'],
 				'value_export' => $temp_folder_protected['value_export'],
 			],
 
 			'mpdf_temp_folder_location' => [
-				'label' => esc_html__( 'mPDF Temporary location', 'gravity-pdf' ),
-				'value' => $this->data->mpdf_tmp_location,
+				'label'        => esc_html__( 'mPDF Temporary location', 'gravity-pdf' ),
+				'label_export' => 'mPDF Temporary location',
+				'value'        => $this->data->mpdf_tmp_location,
 			],
 		];
 
@@ -241,6 +251,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 		if ( ! empty( $template_status ) ) {
 			$items[1]['outdated_templates'] = [
 				'label'        => esc_html__( 'Outdated Templates', 'gravity-pdf' ),
+				'label_export' => 'Outdated Templates',
 				'value'        => $template_status['value'],
 				'value_export' => $template_status['value_export'],
 			];
@@ -260,24 +271,28 @@ class Model_System_Report extends Helper_Abstract_Model {
 		$items[2] = [
 			'canonical_release'             => [
 				'label'        => esc_html__( 'Canonical Release', 'gravity-pdf' ),
+				'label_export' => 'Canonical Release',
 				'value'        => $is_canonical_release ? $this->getController()->view->get_icon( true ) : $this->getController()->view->get_icon( false ) . $is_not_canonical_release_message,
-				'value_export' => $is_canonical_release ? esc_html__( 'Yes', 'gravity-pdf' ) : esc_html__( 'No', 'gravity-pdf' ),
+				'value_export' => $is_canonical_release ? 'Yes' : 'No',
 			],
 
 			'pdf_entry_list_action'         => [
 				'label'        => esc_html__( 'PDF Entry List Action', 'gravity-pdf' ),
+				'label_export' => 'PDF Entry List Action',
 				'value'        => $this->options->get_option( 'default_action', 'View' ) === 'View' ? esc_html__( 'View', 'gravity-pdf' ) : esc_html__( 'Download', 'gravity-pdf' ),
 				'value_export' => $this->options->get_option( 'default_action', 'View' ),
 			],
 
 			'background_processing_enabled' => [
 				'label'        => esc_html__( 'Background Processing', 'gravity-pdf' ),
+				'label_export' => 'Background Processing',
 				'value'        => $this->options->get_option( 'background_processing', 'No' ) === 'Yes' ? $this->getController()->view->get_icon( true ) : esc_html__( 'Off', 'gravity-pdf' ),
 				'value_export' => $this->options->get_option( 'background_processing', 'No' ),
 			],
 
 			'debug_mode_enabled'            => [
 				'label'        => esc_html__( 'Debug Mode', 'gravity-pdf' ),
+				'label_export' => 'Debug Mode',
 				'value'        => $this->options->get_option( 'debug_mode', 'No' ) === 'Yes' ? $this->getController()->view->get_icon( true ) : esc_html__( 'Off', 'gravity-pdf' ),
 				'value_export' => $this->options->get_option( 'debug_mode', 'No' ),
 			],
@@ -286,12 +301,14 @@ class Model_System_Report extends Helper_Abstract_Model {
 		/* Security Settings */
 		$items[3] = [
 			'user_restrictions'  => [
-				'label' => esc_html__( 'User Restrictions', 'gravity-pdf' ),
-				'value' => implode( ', ', $this->options->get_option( 'admin_capabilities', [ 'gravityforms_view_entries' ] ) ),
+				'label'        => esc_html__( 'User Restrictions', 'gravity-pdf' ),
+				'label_export' => 'User Restrictions',
+				'value'        => implode( ', ', $this->options->get_option( 'admin_capabilities', [ 'gravityforms_view_entries' ] ) ),
 			],
 
 			'logged_out_timeout' => [
 				'label'        => esc_html__( 'Logged Out Timeout', 'gravity-pdf' ),
+				'label_export' => 'Logged Out Timeout',
 				'value'        => $this->options->get_option( 'logged_out_timeout', '20' ) . ' ' . esc_html__( 'minute(s)', 'gravity-pdf' ),
 				'value_export' => $this->options->get_option( 'logged_out_timeout', '20' ) . ' minutes(s)',
 			],
@@ -310,7 +327,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 
 		return [
 			'value'        => $this->getController()->view->memory_limit_markup( $memory ),
-			'value_export' => $memory . 'MB',
+			'value_export' => $memory === -1 ? 'Unlimited' : $memory . 'MB',
 		];
 	}
 

--- a/src/View/View_System_Report.php
+++ b/src/View/View_System_Report.php
@@ -126,9 +126,11 @@ class View_System_Report extends Helper_Abstract_View {
 	public function get_template_check_message( string $path, string $template_version, string $core_version ): array {
 		$message = sprintf( esc_html__( '%1$s version %2$s is out of date. The core version is %3$s', 'gravity-pdf' ), $path, '<span style="color: #ff0000;font-weight:bold">' . $template_version . '</span>', $core_version );
 
+		$export_message = sprintf( '%1$s version %2$s is out of date. The core version is %3$s', $path, $template_version, $core_version );
+
 		return [
 			'value'        => $message . $this->get_icon( false ) . '<hr>',
-			'value_export' => wp_strip_all_tags( $message ) . "   &#10008;\n",
+			'value_export' => $export_message . "   &#10008;\n",
 		];
 	}
 


### PR DESCRIPTION
## Description

1. Move Gravity PDF info to bottom of report for quick viewing in support tickets
2. Don't translate labels in exported report
3. Don't translate outdated template export value
4. Display "unlimited" WordPress Memory in export value if PHP memory set to -1

Fixes #1597

## Testing instructions

1. Navigate to Forms -> System Report
2. View report
3. Export the System Report
4. Paste the report into a text editor and view
5. Set site language to Spanish
6. View and export report

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
