### PR TITLE
Enable GF REST API idempotently so E2E survives a fresh-DB wp-env cache

### DIFF
--- a/tools/mu-plugins/gravityforms.php
+++ b/tools/mu-plugins/gravityforms.php
@@ -14,26 +14,27 @@ if ( ! defined( 'GF_LOGGING_DISABLE_NOTICE' ) ) {
 add_action(
 	'init',
 	function () {
-		if ( ! class_exists( '\GFForms' ) ) {
+		if ( ! class_exists( '\GFForms' ) || ! class_exists( 'GFWebAPI' ) ) {
 			return;
 		}
 
-		$pending_installation = get_option( 'gform_pending_installation' ) || isset( $_GET['gform_installation_wizard'] ); //phpcs:ignore
+		/*
+		 * Enable the GF REST API (v2). This is idempotent rather than gated on the one-shot
+		 * `gform_pending_installation` flag: in CI the wp-env work-dir cache can be restored against a fresh
+		 * MySQL volume, which wipes the saved API setting while leaving the flag unset — so the flag-gated
+		 * version never re-enabled the API and /gf/v2 returned 404. Re-enable whenever it isn't already on.
+		 */
+		global $gf_webapi;
+		$gf_webapi = GFWebAPI::get_instance();
 
-		if ( ! $pending_installation ) {
+		$settings = (array) $gf_webapi->get_plugin_settings();
+		if ( ( $settings['enabled'] ?? '' ) === '1' && ( $settings['version'] ?? '' ) === 'v2' ) {
 			return;
 		}
 
 		update_option( 'gform_pending_installation', false );
 		\GFSettings::enable_logging();
 
-		/* Enable API */
-		if ( ! class_exists( 'GFWebAPI' ) ) {
-			return;
-		}
-
-		global $gf_webapi;
-		$gf_webapi = GFWebAPI::get_instance();
 		$gf_webapi->update_plugin_settings(
 			[
 				'enabled' => '1',


### PR DESCRIPTION
## Description

Fixes an intermittent E2E flake where all Gravity Forms PDF view/download Playwright tests fail with the entry/form setup hitting a `404` on `/gf/v2/*`.

### Root cause

`tools/mu-plugins/gravityforms.php` only enabled the Gravity Forms REST API (v2) when the one-shot `gform_pending_installation` option was truthy. The E2E job caches the wp-env work directory but **not** the MySQL volume (see the "Ensure WordPress is installed (wp-env cache fallback)" step in `tests.yml`). When a cached work-dir is restored against a fresh, empty DB:

1. The fallback runs `wp core install` (bare WordPress).
2. The saved GF Web API setting is gone (fresh DB) and `gform_pending_installation` is never re-set.
3. The flag-gated mu-plugin therefore never re-enables the API, so `/gf/v2/*` is unregistered → `404`.
4. Every test that seeds a form/entry via the GF REST API fails before a PDF is even generated.

This is why the failures correlated with the `wp-env work-dir cache hit a fresh DB volume — running wp core install` log line and only appeared on later runs (cache hits), not the first fresh build.

### Fix

Enable the GF REST API **idempotently** — whenever Gravity Forms is loaded and the API isn't already on as v2, enable it. The setup self-heals on the first request after a fresh-DB cache hit, with an early return so already-configured sites skip the option writes.

### Verification

Reproduced and fixed against a live `wp-env:e2e` instance:

- Deleting `gravityformsaddon_gravityformswebapi_settings` + `gform_pending_installation` (fresh-DB simulation) ⇒ `/gf/v2` unregistered (the `404`).
- With this change, the first request self-heals ⇒ `/gf/v2` registered, setting restored to `{"enabled":"1","version":"v2"}`, idempotent on repeat.
- `php -l` clean, `composer lint` (PHPCS) clean.

## Checklist
- [x] I've tested the code.
- [x] My code is easy to read with consistent naming and good comments.