### PR TITLE
Improve URL Signing

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -94,7 +94,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run E2E tests
-        run: yarn test:e2e:headless --stop-on-first-fail
+        run: yarn test:e2e:headless
 
       - name: Dump log files on failure
         if: failure()

--- a/src/Helper/Helper_Url_Signer.php
+++ b/src/Helper/Helper_Url_Signer.php
@@ -2,10 +2,10 @@
 
 namespace GFPDF\Helper;
 
-use DateTime;
-use GFPDF_Vendor\Spatie\UrlSigner\Exceptions\InvalidExpiration;
-use GFPDF_Vendor\Spatie\UrlSigner\Exceptions\InvalidSignatureKey;
 use GPDFAPI;
+use DateTime;
+use SodiumException;
+use Exception;
 
 /**
  * @package     Gravity PDF
@@ -32,9 +32,7 @@ class Helper_Url_Signer implements Helper_Interface_Url_Signer {
 	 * @param string $expiration
 	 *
 	 * @return string
-	 *
-	 * @throws InvalidSignatureKey
-	 * @throws InvalidExpiration
+
 	 * @since 5.2
 	 */
 	public function sign( $url, $expiration ) {
@@ -62,33 +60,57 @@ class Helper_Url_Signer implements Helper_Interface_Url_Signer {
 			GPDFAPI::update_plugin_option( 'signed_secret_token', $secret_key );
 		}
 
-		$url_signer = new Helper_Sha256_Url_Signer( $secret_key );
+		try {
+			$url_signer = new Helper_Sha256_Url_Signer( $secret_key );
 
-		/* Use default timeout if no expiration passed, or expiration is invalid */
-		if ( empty( $expiration ) || (bool) strtotime( $expiration ) === false ) {
-			$expiration = ( (int) GPDFAPI::get_plugin_option( 'logged_out_timeout', '20' ) ) . ' minutes';
+			/* Use default timeout if no expiration passed, or expiration is invalid */
+			if ( empty( $expiration ) || (bool) strtotime( $expiration ) === false ) {
+				$expiration = ( (int) GPDFAPI::get_plugin_option( 'logged_out_timeout', '20' ) ) . ' minutes';
+			}
+
+			$log->notice( 'PDF URL signing period: ' . $expiration, [ 'url' => $url ] );
+
+			$date = new DateTime();
+			$log->notice( 'PDF URL signing date: ' . $date->format( DateTime::W3C ), [ 'url' => $url ] );
+
+			$timeout = $date->modify( $expiration );
+			$log->notice( 'PDF URL signing expiration date: ' . $timeout->format( DateTime::W3C ), [ 'url' => $url ] );
+
+			/* Normalize URL to fix vendor error parsing invalid URL params */
+			$url_parts          = wp_parse_url( $url );
+			$uri_query          = $url_parts['query'] ?? '';
+			$url_parts['query'] = '_QHASH=' . base64_encode( $uri_query ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			$url                = $this->build_url( $url_parts );
+
+			/* Sign normalized URL, then extract the arguments and append to original URL */
+			$signed_url         = $url_signer->sign( $url, $timeout );
+			$signed_parts       = wp_parse_url( $signed_url );
+			$uri_query         .= str_replace( $url_parts['query'], '', $signed_parts['query'] ?? '' );
+			$url_parts['query'] = ltrim( $uri_query, '&' );
+
+			$signed_url = $this->build_url( $url_parts );
+
+			$log->notice(
+				'End PDF URL signing process',
+				[
+					'signed_url' => $signed_url,
+					'url'        => $url,
+					'expiration' => $expiration,
+				]
+			);
+
+			return $signed_url;
+		} catch ( Exception $e ) {
+			$log->error(
+				'PDF URL signing process failed',
+				[
+					'url'        => $url,
+					'expiration' => $expiration,
+				]
+			);
+
+			return $url;
 		}
-
-		$log->notice( 'PDF URL signing period: ' . $expiration, [ 'url' => $url ] );
-
-		$date = new DateTime();
-		$log->notice( 'PDF URL signing date: ' . $date->format( DateTime::W3C ), [ 'url' => $url ] );
-
-		$timeout = $date->modify( $expiration );
-		$log->notice( 'PDF URL signing expiration date: ' . $timeout->format( DateTime::W3C ), [ 'url' => $url ] );
-
-		$signed_url = $url_signer->sign( $url, $timeout );
-
-		$log->notice(
-			'End PDF URL signing process',
-			[
-				'signed_url' => $signed_url,
-				'url'        => $url,
-				'expiration' => $expiration,
-			]
-		);
-
-		return $signed_url;
 	}
 
 	/**
@@ -101,15 +123,94 @@ class Helper_Url_Signer implements Helper_Interface_Url_Signer {
 	 * @since 5.2
 	 */
 	public function verify( $url ) {
+		if ( $this->validate( $this->get_encoded_url( $url ) ) ) {
+			return true;
+		}
+
+		return $this->validate( $url );
+	}
+
+	/**
+	 * Validate the URL and return the results
+	 *
+	 * @param string $url
+	 *
+	 * @return bool
+	 *
+	 * @since 6.14.2
+	 */
+	protected function validate( $url ) {
 		$secret_key = GPDFAPI::get_plugin_option( 'signed_secret_token', '' );
 
 		try {
 			$url_signer = new Helper_Sha256_Url_Signer( $secret_key );
 
-			return $url_signer->validate( $url );
-		} catch ( InvalidSignatureKey $e ) {
-			return false;
+			/* Do legacy URL checks */
+			if ( $url_signer->validate( $url ) ) {
+				return true;
+			}
+
+			if ( $url_signer->validate( rawurldecode( $url ) ) ) {
+				return true;
+			}
+
+			/* Swap the protocol and test again. We use strtr for simultaneous replacement to avoid the sequential swap pitfall. */
+			$protocols = [
+				'https://' => 'http://',
+				'http://'  => 'https://',
+			];
+
+			if ( $url_signer->validate( strtr( $url, $protocols ) ) ) {
+				return true;
+			}
+
+			/* Strip the trailing slash right before the url param and test again */
+			$trailing_slash = [
+				'/?' => '?',
+				'?'  => '/?',
+			];
+
+			if ( $url_signer->validate( strtr( $url, $trailing_slash ) ) ) {
+				return true;
+			}
+		} catch ( Exception $e ) {
+			// do nothing
 		}
+
+		return false;
+	}
+
+	/**
+	 * Return an encoded version of the URL
+	 *
+	 * This resolves errors in the vendor URI library when processing array URL params (e.g. item[]=1)
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 *
+	 * @since 6.14.2
+	 */
+	protected function get_encoded_url( $url ) {
+		/* Get the signature URL params */
+		$url_pieces = explode( '?', $url, 2 );
+		$base       = $url_pieces[0] ?? '';
+		$query      = $url_pieces[1] ?? '';
+
+		$qs = [];
+		wp_parse_str( $query, $qs );
+
+		$expires   = $qs['expires'] ?? '';
+		$signature = $qs['signature'] ?? '';
+
+		/* Remove the signature params, encode the query, then put it back together */
+		$delimeter = count( $qs ) > 2 ? '&' : '';
+
+		$signature_url_params = "expires={$expires}&signature={$signature}";
+		$query                = str_replace( "$delimeter$signature_url_params", '', $query );
+		$query                = '_QHASH=' . base64_encode( $query ) . '&' . $signature_url_params; // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+
+		return implode( '?', [ $base, $query ] );
 	}
 
 	/**
@@ -122,7 +223,7 @@ class Helper_Url_Signer implements Helper_Interface_Url_Signer {
 	protected function generate_secret_key(): string {
 		try {
 			return sodium_bin2hex( sodium_crypto_secretbox_keygen() );
-		} catch ( \SodiumException $e ) {
+		} catch ( SodiumException $e ) {
 			/* Do nothing */
 		}
 
@@ -134,5 +235,27 @@ class Helper_Url_Signer implements Helper_Interface_Url_Signer {
 		}
 
 		return $password;
+	}
+
+	/**
+	 * Reverses `parse_url()`
+	 *
+	 * @param array $parsed_url
+	 *
+	 * @return string
+	 *
+	 * @since 6.14.2
+	 */
+	protected function build_url( $parsed_url ) {
+		$scheme = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '';
+		$host   = $parsed_url['host'] ?? '';
+		$port   = isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '';
+		$user   = $parsed_url['user'] ?? '';
+		$pass   = isset( $parsed_url['pass'] ) ? ':' . $parsed_url['pass'] : '';
+		$pass   = ( $user || $pass ) ? "$pass@" : '';
+		$path   = $parsed_url['path'] ?? '';
+		$query  = isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '';
+
+		return urldecode( "$scheme$user$pass$host$port$path$query" );
 	}
 }

--- a/tests/phpunit/unit-tests/test-url-signer.php
+++ b/tests/phpunit/unit-tests/test-url-signer.php
@@ -22,16 +22,44 @@ class Test_Url_Signer extends WP_UnitTestCase {
 
 	/**
 	 * @throws InvalidExpiration|InvalidSignatureKey
+	 * @dataProvider provider_sign_and_verify
 	 *
-	 * @since 5.2
+	 * @since        5.2
 	 */
-	public function test_sign_and_verify() {
+	public function test_sign_and_verify( $url ) {
 		$signer = new Helper_Url_Signer();
-		$url    = 'https://test.com';
 
 		$this->assertNotEquals( $url, $signer->sign( $url, '+ 1 day' ) );
-		$this->assertTrue( $signer->verify( $signer->sign( $url, '+ 1 day' ) ) );
 		$this->assertFalse( $signer->verify( $url ) );
+		$this->assertStringNotContainsString( '_QHASH', $signer->sign( $url, '+ 1 day' ) );
+
+		$this->assertTrue( $signer->verify( $signer->sign( $url, '+ 5 minutes' ) ) );
+		$this->assertTrue( $signer->verify( $signer->sign( $url, '+ 1 day' ) ) );
+		$this->assertTrue( $signer->verify( $signer->sign( $url, '+ 1 month' ) ) );
+		$this->assertTrue( $signer->verify( $signer->sign( $url, '+ 12 hour' ) ) );
+		$this->assertTrue( $signer->verify( $signer->sign( $url, '+ 1 year' ) ) );
+	}
+
+	public function provider_sign_and_verify() {
+		return [
+			[ 'https://test.com' ],
+			[ 'https://test.com/' ],
+			[ 'https://test.com/this-is-my-url' ],
+			[ 'https://test.com/pdf/69d83eeb6d0d1/3/' ],
+			[ 'https://test.com/pdf/69d83eeb6d0d1/3/?' ],
+			[ 'https://test.com/pdf/69d83eeb6d0d1/3' ],
+			[ 'https://test.com:8000/pdf/69d83eeb6d0d1/3/' ],
+			[ 'https://test.com:8000/pdf/69d83eeb6d0d1/3/#fragment' ],
+			[ 'http://test.com/?p=123' ],
+			[ 'https://test.com/?a=&b=1' ], // Empty value case
+			[ 'https://test.com/?gpdf=1&pid=69d83f41f27fc&lid=1' ],
+			[ 'https://test.com:8000/?gpdf=1&pid=69d83f41f27fc&lid=1' ],
+			[ 'https://test.com:8000/?gpdf=1&pid=69d83f41f27fc&lid=1#fragment-stuff' ],
+			[ 'https://test.com:8000/?gpdf=1&pid=69d83f41f27fc&lid=1&sample[]=1&sample[]=2' ],
+			[ 'https://test.com:8000/?gpdf=1&pid=69d83f41f27fc&lid=1&sample[bob][]=1a&sample[bob][]=2' ],
+			[ 'https://test.com:8000/?gpdf=1&pid=69d83f41f27fc&lid=1&sample[bob][]=1a&sample[bob][]=2bsample[alice][]=1b' ],
+			[ 'https://test.com:8000/?gpdf=1&pid=69d83f41f27fc&lid=1&sample[bob][]=1a&sample[bob][]=2bsample[alice][]=1b#fragment-stuff' ],
+		];
 	}
 
 	public function test_random_password_filter_disabled() {
@@ -46,5 +74,96 @@ class Test_Url_Signer extends WP_UnitTestCase {
 		/* Verify the token generated is 64 characters */
 		$secret_token = \GPDFAPI::get_plugin_option( 'signed_secret_token' );
 		$this->assertSame( 64, strlen( $secret_token ) );
+	}
+
+	/**
+	 * Verify that signatures are protocol-agnostic (http <-> https)
+	 */
+	public function test_protocol_agnostic_verification() {
+		$signer = new Helper_Url_Signer();
+
+		$signed = $signer->sign( 'http://test.com/pdf/69d83eeb6d0d1/3/', '+ 1 day' );
+		$this->assertTrue( $signer->verify( $signed ) );
+
+		/* Swap http to https and verify. The implementation handles this swap internally. */
+		$swapped = str_replace( 'http://', 'https://', $signed );
+		$this->assertTrue( $signer->verify( $swapped ) );
+
+		/* Swap back and verify */
+		$signed_https = $signer->sign( 'https://test.com/pdf/69d83eeb6d0d1/3/', '+ 1 day' );
+		$swapped_http = str_replace( 'https://', 'http://', $signed_https );
+		$this->assertTrue( $signer->verify( $swapped_http ) );
+	}
+
+	/**
+	 * Verify that the signer handles trailing slash normalization by the browser
+	 */
+	public function test_trailing_slash_normalization() {
+		$signer = new Helper_Url_Signer();
+
+		$signed = $signer->sign( 'https://test.com/path?p=123', '+ 1 day' );
+		$this->assertTrue( $signer->verify( $signed ) );
+		$this->assertTrue( $signer->verify( str_replace( '/path?', '/path/?', $signed ) ) );
+
+		$signed = $signer->sign( 'https://test.com/path/?p=123', '+ 1 day' );
+		$this->assertTrue( $signer->verify( $signed ) );
+		$this->assertTrue( $signer->verify( str_replace( '/path/?', '/path?', $signed ) ) );
+	}
+
+	/**
+	 * Verify that changes to the query params correctly fail verification (Forgery protection)
+	 */
+	public function test_forgery_protection() {
+		$signer = new Helper_Url_Signer();
+		$url    = 'https://test.com/?p=123&sample[]=1';
+
+		$signed = $signer->sign( $url, '+ 1 day' );
+
+		/* Modify p */
+		$forged_p = str_replace( 'p=123', 'p=456', $signed );
+		$this->assertFalse( $signer->verify( $forged_p ) );
+
+		/* Modify sample array */
+		$forged_arr = str_replace( 'sample[]=1', 'sample[]=2', $signed );
+		$this->assertFalse( $signer->verify( $forged_arr ) );
+
+		/* Add a param */
+		$forged_add = $signed . '&new=456';
+		$this->assertFalse( $signer->verify( $forged_add ) );
+	}
+
+	/**
+	 * Verify that URLs signed with the legacy (non-tunneled) logic still verify correctly
+	 */
+	public function test_legacy_signing() {
+		$signer = new Helper_Url_Signer();
+
+		/*
+		 * We simulate a legacy signature by using the vendor library directly,
+		 * bypassing the _QHASH tunneling added to sign().
+		 */
+		$secret_key    = \GPDFAPI::get_plugin_option( 'signed_secret_token' );
+		$url_signer    = new \GFPDF\Helper\Helper_Sha256_Url_Signer( $secret_key );
+		$url           = 'https://test.com/?p=123';
+		$expires       = ( new \DateTime() )->modify( '+ 1 day' );
+		$legacy_signed = $url_signer->sign( $url, $expires );
+
+		/* Verify it passes via verify_legacy_signature pathway */
+		$this->assertTrue( $signer->verify( $legacy_signed ) );
+	}
+
+	/**
+	 * Verify that expired URLs fail to verify
+	 */
+	public function test_expiration_failure() {
+		$signer = new Helper_Url_Signer();
+		$url    = 'https://test.com/?p=123';
+
+		/* Sign with a valid future date */
+		$signed = $signer->sign( $url, '+ 1 microsecond' );
+
+		sleep( 1 );
+
+		$this->assertFalse( $signer->verify( $signed ) );
 	}
 }


### PR DESCRIPTION
## Description

- Add redundancy to the verification process
- Overcome vendor library issue parsing URLs params containing `[]`
- Catch and log all Exceptions

## Testing instructions
PHP Unit tests will cover most use cases. But the following manual checks should be completed:

1. Add signed URLs to Confirmation and Notifications using shortcode and merge tag methods
2. Disable IP storage with entries
3. Submit form as a logged out user
4. Verify the PDF can be accessed
5. Disable pretty permalinks and test again.

PDF for GravityView also makes heavy use of this feature. Verify Single Entry View links (and Multi Entry View links) work without an issue. Pay special attention when using the search and filter features of the Multi View. 

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
