### PR TITLE
Consolidate test/expect imports for pdf-access specs

### DIFF
--- a/tests/playwright/core/pdf-access/inactive.spec.ts
+++ b/tests/playwright/core/pdf-access/inactive.spec.ts
@@ -1,7 +1,6 @@
 import type { Admin, RequestUtils } from '@wordpress/e2e-test-utils-playwright';
-import { expect } from '@wordpress/e2e-test-utils-playwright';
 import type { Page } from '@playwright/test';
-import { test } from '@self:playwright/fixtures/test';
+import { test, expect } from '@self:playwright/fixtures/test';
 import Pdf from '@self:playwright/utils/gravitypdf';
 
 test.describe('Advanced Template Checks', () => {

--- a/tests/playwright/core/pdf-access/security.spec.ts
+++ b/tests/playwright/core/pdf-access/security.spec.ts
@@ -1,8 +1,7 @@
 import * as crypto from 'node:crypto';
 import type { Admin, RequestUtils } from '@wordpress/e2e-test-utils-playwright';
-import { expect } from '@wordpress/e2e-test-utils-playwright';
 import type { Page } from '@playwright/test';
-import { test } from '@self:playwright/fixtures/test';
+import { test, expect } from '@self:playwright/fixtures/test';
 import Pdf from '@self:playwright/utils/gravitypdf';
 
 test.describe('PDF Security and Access Policies', () => {


### PR DESCRIPTION
## Summary
- Merge the `expect` import into the shared `@self:playwright/fixtures/test` import in `inactive.spec.ts` and `security.spec.ts` so both bindings come from one fixtures re-export.
- Drop the now-redundant `import { expect } from '@wordpress/e2e-test-utils-playwright';` lines while preserving the type-only imports from `@wordpress/e2e-test-utils-playwright` and `@playwright/test`.
- Part of the broader migration to a single canonical `import { test, expect } from '@self:playwright/fixtures/test';` across the Playwright suite.

## Test plan
- [x] `yarn lint:js` passes
- [x] `npx playwright test --config tools/playwright/config.ts --list` discovers all 9 pdf-access tests with no errors
- [ ] `npx tsc --noEmit` will pass once the companion change re-exports `expect` from `tools/playwright/fixtures/test.ts` (handled by a sibling unit of this migration)

Generated with [Claude Code](https://claude.com/claude-code)