### PR TITLE
Add GPDFAPI::get_pdf_filename() to the public API

### DIFF
--- a/api.php
+++ b/api.php
@@ -352,6 +352,46 @@ final class GPDFAPI {
 	}
 
 	/**
+	 * Retrieve the filename of the PDF document
+	 * The .pdf extension is not returned by default (pass true to the 3rd param)
+	 *
+	 * See https://docs.gravitypdf.com/developers/api/get_pdf_filename/ for more information about this method
+	 *
+	 * @param int    $entry_id          The Gravity Form entry ID
+	 * @param string $pdf_id            The Gravity PDF ID number (the pid number in the URL when viewing a setting in the admin area)
+	 * @param bool   $include_extension Whether to include the .pdf extension in the filename
+	 *
+	 * @return string|WP_Error   Return the filename of the PDF, or a WP_Error on failure
+	 *
+	 * @since 6.16.0
+	 */
+	public static function get_pdf_filename( $entry_id, $pdf_id, bool $include_extension = false ) {
+		$form_class = self::get_form_class();
+
+		/* Get our entry */
+		$entry = $form_class->get_entry( $entry_id );
+		if ( is_wp_error( $entry ) ) {
+			return new WP_Error( 'invalid_entry', esc_html__( 'Make sure to pass in a valid Gravity Forms Entry ID', 'gravity-pdf' ) );
+		}
+
+		/* Get our settings */
+		$setting = self::get_pdf( $entry['form_id'], $pdf_id );
+		if ( is_wp_error( $setting ) ) {
+			return new WP_Error( 'invalid_pdf_setting', esc_html__( 'Could not located the PDF Settings. Ensure you pass in a valid PDF ID.', 'gravity-pdf' ) );
+		}
+
+		/** @var \GFPDF\Model\Model_PDF $pdf */
+		$pdf = self::get_mvc_class( 'Model_PDF' );
+
+		$filename = $pdf->get_pdf_name( $setting, $entry );
+		if ( $include_extension ) {
+			$filename .= '.pdf';
+		}
+
+		return $filename;
+	}
+
+	/**
 	 * Retrieve an array of the global Gravity PDF settings (this doesn't include individual form configuration details - see GPDFAPI::get_form_pdfs)
 	 *
 	 * See https://docs.gravitypdf.com/v6/developers/api/get_plugin_settings/ for more information about this method

--- a/tests/phpunit/unit-tests/test-api.php
+++ b/tests/phpunit/unit-tests/test-api.php
@@ -320,4 +320,34 @@ class Test_API extends WP_UnitTestCase {
 
 		$this->assertEquals( 'My Single Line Response', $results['field'][1] );
 	}
+
+	/**
+	 * Check we can retrieve the PDF filename, with and without the extension, and that the
+	 * WP_Error paths are returned for invalid entry IDs and invalid PDF IDs.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_get_pdf_filename() {
+		$entry_id = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0]['id'];
+		$pdf_id   = '555ad84787d7e';
+
+		/* The extension is excluded by default */
+		$this->assertSame( 'test', GPDFAPI::get_pdf_filename( $entry_id, $pdf_id ) );
+
+		/* Explicitly excluding the extension matches the default */
+		$this->assertSame( 'test', GPDFAPI::get_pdf_filename( $entry_id, $pdf_id, false ) );
+
+		/* The extension is included when requested */
+		$this->assertSame( 'test.pdf', GPDFAPI::get_pdf_filename( $entry_id, $pdf_id, true ) );
+
+		/* An invalid entry ID returns a WP_Error */
+		$invalid_entry = GPDFAPI::get_pdf_filename( '', $pdf_id );
+		$this->assertInstanceOf( \WP_Error::class, $invalid_entry );
+		$this->assertSame( 'invalid_entry', $invalid_entry->get_error_code() );
+
+		/* A valid entry with an invalid PDF ID returns a WP_Error */
+		$invalid_pdf = GPDFAPI::get_pdf_filename( $entry_id, 'does-not-exist' );
+		$this->assertInstanceOf( \WP_Error::class, $invalid_pdf );
+		$this->assertSame( 'invalid_pdf_setting', $invalid_pdf->get_error_code() );
+	}
 }


### PR DESCRIPTION
## Summary

Adds `GPDFAPI::get_pdf_filename( $entry_id, $pdf_id, bool $include_extension = false )` to the public API. It returns the resolved PDF filename for an entry/PDF pairing, optionally with the `.pdf` extension, and returns a `WP_Error` for an invalid entry ID (`invalid_entry`) or invalid PDF ID (`invalid_pdf_setting`).

Cherry-picked from `52ecb38` for the 6.16.0 hot patch, with two adaptations for this branch:

- Test uses this branch's shared-fixture pattern (`$GLOBALS['GFPDF_Test']->entries[...]`) instead of the post-refactor `$this->entry()` factory helper, which does not exist here.
- `@since` set to `6.16.0` (the release this ships in) rather than `7.0`.

## Testing

`--group api`: OK (20 tests, 71 assertions), including the new `test_get_pdf_filename`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)