### PR TITLE
Ensure background queue uses correct entry when resending notifications

### DIFF
--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -55,9 +55,17 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	protected $queue;
 
 	/**
+	 * @var Helper_Form
+	 *
+	 * @since 6.13.5
+	 */
+	protected $form;
+
+	/**
 	 * @var array An array containing the notification objects to be sent using background processing during a request
 	 *
 	 * @since 6.11.0
+	 * @since 6.13.5 Group by form ID and Entry ID [ formId => [ entryId => [] ] ]
 	 */
 	protected $form_async_notifications = [];
 
@@ -70,11 +78,12 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	 *
 	 * @since 5.0
 	 */
-	public function __construct( Helper_Pdf_Queue $queue, Model_PDF $model_pdf, LoggerInterface $log ) {
+	public function __construct( Helper_Pdf_Queue $queue, Model_PDF $model_pdf, LoggerInterface $log, Helper_Form $form ) {
 		/* Assign our internal variables */
 		$this->log       = $log;
 		$this->model_pdf = $model_pdf;
 		$this->queue     = $queue;
+		$this->form      = $form;
 	}
 
 	/**
@@ -87,9 +96,10 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	public function init() {
 		add_filter( 'gform_disable_notification', [ $this, 'maybe_disable_submission_notifications' ], 9999, 5 );
 		add_action( 'gform_after_submission', [ $this, 'queue_async_form_submission_tasks' ], 5, 2 );
+		add_action( 'gform_after_submission', [ $this, 'dispatch_queue' ], 100 );
 
 		add_filter( 'gform_disable_resend_notification', [ $this, 'maybe_disable_resend_notifications' ], 10, 4 );
-		add_action( 'gform_post_resend_all_notifications', [ $this, 'queue_dispatch_resend_notification_tasks' ], 10, 2 );
+		add_action( 'gform_post_resend_all_notifications', [ $this, 'queue_dispatch_resend_notification_tasks' ] );
 	}
 
 	/**
@@ -161,7 +171,15 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	protected function should_send_async_notification( $is_disabled, $notification, $form, $entry ) {
 		$send_async_notification = $this->do_we_disable_notification( $is_disabled, $notification, $form, $entry );
 		if ( $send_async_notification ) {
-			$this->form_async_notifications[] = $notification;
+			if ( ! isset( $this->form_async_notifications[ $form['id'] ] ) ) {
+				$this->form_async_notifications[ $form['id'] ] = [];
+			}
+
+			if ( ! isset( $this->form_async_notifications[ $form['id'] ][ $entry['id'] ] ) ) {
+				$this->form_async_notifications[ $form['id'] ][ $entry['id'] ] = [];
+			}
+
+			$this->form_async_notifications[ $form['id'] ][ $entry['id'] ][] = $notification;
 		}
 
 		return $send_async_notification;
@@ -207,6 +225,7 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	 * @param array $form
 	 *
 	 * @since 5.0
+	 * @since 6.13.5 Move queue dispatch to self::queue_async_form_submission_dispatch()
 	 */
 	public function queue_async_form_submission_tasks( $entry, $form ) {
 		$this->queue_async_tasks( $form, $entry );
@@ -214,20 +233,46 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 		if ( count( $this->queue->get_data() ) > 0 ) {
 			$this->queue_cleanup_task( $form, $entry );
 		}
-
-		$this->dispatch_queue();
 	}
 
 	/**
 	 * Queue and send the notifications after the resend notification process has completed
 	 *
-	 * @param array $form
-	 * @param array $entry
-	 *
 	 * @since 5.0
+	 * @since 6.13.5 $form and $entry arguments ignored and now set in self::should_send_async_notification()
 	 */
-	public function queue_dispatch_resend_notification_tasks( $form, $entry ) {
-		$this->queue_async_form_submission_tasks( $entry, $form );
+	public function queue_dispatch_resend_notification_tasks( $form = null, $entry = null ) {
+		if ( ! is_null( $entry ) ) {
+			_doing_it_wrong( __METHOD__, '$entry argument ignored and now set in self::should_send_async_notification()', '6.13.5' );
+		}
+
+		/* loop over all form/entries */
+		foreach ( $this->form_async_notifications as $form_id => $entry_data ) {
+			$form = $this->form->get_form( $form_id );
+			if ( ! $form ) {
+				$this->log->error( 'Form not found', $form_id );
+				continue;
+			}
+
+			$entry_ids = array_keys( $entry_data );
+			foreach ( $entry_ids as $entry_id ) {
+				$entry = $this->form->get_entry( $entry_id );
+				if ( is_wp_error( $entry ) ) {
+					$this->log->error(
+						'Entry not found',
+						[
+							'entry_id'  => $entry_id,
+							'exception' => $entry->get_error_message() ,
+						]
+					);
+					continue;
+				}
+
+				$this->queue_async_form_submission_tasks( $entry, $form );
+			}
+		}
+
+		$this->dispatch_queue();
 	}
 
 	/**
@@ -241,13 +286,12 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	 * @since 6.11.0
 	 */
 	public function queue_async_tasks( $form, $entry ) {
-		foreach ( $this->form_async_notifications as $notification ) {
-			$tasks = $this->get_queue_tasks( $entry, $form, [ $notification ] );
+		$notifications = $this->form_async_notifications[ $form['id'] ][ $entry['id'] ] ?? [];
+		$tasks         = $this->get_queue_tasks( $entry, $form, $notifications );
 
-			/* Push each task individually for forwards compatibility with new Background Processing update */
-			foreach ( $tasks as $task ) {
-				$this->queue->push_to_queue( [ $task ] );
-			}
+		/* Push each task individually for forwards compatibility with new Background Processing update */
+		foreach ( $tasks as $task ) {
+			$this->queue->push_to_queue( [ $task ] );
 		}
 	}
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -939,7 +939,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	public function async_pdfs() {
 		$queue     = new Helper\Helper_Pdf_Queue( $this->log );
 		$model_pdf = $this->singleton->get_class( 'Model_PDF' );
-		$class     = new Controller\Controller_Pdf_Queue( $queue, $model_pdf, $this->log );
+		$class     = new Controller\Controller_Pdf_Queue( $queue, $model_pdf, $this->log, $this->gform );
 
 		if ( $this->options->get_option( 'background_processing', 'No' ) === 'Yes' ) {
 			$class->init();

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Pdf_Queue.php
@@ -66,7 +66,7 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 		$this->queue_mock->method( 'save' )
 						 ->willReturn( $this->queue_mock );
 
-		$this->controller = new Controller_Pdf_Queue( $this->queue_mock, $model_pdf, $gfpdf->log );
+		$this->controller = new Controller_Pdf_Queue( $this->queue_mock, $model_pdf, $gfpdf->log, $gfpdf->gform );
 	}
 
 	/**
@@ -277,28 +277,26 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 	 */
 	public function test_queue_async_form_submission_tasks() {
 		$results                             = $this->create_form_and_entries();
-		$entry                               = $results['entry'];
 		$form                                = $results['form'];
+		$entry = $results['entry'];
 		$form['notifications']['1254123223'] = $form['notifications']['54bca349732b8'];
 		$form['notifications']['54bca349732b8']['isActive'] = true;
 
-		foreach( $form['notifications'] as $notification ) {
+		/* Queue multiple entry notifications */
+		foreach ( $form['notifications'] as $notification ) {
 			$this->controller->maybe_disable_submission_notifications( false, $notification, $form, $entry );
 		}
-		
 		$this->controller->queue_async_form_submission_tasks( $entry, $form );
 
 		$queue = $this->queue_mock->get_data();
 
-		$this->assertCount( 7, $queue );
+		$this->assertCount( 5, $queue );
 
-		$this->assertStringContainsString( 'create_pdf', $queue[0][0]['func'] );
-		$this->assertStringContainsString( 'create_pdf', $queue[1][0]['func'] );
-		$this->assertStringContainsString( 'send_notification', $queue[2][0]['func'] );
-		$this->assertStringContainsString( 'create_pdf', $queue[3][0]['func'] );
-		$this->assertStringContainsString( 'create_pdf', $queue[4][0]['func'] );
-		$this->assertStringContainsString( 'send_notification', $queue[5][0]['func'] );
-		$this->assertStringContainsString( 'cleanup_pdfs', $queue[6][0]['func'] );
+		$this->assertStringContainsString( 'create-pdf-1-1', $queue[0][0]['id'] );
+		$this->assertStringContainsString( 'create-pdf-1-1', $queue[1][0]['id'] );
+		$this->assertStringContainsString( 'send-notification-1-1', $queue[2][0]['id'] );
+		$this->assertStringContainsString( 'send-notification-1-1', $queue[3][0]['id'] );
+		$this->assertStringContainsString( 'cleanup-pdf-1-1', $queue[4][0]['id'] );
 	}
 
 	/**
@@ -308,22 +306,30 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 	 */
 	public function test_queue_async_resend_notification_tasks() {
 		$results = $this->create_form_and_entries();
-		$entry   = $results['entry'];
 		$form    = $results['form'];
 		$form['notifications']['54bca349732b8']['isActive'] = true;
 
-		foreach( $form['notifications'] as $notification ) {
-			$this->controller->maybe_disable_resend_notifications( false, $notification, $form, $entry );
+		foreach( $GLOBALS['GFPDF_Test']->entries['all-form-fields'] as $entry ) {
+			foreach ( $form['notifications'] as $notification ) {
+				$this->controller->maybe_disable_submission_notifications( false, $notification, $form, $entry );
+			}
 		}
 
-		$this->controller->queue_dispatch_resend_notification_tasks( $form, $entry );
+		$this->controller->queue_dispatch_resend_notification_tasks();
 
 		$queue = $this->queue_mock->get_data();
 
-		$this->assertStringContainsString( 'create_pdf', $queue[0][0]['func'] );
-		$this->assertStringContainsString( 'create_pdf', $queue[1][0]['func'] );
-		$this->assertStringContainsString( 'send_notification', $queue[2][0]['func'] );
-		$this->assertStringContainsString( 'cleanup_pdfs', $queue[3][0]['func'] );
+		$this->assertCount( 28, $queue );
+
+		$this->assertStringContainsString( 'create-pdf-1-1', $queue[0][0]['id'] );
+		$this->assertStringContainsString( 'create-pdf-1-1', $queue[1][0]['id'] );
+		$this->assertStringContainsString( 'send-notification-1-1', $queue[2][0]['id'] );
+		$this->assertStringContainsString( 'cleanup-pdf-1-1', $queue[3][0]['id'] );
+
+		$this->assertStringContainsString( 'create-pdf-1-7', $queue[24][0]['id'] );
+		$this->assertStringContainsString( 'create-pdf-1-7', $queue[25][0]['id'] );
+		$this->assertStringContainsString( 'send-notification-1-7', $queue[26][0]['id'] );
+		$this->assertStringContainsString( 'cleanup-pdf-1-7', $queue[27][0]['id'] );
 	}
 
 	/**
@@ -337,12 +343,12 @@ class Test_Controller_Pdf_Queue extends WP_UnitTestCase {
 						 ->method( 'dispatch' )
 						 ->willReturn( $this->queue_mock );
 
-		$this->controller->queue_dispatch_resend_notification_tasks( [ 'id' => 0 ], [ 'id' => 0 ] );
+		$this->controller->queue_dispatch_resend_notification_tasks();
 
 		$this->assertSame( 0, $spy->getInvocationCount() );
 
 		$this->queue_mock->push_to_queue( 'item' );
-		$this->controller->queue_dispatch_resend_notification_tasks( [ 'id' => 0 ], [ 'id' => 0 ]);
+		$this->controller->queue_dispatch_resend_notification_tasks();
 
 		$this->assertSame( 1, $spy->getInvocationCount() );
 	}


### PR DESCRIPTION
## Description

Also optimizes the queue so the same PDF isn't generated multiple times

## Testing instructions
1. Enable PDF Background Processing
2. Navigate to the Entry List page of a form with the PDF Notification feature enabled 
3. Select multiple entries
4. Use the Resend Notification feature
5. Check inbox and verify the Notification email send matches the selected entries and PDFs

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
