### PR TITLE
Fix pre-rename text domain on three REST strings

### DIFF
--- a/src/Rest/Rest_Download_Pdf.php
+++ b/src/Rest/Rest_Download_Pdf.php
@@ -96,7 +96,7 @@ class Rest_Download_Pdf {
 			[
 				'args' => [
 					'entry' => [
-						'description'       => __( 'The unique identifier for the Gravity Forms entry.', 'gravity-forms-pdf-extended' ),
+						'description'       => __( 'The unique identifier for the Gravity Forms entry.', 'gravity-pdf' ),
 						'type'              => 'integer',
 						'required'          => true,
 						'validate_callback' => function ( $param, $request ) {
@@ -108,14 +108,14 @@ class Rest_Download_Pdf {
 
 							return new WP_Error(
 								'rest_invalid_param',
-								sprintf( __( 'Invalid entry ID %d provided.', 'gravity-forms-pdf-extended' ), $param ),
+								sprintf( __( 'Invalid entry ID %d provided.', 'gravity-pdf' ), $param ),
 								[ 'status' => 400 ]
 							);
 						},
 					],
 
 					'pdf'   => [
-						'description'       => __( 'The identifier for the PDF', 'gravity-forms-pdf-extended' ),
+						'description'       => __( 'The identifier for the PDF', 'gravity-pdf' ),
 						'type'              => 'string',
 						'required'          => true,
 						'validate_callback' => function ( $param, $request ) {


### PR DESCRIPTION
Three REST argument strings in `src/Rest/Rest_Download_Pdf.php` still use the pre-rename `'gravity-forms-pdf-extended'` domain, while the plugin declares `Text Domain: gravity-pdf`. They never resolve to a translation as a result.

This points them at `'gravity-pdf'`, matching the correct sibling calls in the same file (lines 144/151/378). I left the legacy-slug identity checks in the updater alone, since those reference the old slug on purpose.

The REST download flow in Gravity PDF is thoughtfully built. Happy to help a few strings in it translate.

(full disclosure: AI helped me find the mismatch and confirm the updater checks were intentional; the change and this note are mine.)
