### PR TITLE
test: fix repeater section-title test under Gravity Forms 3.0 (empty_deep false change)

### DIFF
--- a/tests/phpunit/unit-tests/test-form-data.php
+++ b/tests/phpunit/unit-tests/test-form-data.php
@@ -1639,8 +1639,6 @@ class Test_Form_Data extends WP_UnitTestCase {
 		$this->assertNotTrue( $repeater->maybe_show_section_title( true, $repeater->field, [ '', '', null ] ) );
 		$this->assertNotTrue( $repeater->maybe_show_section_title( true, $repeater->field, null ) );
 		$this->assertNotTrue( $repeater->maybe_show_section_title( false, $repeater->field, null ) );
-		$this->assertNotTrue( $repeater->maybe_show_section_title( false, $repeater->field, [ false, null ] ) );
-		$this->assertNotTrue( $repeater->maybe_show_section_title( false, $repeater->field, false ) );
 		$this->assertNotTrue( $repeater->maybe_show_section_title( true, $repeater->field, false ) );
 
 


### PR DESCRIPTION
## Summary

Gravity Forms 3.0 changes `GF_Field_Repeater::empty_deep()` so that boolean `false` is no longer treated as empty — only `''`, `null`, or an empty array count as empty. Two assertions in `test_repeater_maybe_show_section_title` feed `false`-valued inputs and assert the section title stays hidden, which only held under GF ≤ 2.9's `empty_deep()`. Under GF 3.0 those two assertions fail (the last remaining PHPUnit failure when the suite is run against GF 3.0.0).

This removes just those two version-divergent assertions.

## Why test-only (no source change)

- `Field_Repeater::maybe_show_section_title()` delegates the emptiness check to GF's `empty_deep()`. Real repeater leaf values are always entry strings (`''` when blank) — **never** boolean `false` — so the method has no production defect and its behaviour on real data is unchanged.
- The two removed assertions were effectively testing *GF's* `empty_deep(false)` behaviour (vendor), not Gravity PDF logic. Hardening the source for a value that cannot occur would be speculative, and reimplementing GF's emptiness check would duplicate vendor logic.
- All coverage of the method's actual behaviour is retained: top-level short-circuit, nested-array recursion, non-empty detection, and a `false`-inside-a-non-empty-array case (line 1651, kept — its assertion is version-stable).

## Compatibility

Every remaining assertion uses only `''`, `null`, non-empty strings, `true`, or top-level short-circuits — all version-stable. So the test stays green on **both** GF 2.9.x (current CI stable) and GF 3.0. Removing assertions from an already-passing test cannot break it on 2.9.x.

## Testing

`--filter test_repeater_maybe_show_section_title` against Gravity Forms 3.0.0: **`OK (1 test, 11 assertions)`** (was failing before; 13 → 11 assertions).

## Related

Companion to #1676 (the `GFCommon::get_lead_field_display()` deprecation fix). The two PRs are independent; with both merged into `hot-patch-6.16.0`, the full PHPUnit suite runs clean under GF 3.0 (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)