### PR TITLE
Mpdf enhancements

### DIFF
--- a/.php-scoper/mpdf.php
+++ b/.php-scoper/mpdf.php
@@ -62,6 +62,10 @@ return [
 				$content = str_replace( "$prefix\\\\</t\\\\1", '</t\\\\1', $content );
 			}
 
+			if ( basename( $filePath ) === 'ServiceFactory.php' ) {
+				$content = str_replace( 'new Cache(', 'new \GFPDF\Helper\Mpdf\Cache(', $content );
+			}
+
 			/* Remove type hinting from prefixed logger */
 			$files = [
 				'LoggerAwareInterface.php',

--- a/bin/install-gravityforms.sh
+++ b/bin/install-gravityforms.sh
@@ -10,8 +10,8 @@ if [ -f ".env" ]; then
 fi
 
 # Install in both development + test environments
-npm run wp-env run cli wp gf install -- -- --key=$GF_LICENSE --activate --force --version=beta
-npm run wp-env run tests-cli wp gf install -- -- --key=$GF_LICENSE --activate --force --version=beta
+npm run wp-env run cli wp gf install -- -- --key=$GF_LICENSE --activate --force
+npm run wp-env run tests-cli wp gf install -- -- --key=$GF_LICENSE --activate --force
 
 # Install add-ons in the test environment
 npm run wp-env run tests-cli wp gf install gravityformspolls -- --key=$GF_LICENSE --activate --force

--- a/src/Helper/Helper_Mpdf.php
+++ b/src/Helper/Helper_Mpdf.php
@@ -2,12 +2,7 @@
 
 namespace GFPDF\Helper;
 
-use GFPDF_Vendor\Mpdf\HTMLParserMode;
-use GFPDF_Vendor\Mpdf\Mpdf;
-use GFPDF_Vendor\Mpdf\MpdfException;
-use GFPDF_Vendor\setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
-use GFPDF_Vendor\setasign\Fpdi\PdfParser\PdfParserException;
-use GFPDF_Vendor\setasign\Fpdi\PdfParser\Type\PdfTypeException;
+use GFPDF\Helper\Mpdf\Mpdf;
 
 /**
  * @package     Gravity PDF
@@ -21,98 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * @since 5.2
+ * @since     5.2
+ * @depecated 6.13.0 Use \GFPDF\Helper\Mpdf\Mpdf instead
  */
 class Helper_Mpdf extends Mpdf {
-
-	/**
-	 * Added for backwards compatibility as it was removed in mPDF 8.0
-	 *
-	 * @since 5.2
-	 */
-	public function SetImportUse() {
-		/* Do nothing */
-	}
-
-	/**
-	 * @param int    $pageNumber The page number.
-	 * @param null   $crop_x     mPDF 8.0 removed this parameter
-	 * @param null   $crop_y     mPDF 8.0 removed this parameter
-	 * @param int    $crop_w     mPDF 8.0 removed this parameter
-	 * @param int    $crop_h     mPDF 8.0 removed this parameter
-	 * @param string $boxName    The page boundary to import.
-	 *
-	 * @return string A unique string identifying the imported page.
-	 * @throws CrossReferenceException
-	 * @throws PdfParserException
-	 * @throws PdfTypeException
-	 *
-	 * @since 5.2
-	 */
-	public function importPage( $pageNumber = 1, $crop_x = null, $crop_y = null, $crop_w = 0, $crop_h = 0, $boxName = 'CropBox' ) {
-		/* mPDF 8.0 no longer needs the box name with `/` included */
-		if ( $boxName[0] === '/' ) {
-			$boxName = substr( $boxName, 1 );
-		}
-
-		/* The signature of this method has changed */
-
-		return parent::importPage( $pageNumber, $boxName );
-	}
-
-	/**
-	 * Draws an imported page or a template onto the page or another template.
-	 *
-	 * Omit one of the size parameters (width, height) to calculate the other one automatically in view to the aspect
-	 * ratio.
-	 *
-	 * @param mixed           $tpl    The template id
-	 * @param float|int|array $x      The abscissa of upper-left corner. Alternatively you could use an assoc array
-	 *                                with the keys "x", "y", "width", "height", "adjustPageSize".
-	 * @param float|int       $y      The ordinate of upper-left corner.
-	 * @param float|int|null  $width  The width.
-	 * @param float|int|null  $height The height.
-	 * @param bool            $adjustPageSize
-	 *
-	 * @return array The size
-	 * @see   Fpdi::getTemplateSize()
-	 *
-	 * @since 5.2
-	 */
-	public function useTemplate( $tpl, $x = 0, $y = 0, $width = null, $height = null, $adjustPageSize = false ) {
-		$template = parent::useTemplate( $tpl, $x, $y, $width, $height, $adjustPageSize );
-
-		/* This return signature for this method changed in mPDF 8.0 */
-		$template['w'] = isset( $template['width'] ) ? $template['width'] : 0;
-		$template['h'] = isset( $template['height'] ) ? $template['height'] : 0;
-
-		return $template;
-	}
-
-	/**
-	 * Write HTML code to the document
-	 *
-	 * Also used internally to parse HTML into buffers
-	 *
-	 * @param string $html
-	 * @param int    $mode  Use HTMLParserMode constants. Controls what parts of the $html code is parsed.
-	 * @param bool   $init  Clears and sets buffers to Top level block etc.
-	 * @param bool   $close If false leaves buffers etc. in current state, so that it can continue a block etc.
-	 *
-	 * @throws MpdfException
-	 * @since 5.2
-	 */
-	public function WriteHTML( $html, $mode = HTMLParserMode::DEFAULT_MODE, $init = true, $close = true ) {
-
-		/* Prevent error if incorrect mode is passed */
-		if ( in_array( $mode, HTMLParserMode::getAllModes(), true ) === false ) {
-			$mode = HTMLParserMode::DEFAULT_MODE;
-		}
-
-		/*
-		 * Cast $html to string by default to prevent warning when null is passed by custom templates that
-		 * reference variables that don't exist
-		 */
-		parent::WriteHTML( (string) $html, $mode, $init, $close );
-	}
 }

--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -4,7 +4,7 @@ namespace GFPDF\Helper;
 
 use Exception;
 use GFPDF_Vendor\Mpdf\Config\FontVariables;
-use GFPDF_Vendor\Mpdf\Mpdf;
+use GFPDF\Helper\Mpdf\Mpdf;
 use GFPDF_Vendor\Mpdf\MpdfException;
 use GFPDF_Vendor\Mpdf\Utils\UtfString;
 use Psr\Log\LoggerInterface;
@@ -619,7 +619,7 @@ class Helper_PDF {
 	protected function begin_pdf() {
 		$default_font_config = ( new FontVariables() )->getDefaults();
 
-		$this->mpdf = new Helper_Mpdf(
+		$this->mpdf = new Mpdf(
 			apply_filters(
 				'gfpdf_mpdf_class_config',
 				[

--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -3,10 +3,12 @@
 namespace GFPDF\Helper;
 
 use Exception;
+use GFPDF\Helper\Mpdf\Request;
 use GFPDF_Vendor\Mpdf\Config\FontVariables;
 use GFPDF\Helper\Mpdf\Mpdf;
 use GFPDF_Vendor\Mpdf\MpdfException;
 use GFPDF_Vendor\Mpdf\Utils\UtfString;
+use GFPDF_Vendor\Mpdf\Container\SimpleContainer;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -623,17 +625,9 @@ class Helper_PDF {
 			apply_filters(
 				'gfpdf_mpdf_class_config',
 				[
-					'fontDir'                => [
-						$this->data->template_font_location,
-					],
-
+					'fontDir'                => [ $this->data->template_font_location ],
 					'fontdata'               => apply_filters( 'mpdf_font_data', $default_font_config['fontdata'] ),
-
 					'tempDir'                => $this->data->mpdf_tmp_location,
-
-					'curlCaCertificate'      => ABSPATH . WPINC . '/certificates/ca-bundle.crt',
-					'curlFollowLocation'     => true,
-					'curlUserAgent'          => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0',
 
 					'allow_output_buffering' => true,
 					'autoLangToFont'         => true,
@@ -657,6 +651,18 @@ class Helper_PDF {
 				$this->entry,
 				$this->settings,
 				$this
+			),
+			new SimpleContainer(
+				apply_filters(
+					'gfpdf_mpdf_class_container',
+					[
+						'httpClient' => new Request( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ),
+					],
+					$this->form,
+					$this->entry,
+					$this->settings,
+					$this
+				)
 			)
 		);
 

--- a/src/Helper/Mpdf/Cache.php
+++ b/src/Helper/Mpdf/Cache.php
@@ -25,4 +25,13 @@ class Cache extends MpdfCache {
 
 		return true;
 	}
+
+	/**
+	 * Do nothing here. Let Gravity PDF's cron cleanup handle old temp files.
+	 *
+	 * @return void
+	 *
+	 * @since 6.13.0
+	 */
+	public function clearOld() {}
 }

--- a/src/Helper/Mpdf/Cache.php
+++ b/src/Helper/Mpdf/Cache.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace GFPDF\Helper\Mpdf;
+
+use GFPDF_Vendor\Mpdf\Cache as MpdfCache;
+
+/**
+ * @since 6.13.0
+ */
+class Cache extends MpdfCache {
+
+	/**
+	 * Override to ensure folder permissions are being set based on the parent directory
+	 *
+	 * @param $basePath
+	 *
+	 * @return bool
+	 *
+	 * @since 6.13.0
+	 */
+	protected function createDirectory( $basePath ) {
+		if ( ! wp_mkdir_p( $basePath ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/Helper/Mpdf/Mpdf.php
+++ b/src/Helper/Mpdf/Mpdf.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace GFPDF\Helper\Mpdf;
+
+use GFPDF_Vendor\Mpdf\Mpdf as MpdfCore;
+use GFPDF_Vendor\Mpdf\HTMLParserMode;
+use GFPDF_Vendor\Mpdf\MpdfException;
+use GFPDF_Vendor\setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
+use GFPDF_Vendor\setasign\Fpdi\PdfParser\PdfParserException;
+use GFPDF_Vendor\setasign\Fpdi\PdfParser\Type\PdfTypeException;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2025, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @since 6.13.0 Moved from \GFPDF\Helper\Helper_Mpdf
+ */
+class Mpdf extends MpdfCore {
+
+	/**
+	 * Added for backwards compatibility as it was removed in mPDF 8.0
+	 *
+	 * @since 5.2
+	 */
+	public function SetImportUse() {
+		/* Do nothing */
+	}
+
+	/**
+	 * @param int    $pageNumber The page number.
+	 * @param null   $crop_x     mPDF 8.0 removed this parameter
+	 * @param null   $crop_y     mPDF 8.0 removed this parameter
+	 * @param int    $crop_w     mPDF 8.0 removed this parameter
+	 * @param int    $crop_h     mPDF 8.0 removed this parameter
+	 * @param string $boxName    The page boundary to import.
+	 *
+	 * @return string A unique string identifying the imported page.
+	 * @throws CrossReferenceException
+	 * @throws PdfParserException
+	 * @throws PdfTypeException
+	 *
+	 * @since 5.2
+	 */
+	public function importPage( $pageNumber = 1, $crop_x = null, $crop_y = null, $crop_w = 0, $crop_h = 0, $boxName = 'CropBox' ) {
+		/* mPDF 8.0 no longer needs the box name with `/` included */
+		if ( $boxName[0] === '/' ) {
+			$boxName = substr( $boxName, 1 );
+		}
+
+		/* The signature of this method has changed */
+
+		return parent::importPage( $pageNumber, $boxName );
+	}
+
+	/**
+	 * Draws an imported page or a template onto the page or another template.
+	 *
+	 * Omit one of the size parameters (width, height) to calculate the other one automatically in view to the aspect
+	 * ratio.
+	 *
+	 * @param mixed           $tpl    The template id
+	 * @param float|int|array $x      The abscissa of upper-left corner. Alternatively you could use an assoc array
+	 *                                with the keys "x", "y", "width", "height", "adjustPageSize".
+	 * @param float|int       $y      The ordinate of upper-left corner.
+	 * @param float|int|null  $width  The width.
+	 * @param float|int|null  $height The height.
+	 * @param bool            $adjustPageSize
+	 *
+	 * @return array The size
+	 * @see   Fpdi::getTemplateSize()
+	 *
+	 * @since 5.2
+	 */
+	public function useTemplate( $tpl, $x = 0, $y = 0, $width = null, $height = null, $adjustPageSize = false ) {
+		$template = parent::useTemplate( $tpl, $x, $y, $width, $height, $adjustPageSize );
+
+		/* This return signature for this method changed in mPDF 8.0 */
+		$template['w'] = $template['width'] ?? 0;
+		$template['h'] = $template['height'] ?? 0;
+
+		return $template;
+	}
+
+	/**
+	 * Write HTML code to the document
+	 *
+	 * Also used internally to parse HTML into buffers
+	 *
+	 * @param string $html
+	 * @param int    $mode  Use HTMLParserMode constants. Controls what parts of the $html code is parsed.
+	 * @param bool   $init  Clears and sets buffers to Top level block etc.
+	 * @param bool   $close If false leaves buffers etc. in current state, so that it can continue a block etc.
+	 *
+	 * @throws MpdfException
+	 * @since 5.2
+	 */
+	public function WriteHTML( $html, $mode = HTMLParserMode::DEFAULT_MODE, $init = true, $close = true ) {
+
+		/* Prevent error if incorrect mode is passed */
+		if ( in_array( $mode, HTMLParserMode::getAllModes(), true ) === false ) {
+			$mode = HTMLParserMode::DEFAULT_MODE;
+		}
+
+		/*
+		 * Cast $html to string by default to prevent warning when null is passed by custom templates that
+		 * reference variables that don't exist
+		 */
+		parent::WriteHTML( (string) $html, $mode, $init, $close );
+	}
+}

--- a/src/Helper/Mpdf/Request.php
+++ b/src/Helper/Mpdf/Request.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace GFPDF\Helper\Mpdf;
+
+use GFPDF_Vendor\Mpdf\Http\ClientInterface;
+use GFPDF_Vendor\Mpdf\Log\Context as LogContext;
+use GFPDF_Vendor\Mpdf\MpdfException;
+use GFPDF_Vendor\Mpdf\PsrHttpMessageShim\Response;
+use GFPDF_Vendor\Mpdf\PsrHttpMessageShim\Stream;
+use GFPDF_Vendor\Mpdf\PsrLogAwareTrait\PsrLogAwareTrait;
+use GFPDF_Vendor\Psr\Http\Message\RequestInterface;
+use GFPDF_Vendor\Psr\Log\LoggerAwareInterface;
+
+/**
+ * @since 6.13.0
+ */
+class Request implements ClientInterface, LoggerAwareInterface {
+	use PsrLogAwareTrait;
+
+	/**
+	 * @var bool Whether to throw an exception on an error
+	 */
+	protected $debug;
+
+	public function __construct( $debug = false ) {
+		$this->debug = $debug;
+	}
+
+	/**
+	 * Use WordPress functions for remote requests
+	 *
+	 * @param RequestInterface $request
+	 *
+	 * @return Response
+	 * @throws MpdfException
+	 *
+	 * @since 6.13.0
+	 */
+	public function sendRequest( RequestInterface $request ) {
+
+		/* Not a valid request */
+		if ( null === $request->getUri() ) {
+			return new Response();
+		}
+
+		$response = new Response();
+		$url      = (string) $request->getUri();
+
+		$this->logger->debug( \sprintf( 'Fetching content of remote URL "%s"', $url ), [ 'context' => LogContext::REMOTE_CONTENT ] );
+
+		/* Make a GET request to the URL */
+		$request_args = apply_filters(
+			'gfpdf_remote_request_args',
+			[
+				'reject_unsafe_urls' => true,
+			]
+		);
+
+		$request = wp_remote_get( $url, (array) $request_args );
+
+		/* Handle any request errors */
+		if ( is_wp_error( $request ) ) {
+			$message = \sprintf( 'Remote request error for %s: "%s: %s"', $url, $request->get_error_code(), $request->get_error_message() );
+			$this->logger->error( $message, [ 'context' => LogContext::REMOTE_CONTENT ] );
+
+			if ( $this->debug ) {
+				throw new MpdfException( esc_html( $message ) );
+			}
+
+			return $response;
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $request );
+		if ( empty( $status_code ) || ! str_starts_with( (string) $status_code, '2' ) ) {
+			$message = \sprintf( 'HTTP error "%d" for %s', $status_code, $url );
+			$this->logger->error( $message, [ 'context' => LogContext::REMOTE_CONTENT ] );
+
+			if ( $this->debug ) {
+				throw new MpdfException( esc_html( $message ) );
+			}
+
+			return $response->withStatus( $status_code );
+		}
+
+		/* Return the request body */
+		$response_body = wp_remote_retrieve_body( $request );
+
+		return $response->withStatus( $status_code )->withBody( Stream::create( $response_body ) );
+	}
+}

--- a/src/Model/Model_Install.php
+++ b/src/Model/Model_Install.php
@@ -267,7 +267,6 @@ class Model_Install extends Helper_Abstract_Model {
 			$this->data->template_font_location,
 			$this->data->template_tmp_location,
 			$this->data->mpdf_tmp_location,
-			$this->data->mpdf_tmp_location . '/ttfontdata',
 		];
 
 		if ( is_multisite() ) {

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -985,7 +985,7 @@ class Model_PDF extends Helper_Abstract_Model {
 			margin-bottom: 0;
 		  }
 		</style>
-		
+
 		<div id="gravitypdf-pdf-box-container" class="postbox">
 
 			<h3 class="hndle" style="cursor:default;">
@@ -1951,30 +1951,44 @@ class Model_PDF extends Helper_Abstract_Model {
 	}
 
 	/**
-	 * Clean-up our tmp directory every 12 hours
+	 * Clean-up the tmp directory/ies
 	 *
 	 * @return void
 	 *
 	 * @since 4.0
 	 */
 	public function cleanup_tmp_dir() {
-		$max_file_age  = time() - 12 * 3600; /* Max age is 12 hours old */
-		$tmp_directory = $this->data->template_tmp_location;
 
-		if ( is_dir( $tmp_directory ) ) {
+		$config = [
+			/* the mPDF tmp directory is usually inside the template tmp directory, but can be moved via a filter */
+			[
+				'dir' => $this->data->mpdf_tmp_location,
+				'age' => time() - 3600, // 1 hour
+			],
+
+			[
+				'dir' => $this->data->template_tmp_location,
+				'age' => time() - 12 * 3600, // 12 hour
+			],
+		];
+
+		foreach ( $config as $item ) {
+			if ( ! is_dir( $item['dir'] ) ) {
+				continue;
+			}
 
 			try {
 				$directory_list = new RecursiveIteratorIterator(
-					new RecursiveDirectoryIterator( $tmp_directory, RecursiveDirectoryIterator::SKIP_DOTS ),
+					new RecursiveDirectoryIterator( $item['dir'], RecursiveDirectoryIterator::SKIP_DOTS ),
 					RecursiveIteratorIterator::CHILD_FIRST
 				);
 
 				foreach ( $directory_list as $file ) {
-					if ( in_array( $file->getFilename(), [ '.htaccess', 'index.html' ], true ) || strpos( realpath( $file->getPathname() ), realpath( $this->data->mpdf_tmp_location ) ) !== false ) {
+					if ( in_array( $file->getFilename(), [ '.htaccess', 'index.html' ], true ) ) {
 						continue;
 					}
 
-					if ( $file->isReadable() && $file->getMTime() < $max_file_age ) {
+					if ( $file->isReadable() && $file->getMTime() < $item['age'] ) {
 						( $file->isDir() ) ?
 							$this->misc->rmdir( $file->getPathName() ) :
 							@unlink( $file->getPathName() ); //phpcs:ignore
@@ -1984,7 +1998,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				$this->log->error(
 					'Filesystem Delete Error',
 					[
-						'dir'       => $tmp_directory,
+						'dir'       => $item['dir'],
 						'exception' => $e->getMessage(),
 					]
 				);

--- a/tests/phpunit/unit-tests/Helper/Mpdf/Test_Cache.php
+++ b/tests/phpunit/unit-tests/Helper/Mpdf/Test_Cache.php
@@ -1,4 +1,3 @@
-
 <?php
 
 declare( strict_types=1 );
@@ -24,8 +23,6 @@ class Test_Cache extends WP_UnitTestCase {
 	 * @dataProvider provider_createDirectory
 	 */
 	public function test_createDirectory( $permission ) {
-		clearstatcache();
-
 		$basepath     = sys_get_temp_dir() . '/mpdf-cache/';
 		$tmp_basepath = $basepath . 'tmp/';
 

--- a/tests/phpunit/unit-tests/Helper/Mpdf/Test_Cache.php
+++ b/tests/phpunit/unit-tests/Helper/Mpdf/Test_Cache.php
@@ -1,0 +1,56 @@
+
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Mpdf;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2025, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   helper
+ */
+class Test_Cache extends WP_UnitTestCase {
+
+	/**
+	 * Verify the cache directory inherits the parent directory permissions
+	 *
+	 * @dataProvider provider_createDirectory
+	 */
+	public function test_createDirectory( $permission ) {
+		clearstatcache();
+
+		$basepath     = sys_get_temp_dir() . '/mpdf-cache/';
+		$tmp_basepath = $basepath . 'tmp/';
+
+		/* ensure we have a clean slate */
+		@rmdir( $tmp_basepath );
+		@rmdir( $basepath );
+
+		/* Create the base directory with the correct permissions */
+		mkdir( $basepath );
+		chmod( $basepath, $permission );
+
+		new Cache( $tmp_basepath );
+
+		$base_permission = substr( decoct( fileperms( $basepath ) ), -3 );
+		$tmp_permission = substr( decoct( fileperms( $tmp_basepath ) ), -3 );
+
+		$this->assertSame( decoct( $permission ), $base_permission );
+		$this->assertSame( decoct( $permission ), $tmp_permission );
+	}
+
+	public function provider_createDirectory() {
+		return [
+			[ 0755 ],
+			[ 0775 ],
+			[ 0777 ],
+		];
+	}
+}

--- a/tests/phpunit/unit-tests/Helper/Mpdf/Test_Request.php
+++ b/tests/phpunit/unit-tests/Helper/Mpdf/Test_Request.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Mpdf;
+
+use GFPDF_Vendor\Mpdf\MpdfException;
+use GFPDF_Vendor\Mpdf\PsrHttpMessageShim\Request as Payload;
+use GFPDF_Vendor\Psr\Log\NullLogger;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2025, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   helper
+ */
+class Test_Request extends WP_UnitTestCase {
+
+	public function test_send_request_success() {
+		$request = new Request();
+		$request->setLogger( new NullLogger() );
+		$response = $request->sendRequest( new Payload( 'GET', 'https://raw.githubusercontent.com/WordPress/WordPress/refs/heads/master/license.txt' ) );
+
+		$this->assertStringContainsString( 'WordPress - Web publishing software', (string) $response->getBody() );
+	}
+
+	public function test_send_request_wp_error() {
+		$request = new Request();
+		$request->setLogger( new NullLogger() );
+		$response = $request->sendRequest( new Payload( 'GET', 'raw.githubusercontent.com/WordPress/WordPress/refs/heads/master/license.txt' ) );
+
+		$this->assertEmpty( (string) $response->getBody() );
+	}
+
+	public function test_send_request_wp_error_with_debug() {
+		$this->expectException( MpdfException::class );
+
+		$request = new Request( true );
+		$request->setLogger( new NullLogger() );
+		$request->sendRequest( new Payload( 'GET', 'raw.githubusercontent.com/WordPress/WordPress/refs/heads/master/license.txt' ) );
+	}
+
+	public function test_send_request_status_error() {
+		$request = new Request();
+		$request->setLogger( new NullLogger() );
+		$response = $request->sendRequest( new Payload( 'GET', 'https://raw.githubusercontent.com/WordPress/WordPress/refs/heads/master/license1.txt' ) );
+
+		$this->assertSame( 404, $response->getStatusCode() );
+		$this->assertEmpty( (string) $response->getBody() );
+	}
+
+	public function test_send_request_status_error_with_debug() {
+		$this->expectException( MpdfException::class );
+
+		$request = new Request( true );
+		$request->setLogger( new NullLogger() );
+		$request->sendRequest( new Payload( 'GET', 'https://raw.githubusercontent.com/WordPress/WordPress/refs/heads/master/license1.txt' ) );
+	}
+}

--- a/tests/phpunit/unit-tests/test-installer.php
+++ b/tests/phpunit/unit-tests/test-installer.php
@@ -172,7 +172,6 @@ class Test_Installer extends WP_UnitTestCase {
 		$this->assertDirectoryExists( $gfpdf->data->template_font_location );
 		$this->assertDirectoryExists( $gfpdf->data->template_tmp_location );
 		$this->assertDirectoryExists( $gfpdf->data->mpdf_tmp_location );
-		$this->assertDirectoryExists( $gfpdf->data->mpdf_tmp_location . '/ttfontdata' );
 
 		$this->assertFileExists( $gfpdf->data->template_tmp_location . '.htaccess' );
 		$this->assertFileExists( $gfpdf->data->template_tmp_location . 'index.html' );

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -1280,7 +1280,11 @@ class Test_PDF extends WP_UnitTestCase {
 			'test5'     => time() - ( 15 * 3600 ),
 			'test6'     => time() - ( 5 * 3600 ),
 			'.htaccess' => time() - ( 48 * 3600 ),
-			'mpdf/test' => time() - ( 25 * 3600 ), /* normally deleted, but excluded */
+			'mpdf/test' => time() - ( 0.5 * 3600 ),
+			'mpdf/test1' => time() - 3601,
+			'mpdf/test2' => time() - 3600,
+			'mpdf/test3' => time() - ( 25 * 3600 ),
+
 		];
 
 		foreach ( $files as $file => $modified ) {
@@ -1299,6 +1303,9 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertFileExists( $tmp . 'test6' );
 		$this->assertFileExists( $tmp . '.htaccess' );
 		$this->assertFileExists( $tmp . 'mpdf/test' );
+		$this->assertFileDoesNotExist( $tmp . 'mpdf/test1' );
+		$this->assertFileExists( $tmp . 'mpdf/test2' );
+		$this->assertFileDoesNotExist( $tmp . 'mpdf/test3' );
 
 		/* Cleanup our files */
 		foreach ( $files as $file => $modified ) {


### PR DESCRIPTION
## Description

- Replace Cache class with version that better accounts for directory permissions of the parent folder
- Remove creation of unnecessary ttfontdata folder
- Move mPDF files/classes to new folder for easier development
- Replace cURL with wp_remote_get() for remote requests
- Remove cache cleanup code from mPDF and rely on Gravity PDF's cron cleanup implementation 

Should resolve intermittent permission issue on WP Engine.

## Testing instructions
1. Setup form with an external IMG included in a HTML field
2. Setup PDF with Show HTML Fields enabled
3. View PDF and verify image displays correctly
4. Set `define( 'WP_HTTP_BLOCK_EXTERNAL', true );` in `wp-config.php` and verify image no longer displays in the PDF
5. Set `define( 'WP_ACCESSIBLE_HOSTS', '*.gravitypdf.com' );` in `wp-config.php`, updating the domain to match the external IMG domain, and verify image displays in PDF

## Screenshots <!-- if applicable -->

## Checklist:
- [X] I've tested the code.
- [X] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->

1. The `'reject_unsafe_urls'` option for `wp_remote_get()` is enabled by default, and URLs that don't pass these checks will be skipped. This includes non HTTP/HTTPS protocols.
2. If `WP_DEBUG_DISPLAY` is set to `true` image errors will generate an exception and prevent the PDF generating

Added filters:

* `gfpdf_mpdf_class_container` - lets developers replace the `httpClient` class, which is used to get remote assets for mPDF
* `gfpdf_remote_request_args` - lets developers modify the arguments passed to `wp_remote_get` for mPDF remote requests