### PR TITLE
fix: replace GFCommon::get_lead_field_display() deprecated in Gravity Forms 3.0

### DIFF
--- a/src/Helper/Fields/Field_Chainedselect.php
+++ b/src/Helper/Fields/Field_Chainedselect.php
@@ -4,7 +4,6 @@ namespace GFPDF\Helper\Fields;
 
 use Exception;
 use GF_Chained_Field_Select;
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Misc;
@@ -63,7 +62,7 @@ class Field_Chainedselect extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );

--- a/src/Helper/Fields/Field_Default.php
+++ b/src/Helper/Fields/Field_Default.php
@@ -2,7 +2,6 @@
 
 namespace GFPDF\Helper\Fields;
 
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 
 /**
@@ -36,7 +35,7 @@ class Field_Default extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );

--- a/src/Helper/Fields/Field_Likert.php
+++ b/src/Helper/Fields/Field_Likert.php
@@ -2,7 +2,6 @@
 
 namespace GFPDF\Helper\Fields;
 
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 
 /**
@@ -84,7 +83,7 @@ class Field_Likert extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );

--- a/src/Helper/Fields/Field_Rank.php
+++ b/src/Helper/Fields/Field_Rank.php
@@ -2,7 +2,6 @@
 
 namespace GFPDF\Helper\Fields;
 
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 
 /**
@@ -53,7 +52,7 @@ class Field_Rank extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );

--- a/src/Helper/Fields/Field_Rating.php
+++ b/src/Helper/Fields/Field_Rating.php
@@ -2,7 +2,6 @@
 
 namespace GFPDF\Helper\Fields;
 
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 
 /**
@@ -53,7 +52,7 @@ class Field_Rating extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );


### PR DESCRIPTION
## Summary

Gravity Forms 3.0 deprecates `GFCommon::get_lead_field_display()` (`_deprecated_function( …, '3.0', 'GF_Field::get_value_entry_detail()' )`). Running the PHPUnit suite against GF 3.0.0 raises this deprecation notice during field rendering, which the WordPress test harness treats as an unexpected-deprecation failure (**10 failures**).

This replaces the call with `$this->field->get_value_entry_detail( $this->get_value(), $property )` in the 5 affected field renderers, and drops the now-unused `use GFCommon;` import.

## Why this is safe

- `get_value_entry_detail()` is exactly what the deprecated wrapper delegates to internally, so behaviour is preserved.
- It is defined on the base `GF_Field` class and long predates Gravity PDF's minimum supported GF **2.5**, so it is forward-compatible — not a version-pinned patch.
- The existing `version_compare( …, '2.9.29', … )` guard (which selects the full entry array vs. the legacy currency string as the 2nd arg) is unchanged and still load-bearing.
- `Helper_Abstract_Fields::__construct()` already guarantees `$this->field instanceof GF_Field`, so the wrapper's `GF_Fields::create()` fallback was redundant here.

## Files changed

- `src/Helper/Fields/Field_Default.php`
- `src/Helper/Fields/Field_Likert.php`
- `src/Helper/Fields/Field_Chainedselect.php`
- `src/Helper/Fields/Field_Rank.php`
- `src/Helper/Fields/Field_Rating.php`

## Testing

PHPUnit against Gravity Forms 3.0.0: failures drop from **11 → 1**. The 10 `get_lead_field_display` deprecation failures all clear.

> The 1 remaining failure (`Test_Form_Data::test_repeater_maybe_show_section_title`) is a **separate** GF 3.0 change — `GF_Field_Repeater::empty_deep()` no longer treats boolean `false` as empty — and is intentionally out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)