### PR TITLE
Restore original LogInterface typehint

### DIFF
--- a/.php-scoper/mpdf.php
+++ b/.php-scoper/mpdf.php
@@ -68,13 +68,14 @@ return [
 
 			/* Remove type hinting from prefixed logger */
 			$files = [
+				'LoggerAwareInterface.php',
 				'LoggerAwareTrait.php',
 				'MpdfPsrLogAwareTrait.php',
 				'PsrLogAwareTrait.php'
 			];
 
 			if ( in_array( basename( $filePath ), $files, true ) ) {
-				$content = str_replace( "\\$prefix\\Psr\\Log\\LoggerInterface", '', $content );
+				$content = str_replace( "\\$prefix\\Psr\\Log\\LoggerInterface", '\\Psr\\Log\\LoggerInterface', $content );
 			}
 
 			/* Global polyfills */


### PR DESCRIPTION
## Description

Further testing showed https://github.com/GravityPDF/gravity-pdf/pull/1636 didn't cut the mustard. Instead, we'll restore the unprefixed typehinting which resolves the lazyload problem.

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
