### PR TITLE
Remove version number from PDF meta

### DIFF
--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -453,7 +453,7 @@ class Helper_PDF {
 	 */
 	public function set_creator( $text = '' ) {
 		if ( empty( $text ) ) {
-			$this->mpdf->SetCreator( 'Gravity PDF v' . PDF_EXTENDED_VERSION . '. https://gravitypdf.com' );
+			$this->mpdf->SetCreator( 'Gravity PDF, gravitypdf.com' );
 		} else {
 			$this->mpdf->SetCreator( $text );
 		}
@@ -646,6 +646,8 @@ class Helper_PDF {
 					'orientation'            => $this->orientation,
 
 					'img_dpi'                => isset( $this->settings['image_dpi'] ) ? (int) $this->settings['image_dpi'] : 96,
+
+					'exposeVersion'          => false,
 				],
 				$this->form,
 				$this->entry,


### PR DESCRIPTION
## Description

This PR removes the Gravity PDF and mPDF version number from the generated PDF metadata

## Testing instructions
1. Generate a new PDF
2. View the Document Properties in Adobe Reader
3. Verify no version number is included

## Screenshots <!-- if applicable -->
<img width="512" height="154" alt="CleanShot 2025-09-03 at 09 48 59@2x" src="https://github.com/user-attachments/assets/46542ca3-8d73-4648-94f3-de5bc5177285" />

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
