### PR TITLE
chore(deps): patch qs to 6.15.2 (Dependabot #201)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8496,9 +8496,9 @@ qrcode-terminal@^0.10.0:
   integrity sha512-ZvWjbAj4MWAj6bnCc9CnculsXnJr7eoKsvH/8rVpZbqYxP2z05HNQa43ZVwe/dVRcFxgfFHE2CkUqn0sCyLfHw==
 
 qs@^6.5.1:
-  version "6.15.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
-  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#201](https://github.com/GravityPDF/gravity-pdf/security/dependabot/201) on the 6.16.0 hot-patch line.

Bumps `qs` **6.15.1 → 6.15.2** ([GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) — `qs.stringify` `TypeError` DoS). `qs` is transitive via `react-instantsearch → instantsearch.js` (`qs@^6.5.1`), so the single `yarn.lock` entry is updated in place. The other copy (`qs@~6.5.2` → 6.5.3) is below the advisory range and unaffected.

`react-router` is 5.x on this line, so the companion alert #208 (react-router 6.x) does not apply here — that one is handled separately against `development` in #1678.

## Verification

`yarn install --frozen-lockfile` passes; the resolved tree contains only `qs@6.15.2` (plus the unaffected 6.5.3). Lockfile-only — no `package.json` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)