### PR TITLE
Prevent Fatal Error when file system log location is readonly

### DIFF
--- a/src/Helper/Helper_Logger.php
+++ b/src/Helper/Helper_Logger.php
@@ -164,6 +164,16 @@ class Helper_Logger {
 			/* Enable logging if not equivalent to 0 or non-existent and not level 6 ("off" in GF world) */
 			if ( ! empty( $log_level ) && $log_level !== 6 ) {
 
+				/* Check log file can be created */
+				$log_path = dirname( $log_filename );
+				if ( ! wp_mkdir_p( $log_path ) ) {
+					return;
+				}
+
+				if ( ! @touch( $log_filename ) ) { // phpcs:ignore
+					return;
+				}
+
 				/* Convert Gravity Forms log levels to the appropriate Monolog level */
 				$monolog_level = ( $log_level === 4 ) ? Logger::ERROR : Logger::DEBUG;
 


### PR DESCRIPTION
## Description

Manually create the log file before initializing, and exit early if this fails. On a read-only filesystem the log file won't be created, and Monolog will auto-drop all log messages.

Resolves #1580

## Testing instructions

1. On a Mac or Linux machine, in a CLI run `chmod 500 wp-content/uploads/gravity_forms` in the root WordPress directory
2. Verify the GF upload directory is read-only by navigating to Forms -> System Status
3. Enable Gravity Forms logging
4. Try generate a PDF

Verify no fatal errors occur.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
