### PR TITLE
Standardize Products Empty Check

### DIFF
--- a/src/Helper/Fields/Field_Products.php
+++ b/src/Helper/Fields/Field_Products.php
@@ -37,12 +37,14 @@ class Field_Products extends Helper_Abstract_Fields {
 	 */
 	public function is_empty() {
 
-		/* Set up the form / lead information */
-		$form = $this->form;
-		$lead = $this->entry;
+		$form  = $this->form;
+		$entry = $this->entry;
 
 		/* Get all products for this field */
-		$products = GFCommon::get_product_fields( $form, $lead, true );
+		$use_value       = (bool) apply_filters( 'gfpdf_show_field_value', false, $this->field, '' ); /* Set to `true` to show a field's value instead of the label */
+		$use_admin_label = (bool) apply_filters( 'gfpdf_use_admin_label', false, $this->field, '' ); /* Set to `true` to use the admin label */
+
+		$products = GFCommon::get_product_fields( $form, $entry, ! $use_value, $use_admin_label );
 
 		if ( count( $products['products'] ) > 0 ) {
 			return false; /* not empty */


### PR DESCRIPTION
## Description

When getting the product fields to determine if its empty, pass the filtered `use_value` and `use_admin_label` arguments to match the actual PDF output.

Fixes #1595

## Testing instructions

1. Create a form with products
2. Submit the form
3. Create a Core PDF on the form
4. View the PDF and verify the Product Table at the end of the document matches the Entry Details page
## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
