### PR TITLE
Resolve conflict with Event Expresso plugin

### DIFF
--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -117,8 +117,8 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	 */
 	public function add_actions() {
 		/* Process PDF if needed */
-		add_action( 'parse_request', [ $this, 'process_legacy_pdf_endpoint' ] ); /* legacy PDF endpoint */
-		add_action( 'parse_request', [ $this, 'process_pdf_endpoint' ] ); /* new PDF endpoint */
+		add_action( 'parse_request', [ $this, 'process_legacy_pdf_endpoint' ], 1 ); /* legacy PDF endpoint */
+		add_action( 'parse_request', [ $this, 'process_pdf_endpoint' ], 1 ); /* new PDF endpoint */
 
 		/* Allow custom PDF tags / CSS */
 		add_action( 'gfpdf_pre_pdf_generation', [ $this, 'add_pre_pdf_hooks' ] );

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -107,8 +107,8 @@ class Test_PDF extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_actions() {
-		$this->assertSame( 10, has_action( 'parse_request', [ $this->controller, 'process_legacy_pdf_endpoint' ] ) );
-		$this->assertSame( 10, has_action( 'parse_request', [ $this->controller, 'process_pdf_endpoint' ] ) );
+		$this->assertSame( 1, has_action( 'parse_request', [ $this->controller, 'process_legacy_pdf_endpoint' ] ) );
+		$this->assertSame( 1, has_action( 'parse_request', [ $this->controller, 'process_pdf_endpoint' ] ) );
 
 		$this->assertSame(
 			10,


### PR DESCRIPTION
## Description

The `EE_Front_Controller::get_request()` runs on the `parse_request` hook with a priority of 1. For whatever reason, this hook also removes itself when it runs. Under specific circumstances, WordPress will skip hooks on priority 10 due to this removal.

To workaround this bug this PR moves our own `parse_request` hooks to priority 1.

## Testing instructions
1. [Install Event Expresso plugin](https://wordpress.org/plugins/event-espresso-decaf/)
2. [Install LifterLMS plugin](https://wordpress.org/plugins/lifterlms/)
3. Try view a PDF from the Entry List page

Using this PR the PDF will display. Prior to this PR the PDF would not.

## Checklist:
- [X] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
