### PR TITLE
Consolidate Playwright imports for permalinks/download-shortcode specs

### DIFF
--- a/tests/playwright/permalinks/download-shortcode/copy-to-clipboard.spec.ts
+++ b/tests/playwright/permalinks/download-shortcode/copy-to-clipboard.spec.ts
@@ -1,7 +1,6 @@
 import type { Admin, RequestUtils } from '@wordpress/e2e-test-utils-playwright';
 import type { Page } from '@playwright/test';
-import { expect } from '@wordpress/e2e-test-utils-playwright';
-import { test } from '@self:playwright/fixtures/test';
+import { test, expect } from '@self:playwright/fixtures/test';
 import Pdf from '@self:playwright/utils/gravitypdf';
 import { takeSnapshot } from '@chromatic-com/playwright';
 

--- a/tests/playwright/permalinks/download-shortcode/inactive-pdf.spec.ts
+++ b/tests/playwright/permalinks/download-shortcode/inactive-pdf.spec.ts
@@ -1,7 +1,6 @@
 import type { Admin, RequestUtils } from '@wordpress/e2e-test-utils-playwright';
 import type { Page } from '@playwright/test';
-import { expect } from '@wordpress/e2e-test-utils-playwright';
-import { test } from '@self:playwright/fixtures/test';
+import { test, expect } from '@self:playwright/fixtures/test';
 import Pdf from '@self:playwright/utils/gravitypdf';
 import type { Form } from '@self:playwright/utils/gravityforms';
 


### PR DESCRIPTION
## Summary
- Merges `expect` (previously from `@wordpress/e2e-test-utils-playwright`) onto the same import line as `test` from `@self:playwright/fixtures/test` for the two specs that mixed the two sources.
- Files touched: `tests/playwright/permalinks/download-shortcode/copy-to-clipboard.spec.ts` and `tests/playwright/permalinks/download-shortcode/inactive-pdf.spec.ts`.
- The other two files in this directory (`page-confirmation.spec.ts`, `redirect-confirmation.spec.ts`) were already compliant (no `expect` import; `test` already comes from the alias) and were left untouched.

## Notes for the coordinator
- Targets `font-manager-overhaul` because that is the integration branch for this migration. The repo's standing rule of "PRs target `development`" still applies for the eventual merge from `font-manager-overhaul`.
- `npx tsc --noEmit` currently reports two errors (one per touched file): `Module '@self:playwright/fixtures/test' has no exported member 'expect'`. This is expected and resolves once the parallel fixtures-file worker re-exports `expect` from `tools/playwright/fixtures/test.ts` (the only file exempted from the import-source rule).
- `yarn lint:js` passes clean.
- `npx playwright test --config tools/playwright/config.ts --list` discovers all 70 tests across 19 files including the 5 in this directory; no discovery errors.

## Test plan
- [ ] After the fixtures worker lands `expect` re-export, re-run `npx tsc --noEmit` and confirm zero errors in these files.
- [ ] Run the full Playwright suite via `yarn test:e2e` once the e2e env is up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>