### PR TITLE
Use @self:playwright/fixtures/test in global-setup

### DIFF
--- a/tools/playwright/global-setup.ts
+++ b/tools/playwright/global-setup.ts
@@ -1,4 +1,4 @@
-import { test as setup } from '@playwright/test';
+import { test as setup } from '@self:playwright/fixtures/test';
 
 setup('setup', async ({ request }, testInfo) => {
 	const storageStatePath = testInfo.project.metadata


### PR DESCRIPTION
## Summary
- Switches `tools/playwright/global-setup.ts` to import `test as setup` from `@self:playwright/fixtures/test` instead of `@playwright/test`, in line with the repo-wide migration to a single merged-fixtures source.
- Single-line change; the `test as setup` alias is preserved and the rest of the file (including the dynamic `@wordpress/e2e-test-utils-playwright` import for `RequestUtils`) is unchanged.

Targeting `font-manager-overhaul` because the `tools/playwright/` directory and the `@self:playwright/*` tsconfig path alias only exist on that branch, not yet on `development`.

## Test plan
- [x] `npx tsc --noEmit` passes with no new errors
- [x] `yarn lint:js` passes
- [x] `npx playwright test --config tools/playwright/config.ts --list` discovers all 70 tests across 19 files
- [ ] Full E2E suite (skipped per migration spec — needs docker wp-env up; discovery + typecheck cover the import-correctness risk)

Generated with Claude Code