### PR TITLE
Allow GPDF_API_URL to be overridden via wp-config.php

### DIFF
--- a/pdf.php
+++ b/pdf.php
@@ -41,7 +41,11 @@ define( 'PDF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); /* plugin directory pat
 define( 'PDF_PLUGIN_URL', plugin_dir_url( __FILE__ ) ); /* plugin directory url */
 define( 'PDF_PLUGIN_BASENAME', plugin_basename( __FILE__ ) ); /* the plugin basename */
 define( 'GPDF_PLUGIN_FILE', __FILE__ );
-define( 'GPDF_API_URL', 'https://api.gravitypdf.com' );
+
+/* Allow wp-config.php to point licensing/update requests at a staging endpoint */
+if ( ! defined( 'GPDF_API_URL' ) ) {
+	define( 'GPDF_API_URL', 'https://api.gravitypdf.com' );
+}
 
 if ( ! class_exists( 'GFPDF_Major_Compatibility_Checks' ) ) {
 	/*

--- a/src/Model/Model_Settings.php
+++ b/src/Model/Model_Settings.php
@@ -443,6 +443,12 @@ class Model_Settings extends Helper_Abstract_Model {
 			)
 		);
 
+		/*
+		 * Keep $bulk_api_params numerically indexed. The API keys its response array by the same
+		 * keys it receives, so numeric indices make it return a JSON array (which the response
+		 * handlers below decode via is_array()). Switching to slug keys would return a JSON object
+		 * and silently break bulk handling.
+		 */
 		$bulk_api_params = [];
 		foreach ( $products as $product ) {
 			/* skip improperly-registered plugins */


### PR DESCRIPTION
## Summary

Wraps the `GPDF_API_URL` define in an `if ( ! defined() )` guard so a site can override the licensing/update endpoint from `wp-config.php`. This lets a staging site point at the upcoming Cloudflare Worker licensing proxy without editing plugin code. Also adds a comment documenting why the bulk `get_version` params must stay numerically indexed (the API keys its response array by the same keys it receives, so numeric indices keep the response a JSON array that the response handlers decode via `is_array()`).

## Try it

Add to `wp-config.php`:

```php
define( 'GPDF_API_URL', 'https://staging-endpoint.example.com' );
```

Licensing and update checks now hit that endpoint; with no override they continue to use `https://api.gravitypdf.com`.

## Test plan

- [ ] With no override defined, licensing and update checks work against `https://api.gravitypdf.com` as before
- [ ] With the constant defined in `wp-config.php`, requests go to the override endpoint

<details>
<summary>More info</summary>

Part of repointing the licensing/update API at a Cloudflare Worker proxy. The proxy-side changes (status passthrough, content-type handling, rate-limit bypass, tests) live in the `gravitypdf-update-server` repo. The guard is the standard WordPress constant-override idiom and is a no-op when the constant isn't pre-defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>