### PR TITLE
Exclude LoggerAwareInterface from typehint removal

### DIFF
--- a/.php-scoper/mpdf.php
+++ b/.php-scoper/mpdf.php
@@ -68,7 +68,6 @@ return [
 
 			/* Remove type hinting from prefixed logger */
 			$files = [
-				'LoggerAwareInterface.php',
 				'LoggerAwareTrait.php',
 				'MpdfPsrLogAwareTrait.php',
 				'PsrLogAwareTrait.php'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.14.1
 * 🧹 Housekeeping: Add `gfpdf-{$type}` CSS class to the HTML mark-up when a field uses a different input type 
 * 🧹 Housekeeping: Use the field type (not input type) in the `gfpdf_pdf_field_content_{$type}` filter
+* 🐞Bug: Fix PHP error if another plugin lazy loads the PSR/Log v1 library 
 
 ## 6.14.0
 * 🎉 Feature: Rotate Gravity PDF log files when Gravity Forms logging is enabled. This prevents the log file getting to large.


### PR DESCRIPTION
## Description

Resolves issue with plugins loading PSR/Log v1 after Gravity PDF initializes (e.g. lazy load composer).

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
