### PR TITLE
Fix PHP Array to String Conversion Error

### DIFF
--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -80,15 +80,26 @@ class Helper_Misc {
 	 *
 	 */
 	public function is_gfpdf_page() {
-		/* phpcs:disable WordPress.Security.NonceVerification.Recommended */
-		if ( is_admin() && ( ! empty( $_GET['page'] ) || ! empty( $_GET['subview'] ) ) ) {
-			if ( strpos( $_GET['page'] ?? '', 'gfpdf-' ) === 0 || strtoupper( $_GET['subview'] ?? '' ) === 'PDF' ) {
-				return true;
-			}
+		if ( ! is_admin() ) {
+			return false;
 		}
-		/* phpcs:enable */
 
-		return false;
+		$page    = $_GET['page'] ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$subview = $_GET['subview'] ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( empty( $page ) && empty( $subview ) ) {
+			return false;
+		}
+
+		if ( ! is_string( $page ) || ! is_string( $subview ) ) {
+			return false;
+		}
+
+		if ( strpos( $page, 'gfpdf-' ) !== 0 && strtoupper( $subview ) !== 'PDF' ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Description

Guard against arrays when checking `page` and `subview` URL params in admin area

## Testing instructions
1. Navigate to https://example.com/wp-admin/admin.php?page[] and see error
2. Swap to patch and reload page to see different error (WordPress admin also doesn't check the type and triggers a similar error).

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
