### PR TITLE
chore(deps): weekly bump of WordPress core + Gravity Forms

### DIFF
--- a/tools/wp-env/development.json
+++ b/tools/wp-env/development.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.1.zip",
+  "core": "https://wordpress.org/wordpress-7.0.2.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/e2e.json
+++ b/tools/wp-env/e2e.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.1.zip",
+  "core": "https://wordpress.org/wordpress-7.0.2.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/integration.json
+++ b/tools/wp-env/integration.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.1.zip",
+  "core": "https://wordpress.org/wordpress-7.0.2.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {


### PR DESCRIPTION
Automated weekly dependency refresh.

**WordPress core (wp-env configs):** `7.0.1` → `7.0.2`

**Composer packages** — `gravity/gravityforms`

| Package | Before | After |
| --- | --- | --- |