### PR TITLE
Fix edge-case error in upgrade routine

### DIFF
--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -113,26 +113,32 @@ class Controller_Upgrade_Routines {
 		foreach ( $folders as $folder ) {
 			/* Try get the folder permission from the parent directory */
 			$folder_perms = 0755;
-			$parent_dir   = dirname( $folder );
+
+			/* Ignore parent folder if it is `/` */
+			$parent_dir = dirname( $folder ) !== '/' ? dirname( $folder ) : $folder;
 			if ( is_dir( $parent_dir ) ) {
 				$stat         = @stat( $parent_dir ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 				$folder_perms = $stat ? $stat['mode'] & 0007777 : 0755;
 			}
 
-			/* Get all directories in folder */
-			$dir            = new \RecursiveDirectoryIterator( $folder, \RecursiveDirectoryIterator::SKIP_DOTS );
-			$files          = new \RecursiveCallbackFilterIterator(
-				$dir,
-				function ( $current, $key, $iterator ) {
-					return $iterator->hasChildren() || $current->isDir();
-				}
-			);
-			$files_iterator = new \RecursiveIteratorIterator( $files, \RecursiveIteratorIterator::SELF_FIRST );
+			try {
+				/* Get all directories in folder */
+				$dir            = new \RecursiveDirectoryIterator( $folder, \RecursiveDirectoryIterator::SKIP_DOTS );
+				$files          = new \RecursiveCallbackFilterIterator(
+					$dir,
+					function ( $current, $key, $iterator ) {
+						return $iterator->hasChildren() || $current->isDir();
+					}
+				);
+				$files_iterator = new \RecursiveIteratorIterator( $files, \RecursiveIteratorIterator::SELF_FIRST );
 
-			/* Reset permissions on folder and all subdirectories */
-			chmod( $folder, $folder_perms ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
-			foreach ( $files_iterator as $file ) {
-				chmod( $file->getRealPath(), $folder_perms ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+				/* Reset permissions on folder and all subdirectories */
+				@chmod( $folder, $folder_perms ); // phpcs:ignore
+				foreach ( $files_iterator as $file ) {
+					@chmod( $file->getRealPath(), $folder_perms ); // phpcs:ignore
+				}
+			} catch ( \Exception $e ) {
+				// do nothing
 			}
 		}
 	}


### PR DESCRIPTION
## Description

When the PDF tmp directory is moved to a shared folder – like the top-level `tmp` folder – permission errors can occur. Add extra error handling for this use-case.

## Testing instructions

1. Add filter to MU Plugin: 
 
```
add_filter( 'gfpdf_tmp_location', function( $path, $working_folder, $upload_url ) {
	return '/tmp/';
}, 10, 3 );
```

2. Install Gravity PDF 6.13.1
3. Upgrade to 6.13.2
4. Upgrade routine should generate an error
5. Swap to this patch and the routine will complete without an error

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->

The usage of the filter is incorrect, and the documentation for it has been updated to better reflect that Gravity PDF needs a dedicated folder to work from e.g. `/tmp/GravityPDF/`.