### PR TITLE
chore(deps): patch react-router 6.30.4 and qs 6.15.2 (Dependabot #208, #201)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,10 +3241,10 @@
   resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.3.1.tgz#7cda9b29dca868a9689a7105aec7c21d54575489"
   integrity sha512-YRCrJdhQLobGIQ8Cj1sta3nn6DrZDTSUnrIYhS2e5V590BmfVDleKoAquclAiKSBKWJwmuXTb+b4BL6rSHnahw==
 
-"@remix-run/router@1.23.2":
-  version "1.23.2"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
-  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
+"@remix-run/router@1.23.3":
+  version "1.23.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
+  integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -13387,9 +13387,9 @@ qified@^0.9.0:
     hookified "^2.1.1"
 
 qs@^6.5.1:
-  version "6.15.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
-  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 
@@ -13530,19 +13530,19 @@ react-refresh@^0.14.0:
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
 react-router-dom@^6.27.0:
-  version "6.30.3"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.3.tgz#42ae6dc4c7158bfb0b935f162b9621b29dddf740"
-  integrity sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.4.tgz#f7167bf3da6c7d9132130ea985dd06def25e84d5"
+  integrity sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==
   dependencies:
-    "@remix-run/router" "1.23.2"
-    react-router "6.30.3"
+    "@remix-run/router" "1.23.3"
+    react-router "6.30.4"
 
-react-router@6.30.3, react-router@^6.27.0:
-  version "6.30.3"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
-  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
+react-router@6.30.4, react-router@^6.27.0:
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.4.tgz#638f35176527bd243d96d81d35d33b757bad46c2"
+  integrity sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==
   dependencies:
-    "@remix-run/router" "1.23.2"
+    "@remix-run/router" "1.23.3"
 
 react-shallow-renderer@^16.15.0:
   version "16.15.0"


### PR DESCRIPTION
## Summary

Resolves the two open [Dependabot security alerts](https://github.com/GravityPDF/gravity-pdf/security/dependabot). Both are `yarn.lock`-only patch bumps within existing `package.json` ranges — no source or `package.json` changes.

| Alert | Package | Before | After | Advisory |
|-------|---------|--------|-------|----------|
| [#208](https://github.com/GravityPDF/gravity-pdf/security/dependabot/208) | `react-router` / `react-router-dom` | 6.30.3 | **6.30.4** | [GHSA-2j2x-hqr9-3h42](https://github.com/advisories/GHSA-2j2x-hqr9-3h42) — open redirect via protocol-relative `//` path |
| [#201](https://github.com/GravityPDF/gravity-pdf/security/dependabot/201) | `qs` (via `react-instantsearch` → `instantsearch.js`) | 6.15.1 | **6.15.2** | [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) — `qs.stringify` `TypeError` DoS |

`react-router` 6.30.4 also pulls `@remix-run/router` 1.23.3.

## How

- `react-router` / `react-router-dom` are direct deps (`^6.27.0`); bumped via `yarn upgrade react-router react-router-dom`.
- `qs` is transitive, so the single `qs@^6.5.1` lockfile entry (only consumer: `instantsearch.js@4.93.0`) was updated in place to 6.15.2.

## Verification

`yarn install --frozen-lockfile` passes. Installed tree confirms `instantsearch.js/node_modules/qs@6.15.2` and `react-router@6.30.4`.

## Known residual (out of scope for these alerts)

`express` / `body-parser` (dev-only, via `webpack-dev-server` / test tooling) pin `qs@~6.14.0` → **6.14.2**, which is within the advisory range but has no in-range patch (fix is 6.15.2). It is a build/test dependency (not shipped) and is outside the runtime-scoped alert #201. Fully eliminating it would require a `resolutions` override forcing those dev consumers onto 6.15.2 — happy to add that if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)