### PR TITLE
Fix E2E: wp-env reset on cache-restore fresh DB so GF REST enables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -461,24 +461,16 @@ jobs:
       - name: Install / Setup Gravity PDF + WordPress
         run: yarn wp-env:e2e start
 
-      # wp-env's work-dir is cached but its MySQL volume isn't, so a restored work-dir can pair with a fresh empty DB
-      # — wp-env then skips `wp core install` and Playwright fails with "The site you have requested is not installed."
+      # wp-env's work-dir is cached but its MySQL volume isn't, so a restored work-dir can pair with a fresh empty DB.
+      # A bare `wp core install` leaves the env half-configured (GF REST never enables), so run wp-env's full reset.
       - name: Ensure WordPress is installed (wp-env cache fallback)
         run: |
-          yarn wp-env:e2e run cli bash -c '
-            if ! wp core is-installed >/dev/null 2>&1; then
-              echo "wp-env work-dir cache hit a fresh DB volume — running wp core install."
-              wp core install \
-                --url=http://localhost:8702 \
-                --title=Test \
-                --admin_user=admin \
-                --admin_password=password \
-                --admin_email=admin@test.local \
-                --skip-email
-            else
-              echo "WordPress already installed."
-            fi
-          '
+          if yarn wp-env:e2e run cli wp core is-installed >/dev/null 2>&1; then
+            echo "WordPress already installed."
+          else
+            echo "wp-env work-dir cache hit a fresh DB volume — running wp-env reset for a full install."
+            yarn wp-env:e2e reset
+          fi
 
       - name: Run the tests
         run: yarn test:e2e -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}

--- a/tools/mu-plugins/gravityforms.php
+++ b/tools/mu-plugins/gravityforms.php
@@ -18,12 +18,6 @@ add_action(
 			return;
 		}
 
-		/*
-		 * Enable the GF REST API (v2). This is idempotent rather than gated on the one-shot
-		 * `gform_pending_installation` flag: in CI the wp-env work-dir cache can be restored against a fresh
-		 * MySQL volume, which wipes the saved API setting while leaving the flag unset — so the flag-gated
-		 * version never re-enabled the API and /gf/v2 returned 404. Re-enable whenever it isn't already on.
-		 */
 		global $gf_webapi;
 		$gf_webapi = GFWebAPI::get_instance();
 
@@ -33,7 +27,7 @@ add_action(
 		}
 
 		update_option( 'gform_pending_installation', false );
-		\GFSettings::enable_logging();
+		GFSettings::enable_logging();
 
 		$gf_webapi->update_plugin_settings(
 			[


### PR DESCRIPTION
## Problem

The Playwright E2E shards fail intermittently with `rest_no_route` for `/gf/v2/*` — but the pattern is not random. They fail whenever the `wp-env` work-directory cache is **restored** (a cache hit), and pass on a cache **miss**.

The work-dir cache is keyed on `hashFiles('tools/wp-env/e2e.json', 'composer.lock')`, but the MySQL volume is **not** cached. So a restored work-dir pairs with a fresh, empty database. The existing fallback ran a bare `wp core install`, which installs WordPress core but skips wp-env's full configure path — leaving Gravity Forms half-configured. The result: the `gravityformsaddon_gravityformswebapi_settings` option never persists, `is_v2_enabled` stays `false`, and the `gf/v2` REST routes never register.

This was masked because a fresh CI run (cold cache) installs everything correctly; only cache-hit runs regressed.

## Fix

In the cache-fallback step, run wp-env's own `reset` instead of a bare `wp core install`. `wp-env reset` performs the full database reinstall + configure path (and the `afterReset` lifecycle hook), matching a fresh `wp-env start`.

## Verification

Confirmed on a cache-hit run (diagnostic, since removed):

```
fallback:  cache hit a fresh DB volume — running wp-env reset
           ✔ Executing afterReset Script
webapi:    {"enabled":"1","version":"v2"}
is_v2_enabled=true  gf_v2_route=true
```

All 4 Playwright shards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)