### PR TITLE
Extra checks for GP Populate Anything classes/methods

### DIFF
--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -2418,6 +2418,10 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @since 5.3
 	 */
 	public function process_gp_populate_anything( $text, $form, $entry ) {
+		if ( ! method_exists( '\GP_Populate_Anything_Live_Merge_Tags', 'replace_live_merge_tags_static' ) ) {
+			return $text;
+		}
+
 		$gp = GP_Populate_Anything_Live_Merge_Tags::get_instance();
 
 		$this->disable_gp_populate_anything();
@@ -2543,6 +2547,10 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @since 6.10.2
 	 */
 	public function gp_populate_anything_hydrate_form( $form, $entry ) {
+		if ( ! method_exists( '\GP_Populate_Anything', 'populate_form' ) ) {
+			return $form;
+		}
+
 		static $cache = [];
 
 		$form_id  = $form['id'] ?? '';


### PR DESCRIPTION
## Description

Prevents a fatal error if a user is running a very old version of the software, or these classes/methods are removed in a future release.

## Testing instructions

1. Install GP Populate Anything and configure on a form
2. Setup Core PDF template on a form
3. Verify you can view the PDF

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
