### PR TITLE
Housekeeping: Temp folder permission upgrade routine

### DIFF
--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -54,6 +54,10 @@ class Controller_Upgrade_Routines {
 			$this->update_background_processing_values();
 			$this->upgrade_custom_fonts();
 		}
+
+		if ( version_compare( $current_version, '6.13.2', '>=' ) && version_compare( $old_version, '6.13.2', '<' ) ) {
+			$this->fix_tmp_folder_permissions();
+		}
 	}
 
 	/**
@@ -88,5 +92,48 @@ class Controller_Upgrade_Routines {
 		}
 
 		$this->options->update_option( 'custom_fonts', $fonts );
+	}
+
+	/**
+	 * Reset temporary folders permission
+	 *
+	 * This upgrade routine will try reset all temporary folder permissions to match the parent directory,
+	 * or fallback to 755 if it cannot be read.
+	 *
+	 * @since 6.13.2
+	 */
+	protected function fix_tmp_folder_permissions() {
+		$folders = [ $this->data->template_tmp_location ];
+
+		/* If the mPDF tmp directory is moved outside the GPDF tmp directory, fix the folder permissions separately */
+		if ( strpos( $this->data->mpdf_tmp_location, $this->data->template_tmp_location ) !== 0 ) {
+			$folders[] = $this->data->mpdf_tmp_location;
+		}
+
+		foreach ( $folders as $folder ) {
+			/* Try get the folder permission from the parent directory */
+			$folder_perms = 0755;
+			$parent_dir   = dirname( $folder );
+			if ( is_dir( $parent_dir ) ) {
+				$stat         = @stat( $parent_dir ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				$folder_perms = $stat ? $stat['mode'] & 0007777 : 0755;
+			}
+
+			/* Get all directories in folder */
+			$dir            = new \RecursiveDirectoryIterator( $folder, \RecursiveDirectoryIterator::SKIP_DOTS );
+			$files          = new \RecursiveCallbackFilterIterator(
+				$dir,
+				function ( $current, $key, $iterator ) {
+					return $iterator->hasChildren() || $current->isDir();
+				}
+			);
+			$files_iterator = new \RecursiveIteratorIterator( $files, \RecursiveIteratorIterator::SELF_FIRST );
+
+			/* Reset permissions on folder and all subdirectories */
+			chmod( $folder, $folder_perms ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+			foreach ( $files_iterator as $file ) {
+				chmod( $file->getRealPath(), $folder_perms ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Description

Reset the PDF tmp and mPDF tmp folder permissions back to the parent folder permission, or fallback to 755.

## Testing instructions

1. Install Gravity PDF 6.13.1 and view a configured PDF
2. With an FTP client, check the directory permissions of /wp-content/uploads/PDF_EXTENDED_TEMPLATES/tmp/mpdf
3. Upgrade to 6.13.2 (or this PR with the version bumped in pdf.php) and load the admin area
4. Recheck the directory permissions with an FTP client

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
