### PR TITLE
chore(deps): weekly bump of WordPress core + Gravity Forms

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1538,10 +1538,10 @@
         },
         {
             "name": "gravity/gravityforms",
-            "version": "2.10.2",
+            "version": "2.10.3",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.gravity.io/downloads/?plugin=gravityforms&version=2.10.2"
+                "url": "https://composer.gravity.io/downloads/?plugin=gravityforms&version=2.10.3"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
Automated weekly dependency refresh.

**Composer packages** — `gravity/gravityforms`

| Package | Before | After |
| --- | --- | --- |
| gravity/gravityforms | `2.10.2` | `2.10.3` |