### PR TITLE
Fix memory issue with lots of classes on Rich Text Field

### DIFF
--- a/src/Helper/Fields/Field_Textarea.php
+++ b/src/Helper/Fields/Field_Textarea.php
@@ -7,7 +7,10 @@ use GF_Field_Textarea;
 use GFPDF\Helper\Helper_Abstract_Fields;
 use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Misc;
+use GFPDF\Helper\Helper_QueryPath;
 use GFPDF\Statics\Kses;
+use GFPDF_Vendor\QueryPath\CSS\ParseException;
+use GFPDF_Vendor\QueryPath\DOMQuery;
 
 /**
  * @package     Gravity PDF
@@ -53,7 +56,44 @@ class Field_Textarea extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$value = $this->value();
 
+		/**
+		 * Allow a maximum of 8 User-Defined CSS Classes to prevent memory issues in mPDF
+		 * @see https://github.com/mpdf/mpdf/issues/1753
+		 */
+		if ( ! empty( $this->field->useRichTextEditor ) ) {
+			try {
+				$qp  = new Helper_QueryPath();
+				$dom = $qp->html5( $value );
+				$this->strip_extra_classes_from_dom( $dom );
+				$value = (string) $dom->top( 'html' )->innerHTML5();
+			} catch ( \Exception $e ) {
+				// do nothing
+			}
+		}
+
 		return parent::html( $value );
+	}
+
+	/**
+	 * Recursively check DOM node for class attribute and remove any with 9+ classes
+	 *
+	 * @param DOMQuery $dom
+	 *
+	 * @return void
+	 * @throws ParseException
+	 */
+	protected function strip_extra_classes_from_dom( $dom ) {
+		foreach ( $dom->children() as $child_dom ) {
+			$this->strip_extra_classes_from_dom( $child_dom );
+		}
+
+		$classes     = $dom->attr( 'class' );
+		$class_array = explode( ' ', $classes );
+		if ( count( $class_array ) > 8 ) {
+			$class_array = array_slice( $class_array, 0, 8 );
+			// Set the new class attribute value.
+			$dom->attr( 'class', implode( ' ', $class_array ) );
+		}
 	}
 
 	/**
@@ -70,7 +110,7 @@ class Field_Textarea extends Helper_Abstract_Fields {
 
 		$value = $this->get_value();
 
-		if ( isset( $this->field->useRichTextEditor ) && true === $this->field->useRichTextEditor ) {
+		if ( ! empty( $this->field->useRichTextEditor ) ) {
 			$html = Kses::parse(
 				wpautop(
 					$this->gform->process_tags( $value, $this->form, $this->entry )

--- a/src/Helper/Helper_Abstract_Fields.php
+++ b/src/Helper/Helper_Abstract_Fields.php
@@ -341,7 +341,7 @@ abstract class Helper_Abstract_Fields implements Helper_Interface_Field_Pdf_Conf
 		}
 
 		/* Backwards compat */
-		$value = apply_filters( 'gfpdf_field_content', $value, $this->field, GFFormsModel::get_lead_field_value( $this->entry, $this->field ), $this->entry['id'], $this->form['id'] );
+		$value = apply_filters( 'gfpdf_field_content', $value, $this->field, GFFormsModel::get_lead_field_value( $this->entry, $this->field ), $this->entry['id'] ?? 0, $this->form['id'] ?? 0 );
 
 		/**
 		 * See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_pdf_field_content for usage

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Textarea.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Textarea.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Fields;
+
+use GF_Field_Textarea;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2025, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   helper
+ * @group   fields
+ */
+class Test_Field_Textarea extends WP_UnitTestCase {
+
+	public function test_rich_text_html() {
+		$field = new GF_Field_Textarea( [
+			'id' => 1,
+			'useRichTextEditor' => true,
+		] );
+
+		$entry = [
+			'id' => 0,
+			'form_id' => 0,
+			'1'       => '<div class="a b c d e f g h i j k l m n o p q r s t u v w x y z">Hi <ul id="list"><li>Item 1</li><li class="1 2 3 4 5 6 7 8 9 10 11 12 13">Item 2</li><li>Item 3</li></ul></div><p class="a b c">My paragraph</p>',
+		];
+
+		$pdf_field = new Field_Textarea( $field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+
+		$value = $pdf_field->html();
+		$this->assertStringContainsString('<div class="a b c d e f g h">Hi <ul id="list"><li>Item 1</li><li class="1 2 3 4 5 6 7 8">Item 2</li><li>Item 3</li></ul></div><p class="a b c">My paragraph</p>', str_replace( [ "\n", "\t" ], '', $value ) );
+	}
+}


### PR DESCRIPTION
## Description

Strip excess classes from nodes when they contain more than 8 individual classes.

Resolves #1536

## Testing instructions
1. Create form with paragraph field w/rich text option enabled
2. Submit the form with any data
3. Edit the entry on the Entry Details page
4. Enter `<div class="a b c d e f g h i j k l m n o p q r s t u v w x y z">Hi <ul id="list"><li>Item 1</li><li class="1 2 3 4 5 6 7 8 9 10 11 12 13">Item 2</li><li>Item 3</li></ul></div><p class="a b c">My paragraph</p>` into the Rich Text field (now only a textarea) and save the entry
5. Setup a Core PDF on the form
6. View the PDF

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
