### PR TITLE
Security Hardening - Limit filesystem folders that can be deleted

### DIFF
--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -353,9 +353,61 @@ class Helper_Misc {
 	 * @return bool|WP_Error
 	 *
 	 * @since 4.0
+	 * @since 6.13.0 Directories not managed by Gravity PDF will throw an error if tried to be deleted
 	 */
 	public function rmdir( $dir, bool $delete_top_level_dir = true ) {
 
+		/*
+		 * Do not allow directories outside the folders managed by Gravity PDF to be deleted
+		 */
+		$folders = [
+			$this->data->template_location,
+			$this->data->template_font_location,
+			$this->data->template_tmp_location,
+			$this->data->mpdf_tmp_location,
+		];
+
+		if ( is_multisite() ) {
+			$folders[] = $this->data->multisite_template_location;
+		}
+
+		/* Verify $dir is a real path on the current file system */
+		$path_to_test = realpath( $dir );
+		if ( $path_to_test === false ) {
+			$this->log->error(
+				'Filesystem Delete Error',
+				[
+					'dir'       => $dir,
+					'exception' => 'Not a real path on the file system',
+				]
+			);
+
+			return new WP_Error( 'gfpdf_rmdir_not_a_real_path' );
+		}
+
+		/* Check if $dir to delete falls inside one of the Gravity PDF directories */
+		$allowed_to_delete = false;
+		foreach ( $folders as $folder ) {
+
+			if ( strpos( $path_to_test, realpath( $folder ) ) === 0 ) {
+				$allowed_to_delete = true;
+				break;
+			}
+		}
+
+		if ( ! $allowed_to_delete ) {
+			$this->log->error(
+				'Filesystem Delete Error',
+				[
+					'dir'       => $dir,
+					'exception' => 'Directory falls outside of approved paths',
+				]
+			);
+
+			return new WP_Error( 'gfpdf_rmdir_directory_not_approved', esc_html( 'Cannot delete path. Directory falls outside of approved Gravity PDF paths: ' . $dir ) );
+		}
+
+		/* Path is managed by Gravity PDF and can be deleted */
 		$this->log->notice( sprintf( 'Begin deleting directory recursively: %s', $dir ) );
 
 		try {
@@ -368,7 +420,7 @@ class Helper_Misc {
 				$function  = ( $fileinfo->isDir() ) ? 'rmdir' : 'unlink';
 				$real_path = $fileinfo->getRealPath();
 				if ( ! $function( $real_path ) ) {
-					throw new Exception( 'Could not run ' . $function . ' on  ' . $real_path );
+					throw new Exception( esc_html( 'Could not run ' . $function . ' on  ' . $real_path ) );
 				}
 
 				$this->log->notice( sprintf( 'Successfully ran `%s` on %s', $function, $real_path ) );
@@ -382,7 +434,7 @@ class Helper_Misc {
 				]
 			);
 
-			return new WP_Error( 'recursion_delete_problem', $e );
+			return new WP_Error( 'recursion_delete_problem', esc_html( $e ) );
 		}
 
 		$results = true;

--- a/src/Model/Model_Install.php
+++ b/src/Model/Model_Install.php
@@ -182,22 +182,22 @@ class Model_Install extends Helper_Abstract_Model {
 		$upload_dir_url = $this->data->upload_dir_url;
 
 		/* Legacy Filters */
-		$this->data->template_location     = apply_filters( 'gfpdfe_template_location', $template_dir, $working_folder, $upload_dir );
-		$this->data->template_location_url = apply_filters( 'gfpdfe_template_location_uri', $template_url, $working_folder, $upload_dir_url );
+		$this->data->template_location     = trailingslashit( apply_filters( 'gfpdfe_template_location', $template_dir, $working_folder, $upload_dir ) );
+		$this->data->template_location_url = trailingslashit( apply_filters( 'gfpdfe_template_location_uri', $template_url, $working_folder, $upload_dir_url ) );
 
 		/* Allow user to change directory location(s) */
 
 		/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_template_location/ for more details about this filter */
-		$this->data->template_location = apply_filters( 'gfpdf_template_location', $this->data->template_location, $working_folder, $upload_dir ); /* needs to be accessible from the web */
+		$this->data->template_location = trailingslashit( apply_filters( 'gfpdf_template_location', $this->data->template_location, $working_folder, $upload_dir ) ); /* needs to be accessible from the web */
 
 		/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_template_location_uri/ for more details about this filter */
-		$this->data->template_location_url = apply_filters( 'gfpdf_template_location_uri', $this->data->template_location_url, $working_folder, $upload_dir_url ); /* needs to be accessible from the web */
+		$this->data->template_location_url = trailingslashit( apply_filters( 'gfpdf_template_location_uri', $this->data->template_location_url, $working_folder, $upload_dir_url ) ); /* needs to be accessible from the web */
 
 		/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_font_location/ for more details about this filter */
-		$this->data->template_font_location = apply_filters( 'gfpdf_font_location', $this->data->template_location . 'fonts/', $working_folder, $upload_dir ); /* can be in a directory not accessible via the web */
+		$this->data->template_font_location = trailingslashit( apply_filters( 'gfpdf_font_location', $this->data->template_location . 'fonts/', $working_folder, $upload_dir ) ); /* can be in a directory not accessible via the web */
 
 		/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_tmp_location/ for more details about this filter */
-		$this->data->template_tmp_location = apply_filters( 'gfpdf_tmp_location', $this->data->template_location . 'tmp/', $working_folder, $upload_dir_url ); /* encouraged to move this to a directory not accessible via the web */
+		$this->data->template_tmp_location = trailingslashit( apply_filters( 'gfpdf_tmp_location', $this->data->template_location . 'tmp/', $working_folder, $upload_dir_url ) ); /* encouraged to move this to a directory not accessible via the web */
 
 		/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_mpdf_tmp_location/ for more details about this filter */
 		$mpdf_tmp_path                 = $this->data->template_tmp_location . 'mpdf';
@@ -213,34 +213,35 @@ class Model_Install extends Helper_Abstract_Model {
 	 */
 	public function setup_multisite_template_location() {
 
-		if ( is_multisite() ) {
-
-			$blog_id = get_current_blog_id();
-
-			$template_dir   = $this->data->template_location . $blog_id . '/';
-			$template_url   = $this->data->template_location_url . $blog_id . '/';
-			$working_folder = $this->data->working_folder;
-			$upload_dir     = $this->data->upload_dir;
-			$upload_dir_url = $this->data->upload_dir_url;
-
-			/**
-			 * Allow user to change directory location(s)
-			 *
-			 * @internal Folder location needs to be accessible from the web
-			 */
-
-			/* Global filter */
-
-			/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_multisite_template_location/ for more details about this filter */
-			$this->data->multisite_template_location = apply_filters( 'gfpdf_multisite_template_location', $template_dir, $working_folder, $upload_dir, $blog_id );
-
-			/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_multisite_template_location_uri/ for more details about this filter */
-			$this->data->multisite_template_location_url = apply_filters( 'gfpdf_multisite_template_location_uri', $template_url, $working_folder, $upload_dir_url, $blog_id );
-
-			/* Per-blog filters */
-			$this->data->multisite_template_location     = apply_filters( 'gfpdf_multisite_template_location_' . $blog_id, $this->data->multisite_template_location, $working_folder, $upload_dir, $blog_id );
-			$this->data->multisite_template_location_url = apply_filters( 'gfpdf_multisite_template_location_uri_' . $blog_id, $this->data->multisite_template_location_url, $working_folder, $upload_dir_url, $blog_id );
+		if ( ! is_multisite() ) {
+			return;
 		}
+
+		$blog_id = get_current_blog_id();
+
+		$template_dir   = $this->data->template_location . $blog_id . '/';
+		$template_url   = $this->data->template_location_url . $blog_id . '/';
+		$working_folder = $this->data->working_folder;
+		$upload_dir     = $this->data->upload_dir;
+		$upload_dir_url = $this->data->upload_dir_url;
+
+		/**
+		 * Allow user to change directory location(s)
+		 *
+		 * @internal Folder location needs to be accessible from the web
+		 */
+
+		/* Global filter */
+
+		/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_multisite_template_location/ for more details about this filter */
+		$this->data->multisite_template_location = trailingslashit( apply_filters( 'gfpdf_multisite_template_location', $template_dir, $working_folder, $upload_dir, $blog_id ) );
+
+		/* See https://docs.gravitypdf.com/v6/developers/filters/gfpdf_multisite_template_location_uri/ for more details about this filter */
+		$this->data->multisite_template_location_url = trailingslashit( apply_filters( 'gfpdf_multisite_template_location_uri', $template_url, $working_folder, $upload_dir_url, $blog_id ) );
+
+		/* Per-blog filters */
+		$this->data->multisite_template_location     = trailingslashit( apply_filters( 'gfpdf_multisite_template_location_' . $blog_id, $this->data->multisite_template_location, $working_folder, $upload_dir, $blog_id ) );
+		$this->data->multisite_template_location_url = trailingslashit( apply_filters( 'gfpdf_multisite_template_location_uri_' . $blog_id, $this->data->multisite_template_location_url, $working_folder, $upload_dir_url, $blog_id ) );
 	}
 
 	/**
@@ -254,10 +255,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 */
 	public function create_folder_structures() {
 
-		/* don't create the folder structure on our welcome page or through AJAX as an errors on the first page they see will confuse users */
-		if ( is_admin() &&
-			 ( rgget( 'page' ) === 'gfpdf-getting-started' || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) )
-		) {
+		/* don't create the folder structure if an AJAX or REST API request */
+		if ( ( defined( 'DOING_AJAX' ) && DOING_AJAX ) || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 			return null;
 		}
 

--- a/tests/phpunit/unit-tests/test-helper-misc.php
+++ b/tests/phpunit/unit-tests/test-helper-misc.php
@@ -622,7 +622,8 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 	public function test_cleanup_dir() {
 
 		/* Create our test data */
-		$path = '/tmp/test/';
+		$data = \GPDFAPI::get_data_class();
+		$path = $data->template_location .'folder/';
 		wp_mkdir_p( $path );
 		touch( $path . 'test' );
 
@@ -637,11 +638,24 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 		$this->assertDirectoryExists( $path );
 
 		rmdir( $path );
+
+		/* Verify we cannot delete folders outside those the plugin manages */
+		$path = sys_get_temp_dir() . '/folder/';
+		wp_mkdir_p( $path );
+		touch( $path . 'test' );
+		$this->assertFileExists( $path . 'test' );
+
+		$this->misc->cleanup_dir( $path );
+
+		$this->assertFileExists( $path . 'test' );
+		unlink( $path . 'test' );
+		rmdir( $path );
 	}
 
 	public function test_rmdir() {
-		/* Create test data */
-		$path = '/tmp/test/';
+		/* Create our test data */
+		$data = \GPDFAPI::get_data_class();
+		$path = $data->template_location .'folder/';
 		wp_mkdir_p( $path );
 		touch( $path . 'test' );
 
@@ -665,5 +679,16 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 
 		$this->assertFileDoesNotExist( $path . 'test' );
 		$this->assertDirectoryDoesNotExist( $path );
+
+		/* Verify we cannot delete folders outside those the plugin manages */
+		$path = sys_get_temp_dir() . '/folder/';
+		wp_mkdir_p( $path );
+		$this->assertDirectoryExists( $path );
+
+		$results = $this->misc->rmdir( $path );
+		$this->assertSame( 'gfpdf_rmdir_directory_not_approved', $results->get_error_code() );
+
+		$this->assertDirectoryExists( $path );
+		rmdir( $path );
 	}
 }


### PR DESCRIPTION
## Description

Only allow files/folders that are created/managed by Gravity PDF to be deleted. The paths/URLs are also standardized with trailing slashes.

## Testing instructions
1. Verify PDFs can be created and attached to email notifications, with no PHP errors

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
