### PR TITLE
Licensing and Update API Improvements

### DIFF
--- a/gravity-pdf-updater.php
+++ b/gravity-pdf-updater.php
@@ -25,18 +25,31 @@ if ( ! class_exists( '\GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater' ) ) {
 add_action(
 	'init',
 	function () {
-		new EDD_SL_Plugin_Updater(
+		$plugin_updater = new EDD_SL_Plugin_Updater(
 			GPDF_API_URL,
 			GPDF_PLUGIN_FILE,
 			[
-				'version' => PDF_EXTENDED_VERSION,
-				'item_id' => 137043,
-				'license' => md5( site_url() ),
-				'author'  => 'Blue Liquid Designs',
-				'beta'    => false,
+				'version'     => PDF_EXTENDED_VERSION,
+				'item_name'   => 'Gravity PDF',
+				'item_id'     => 137043,
+				'license'     => md5( site_url() ),
+				'author'      => 'Blue Liquid Designs',
+				'beta'        => false,
+				'wp_override' => current_user_can( 'update_plugins' ) && ! empty( $_GET['force-check'] ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			]
 		);
-	}
+
+		$plugin_updater->init();
+
+		/* Only make plugin updater available when fully initialized */
+		if ( ! class_exists( 'GPDFAPI' ) ) {
+			return;
+		}
+
+		$data          = \GPDFAPI::get_data_class();
+		$data->updater = $plugin_updater;
+	},
+	1
 );
 
 /**
@@ -45,8 +58,8 @@ add_action(
 add_action(
 	'http_api_debug',
 	function ( $response, $context, $class_object, $parsed_args, $url ) {
-		/* Log only Gravity PDF requests */
-		if ( $url !== GPDF_API_URL ) {
+		/* Log only Gravity PDF requests. The self-update check posts to a trailingslashit()'d URL, so normalise both sides. */
+		if ( untrailingslashit( $url ) !== untrailingslashit( GPDF_API_URL ) ) {
 			return;
 		}
 
@@ -57,27 +70,23 @@ add_action(
 
 		$logger = \GPDFAPI::get_log_class();
 
-		$request_body = $parsed_args['body'] ?? [];
-		if ( isset( $request_body['license'] ) && is_string( $request_body['license'] ) && strlen( $request_body['license'] ) > 2 ) {
-			/* mask the license key, if exists */
-			$license                 = $request_body['license'];
-			$request_body['license'] = substr( $license, 0, 1 ) . str_repeat( '*', strlen( $license ) - 2 ) . substr( $license, -1, 1 );
-		}
-
 		$logger->notice(
 			'Gravity PDF License Check API Request',
 			[
 				'url'    => $url,
 				'method' => $parsed_args['method'] ?? '',
-				'body'   => $request_body,
+				'body'   => $parsed_args['body'] ?? [],
 			]
 		);
 
-		$response_code    = wp_remote_retrieve_response_code( $response );
+		$response_code      = wp_remote_retrieve_response_code( $response );
+		$response_body      = wp_remote_retrieve_body( $response );
+		$response_body_json = json_decode( $response_body, true );
+
 		$response_context = [
 			'status'  => $response_code,
-			'headers' => wp_remote_retrieve_headers( $response ),
-			'body'    => wp_remote_retrieve_body( $response ),
+			'headers' => (array) wp_remote_retrieve_headers( $response ),
+			'body'    => $response_body_json ?? $response_body,
 		];
 
 		if ( $response_code >= 300 ) {
@@ -121,15 +130,15 @@ add_action(
 
 		printf(
 			'<tr class="plugin-update-tr %3$s" id="%1$s-update" data-slug="%1$s" data-plugin="%2$s">',
-			esc_attr( $plugin_data['slug'] ?? '' ),
-			esc_attr( $plugin_data['plugin'] ?? '' ),
+			esc_attr( 'gravity-forms-pdf-extended' ),
+			esc_attr( 'gravity-forms-pdf-extended/pdf.php' ),
 			'inactive'
 		);
 
 		echo '<td colspan="4" class="plugin-update colspanchange">';
 		echo '<div class="notice inline notice-warning notice-alt"><p>';
 
-		echo esc_html__( 'This is the non-canonical release of Gravity PDF.', 'gravity-pdf' );
+		echo esc_html__( 'This is the non-canonical release of Gravity PDF which can be deleted.', 'gravity-pdf' );
 
 		echo '</p></div>';
 		echo '</td>';

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -46,6 +46,7 @@
         <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
         <exclude name="PSR12.Files.FileHeader.IncorrectOrder"/>
         <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed"/>
+        <exclude name="Universal.Operators.DisallowShortTernary.Found"/>
 
         <exclude-pattern>/tests/*</exclude-pattern>
     </rule>
@@ -97,6 +98,5 @@
     <exclude-pattern>/vendor/*</exclude-pattern>
     <exclude-pattern>/vendor_prefixed/*</exclude-pattern>
     <exclude-pattern>/node_modules/*</exclude-pattern>
-    <exclude-pattern>/src/helper/licensing/EDD_SL_Plugin_Updater.php</exclude-pattern>
     <exclude-pattern>/.php-scoper/*</exclude-pattern>
 </ruleset>

--- a/src/Controller/Controller_Activation.php
+++ b/src/Controller/Controller_Activation.php
@@ -70,6 +70,8 @@ class Controller_Activation {
 
 		/* Remove our scheduled tasks */
 		wp_clear_scheduled_hook( 'gfpdf_cleanup_tmp_dir' );
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+		wp_clear_scheduled_hook( 'gfpdf_bulk_license_check' );
 
 		/* Flush caches */
 		$templates = \GPDFAPI::get_templates_class();

--- a/src/Controller/Controller_Settings.php
+++ b/src/Controller/Controller_Settings.php
@@ -170,6 +170,27 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		 * Add AJAX Action Endpoints
 		 */
 		add_action( 'wp_ajax_gfpdf_deactivate_license', [ $this->model, 'process_license_deactivation' ] );
+
+		/* Schedule License Check for all add-ons */
+		add_action(
+			'init',
+			function () {
+				if ( empty( $this->data->addon ) ) {
+					return;
+				}
+
+				if ( $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+					return;
+				}
+
+				add_action( 'gfpdf_bulk_license_check', [ $this->model, 'licensing_bulk_license_check' ] );
+				if ( ! wp_next_scheduled( 'gfpdf_bulk_license_check' ) ) {
+					wp_schedule_single_event( strtotime( '+1 week' ), 'gfpdf_bulk_license_check' );
+				}
+			}
+		);
+
+		$this->maybe_schedule_network_update_check();
 	}
 
 	/**
@@ -200,6 +221,8 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		/* Register add-ons for licensing page */
 		add_filter( 'gfpdf_settings_licenses', [ $this->model, 'register_addons_for_licensing' ] );
 		add_filter( 'gfpdf_settings_license_sanitize', [ $this->model, 'maybe_active_licenses' ] );
+		add_filter( 'gpdf_sl_plugin_updater_api_params', [ $this->model, 'licensing_bulk_get_version_api_params' ] );
+		add_filter( 'gpdf_sl_plugin_updater_api_response', [ $this->model, 'licensing_bulk_get_version_api_response' ], 10, 3 );
 	}
 
 	/**
@@ -283,5 +306,33 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		}
 
 		return $nav;
+	}
+
+	/**
+	 * On a Multisite installation where Gravity PDF isn't network/primary site activated,
+	 * add a scheduled task to display an update nag in the network admin on a best-effort basis
+	 *
+	 * @return void
+	 *
+	 * @since 6.16.0
+	 */
+	protected function maybe_schedule_network_update_check() {
+		if ( ! is_multisite() || is_main_site() ) {
+			return;
+		}
+
+		/* Network-activated installs already receive update checks through the normal flow */
+		if ( $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return;
+		}
+
+		add_action( 'gfpdf_network_update_check', [ $this->model, 'run_network_update_check' ] );
+
+		/* skip if event already scheduled; run_network_update_check() re-arms it each cycle */
+		if ( wp_next_scheduled( 'gfpdf_network_update_check' ) ) {
+			return;
+		}
+
+		$this->model->schedule_network_update_check();
 	}
 }

--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -58,6 +58,10 @@ class Controller_Upgrade_Routines {
 		if ( version_compare( $current_version, '6.13.2', '>=' ) && version_compare( $old_version, '6.13.2', '<' ) ) {
 			$this->fix_tmp_folder_permissions();
 		}
+
+		if ( version_compare( $current_version, '6.16.0', '>=' ) && version_compare( $old_version, '6.16.0', '<' ) ) {
+			$this->remove_legacy_update_cache();
+		}
 	}
 
 	/**
@@ -141,5 +145,22 @@ class Controller_Upgrade_Routines {
 				// do nothing
 			}
 		}
+	}
+
+	/**
+	 * Remove Gravity PDF's legacy edd_sl_* update cache options left behind by the previous plugin updater
+	 *
+	 * @since 6.16.0
+	 */
+	protected function remove_legacy_update_cache() {
+		global $wpdb;
+
+		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'edd_sl_%' AND option_value LIKE '%gravity-pdf%'" );
+
+		/* The failure-backoff option stores a bare timestamp, so the value filter above can't match it — target both
+		   the historical (≤6.14.x) and the 6.15.0 API hosts by exact name. 6.15.0's key was autoloaded, so a site that
+		   ever hit an API failure would otherwise carry a stale autoloaded option forever. */
+		delete_option( 'edd_sl_failed_http_' . md5( 'https://gravitypdf.com?api=1' ) );
+		delete_option( 'edd_sl_failed_http_' . md5( GPDF_API_URL ) );
 	}
 }

--- a/src/Helper/Helper_Abstract_Addon.php
+++ b/src/Helper/Helper_Abstract_Addon.php
@@ -2,6 +2,7 @@
 
 namespace GFPDF\Helper;
 
+use GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -25,35 +26,35 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @since 4.2
 	 */
-	private $slug;
+	protected $slug;
 
 	/**
 	 * @var string The add-on name (should match the name/title used in EDD)
 	 *
 	 * @since 4.2
 	 */
-	private $name;
+	protected $name;
 
 	/**
 	 * @var string The add-on author
 	 *
 	 * @since 4.2
 	 */
-	private $author;
+	protected $author;
 
 	/**
 	 * @var string The add-on version
 	 *
 	 * @since 4.2
 	 */
-	private $version;
+	protected $version;
 
 	/**
 	 * @var string The add-on mail file path
 	 *
 	 * @since 4.2
 	 */
-	private $addon_path_main_plugin_file;
+	protected $addon_path_main_plugin_file;
 
 	/**
 	 * Holds our registered objects
@@ -123,6 +124,42 @@ abstract class Helper_Abstract_Addon {
 	 * @internal This has been added for backwards compatibility. Use self::enable_settings_prefix() after initialization to opt in
 	 */
 	protected $use_settings_prefix = false;
+
+	/**
+	 * @var EDD_SL_Plugin_Updater
+	 * @since 6.16.0
+	 */
+	protected $plugin_updater;
+
+	/**
+	 * @var string The current license key for this addon
+	 * @since 6.16.0
+	 */
+	protected $license_key = '';
+
+	/**
+	 * @var string The current license key status (retrieved from the API) for this addon
+	 * @since 6.16.0
+	 */
+	protected $license_key_status = '';
+
+	/**
+	 * @var string The current license key message for this addon (based on the status)
+	 * @since 6.16.0
+	 */
+	protected $license_key_message = '';
+
+	/**
+	 * @var bool Whether the addon activated the license based on another addon activation
+	 * @since 6.16.0
+	 */
+	protected $license_auto_activated = false;
+
+	/**
+	 * @var bool Whether the addon deactivated the license based on another addon deactivation
+	 * @since 6.16.0
+	 */
+	protected $license_auto_deactivated = false;
 
 	/**
 	 * Helper_Abstract_Addon constructor.
@@ -253,6 +290,19 @@ abstract class Helper_Abstract_Addon {
 	}
 
 	/**
+	 * @return EDD_SL_Plugin_Updater|null
+	 * @since 6.16.0
+	 */
+	public function get_plugin_updater() {
+		$updater = $this->plugin_updater;
+		if ( ! $updater ) {
+			_doing_it_wrong( __METHOD__, 'This method should not be called before the "init" hook (priority 1)', '6.16.0' );
+		}
+
+		return $updater;
+	}
+
+	/**
 	 * Setup the add-on licensing and initialise any classes
 	 *
 	 * @param array $classes
@@ -261,13 +311,24 @@ abstract class Helper_Abstract_Addon {
 	 */
 	public function init( $classes = [] ) {
 
+		/* Get and store the license information from the database */
+		$this->get_license_info( true );
+
 		/*
-		 * Register our plugin updater on the admin initialisation action
-		 *
-		 * @Internal Due to WordPress.org rules we cannot initialisation the updater code in the core plugin
-		 *           Add-ons have to initialise this functionality via GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater
+		 * Register our plugin updater
 		 */
-		add_action( 'init', [ $this, 'plugin_updater' ] );
+		$central_plugin_updater = function () {
+			$this->central_plugin_updater();
+		};
+
+		add_action( 'init', $central_plugin_updater, 1 );
+
+		/* Maybe auto-activate hardcoded license */
+		$maybe_activate_hardcoded_license = function () {
+			$this->maybe_activate_hardcoded_license();
+		};
+
+		add_action( 'init', $maybe_activate_hardcoded_license, 2 );
 
 		/*
 		 * Automatically register our addon with the main plugin to enable license management in the UI
@@ -281,22 +342,17 @@ abstract class Helper_Abstract_Addon {
 			add_filter( 'gfpdf_settings_extensions', [ $this, 'register_addon_fields' ] );
 		}
 
-		/*
-		 * Automatically schedule license checks weekly
-		 */
-		add_action( 'admin_init', [ $this, 'maybe_schedule_license_check' ] );
+		/* Add listener for now-deprecated individual licence check (handled in bulk in Controller_Settings) */
 		add_action( 'gfpdf_' . $this->get_slug() . '_license_check', [ $this, 'schedule_license_check' ] );
+
+		/* Add listener for other license activation/deactivation */
+		add_action( 'gfpdf_addon_post_license_activation', [ $this, 'maybe_auto_activate_license' ], 10, 3 );
+		add_action( 'gfpdf_addon_post_license_deactivation', [ $this, 'maybe_auto_deactivate_license' ], 10, 2 );
 
 		/*
 		 * Include info on plugin listing
 		 */
-		add_action(
-			'after_plugin_row_' . plugin_basename( $this->get_main_plugin_file() ),
-			[
-				$this,
-				'license_registration',
-			]
-		);
+		add_action( 'after_plugin_row_' . plugin_basename( $this->get_main_plugin_file() ), [ $this, 'license_registration' ] );
 		add_filter( 'plugin_row_meta', [ $this, 'plugin_row_meta' ], 10, 2 );
 
 		/*
@@ -329,15 +385,12 @@ abstract class Helper_Abstract_Addon {
 	/**
 	 * This method handles the add-on update code
 	 *
-	 * Due to WordPress.org rules we cannot initialisation the updater code in the core plugin so add-ons that utilise
-	 * this class need to handle that code themselves.
-	 *
 	 * Official Gravity PDF add-ons should initialise the GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater class
 	 * when the add-on license status is set to "active". You can check the status of the plugin
 	 * using the following:
 	 *
 	 * $license_info = $this->get_license_info();
-	 * if ( $license_info['status'] !== 'active' ) {
+	 * if ( in_array( $this->get_license_status(), [ 'active', 'valid' ], true ) ) {
 	 *    return;
 	 * }
 	 *
@@ -357,14 +410,85 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @return void
 	 * @since 4.2
-	 *
+	 * @deprecated 6.16.0 Use self::central_plugin_updater()
 	 */
-	abstract public function plugin_updater();
+	public function plugin_updater() {}
+
+	/**
+	 * @return array
+	 * @since 6.16.0
+	 */
+	public function get_default_api_params() {
+		return [
+			'version'   => $this->get_version(),
+			'license'   => $this->get_license_key(),
+			'item_name' => $this->get_short_name(),
+			'item_id'   => $this->get_edd_download_id(),
+			'author'    => $this->get_author(),
+			'beta'      => false,
+		];
+	}
+
+	/**
+	 * The central add-on update initializer
+	 *
+	 * @return void
+	 * @since 6.16.0
+	 */
+	protected function central_plugin_updater() {
+		$this->plugin_updater = new EDD_SL_Plugin_Updater(
+			$this->data->store_url,
+			$this->get_main_plugin_file(),
+			$this->get_default_api_params()
+		);
+
+		$this->plugin_updater->set_license_status( $this->get_license_status() );
+		$this->plugin_updater->init();
+	}
+
+	/**
+	 * Activate a hardcoded license key (set via the GPDF_LICENSE_KEY constant) on an admin request.
+	 *
+	 * Retries while the stored status isn't active/valid so a transient API failure on the first attempt self-heals,
+	 * and re-activates when the constant key is rotated. A short backoff keeps a rejected or unreachable key from
+	 * hitting the licensing API on every admin request.
+	 *
+	 * @return void
+	 * @since 6.16.0
+	 */
+	protected function maybe_activate_hardcoded_license() {
+		$hardcoded_license = $this->get_license_key_from_constant();
+		if ( ! $hardcoded_license || $this->license_auto_activated || ! is_admin() ) {
+			return;
+		}
+
+		/* On a network-activated Multisite, only the primary site activates the hardcoded license */
+		if ( \GPDFAPI::get_misc_class()->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return;
+		}
+
+		$key_changed = $hardcoded_license !== $this->license_key;
+		$is_active   = in_array( $this->get_license_status(), [ 'active', 'valid' ], true );
+
+		if ( ! $key_changed && $is_active ) {
+			return;
+		}
+
+		/* Back off retries for an unchanged, still-inactive key so a bad or unreachable key doesn't POST every request */
+		$backoff = 'gfpdf_license_activation_' . $this->get_slug();
+		if ( ! $key_changed && get_transient( $backoff ) ) {
+			return;
+		}
+
+		$this->activate_license( $hardcoded_license, true );
+
+		if ( ! in_array( $this->get_license_status(), [ 'active', 'valid' ], true ) ) {
+			set_transient( $backoff, 1, 3 * HOUR_IN_SECONDS );
+		}
+	}
 
 	/**
 	 * Register the add-on with Gravity PDF
-	 *
-	 * @Internal If you don't want the add-on licensing handled automatically in the UI override this method
 	 *
 	 * @since    4.2
 	 */
@@ -522,24 +646,27 @@ abstract class Helper_Abstract_Addon {
 	}
 
 	/**
-	 * Get the add-on license information stored in the database (if any)
+	 * Get the add-on license information (if any)
 	 *
-	 * @Internal If you don't want the add-on licensing handled automatically in the UI override this method
+	 * @param bool $use_database Fetch license info from the database
 	 *
 	 * @since    4.2
+	 * @since 6.16.0 Get license info stored in the object
 	 */
-	public function get_license_info() {
-		$settings = $this->options->get_settings();
+	public function get_license_info( $use_database = false ) {
+		if ( $use_database ) {
+			$settings = $this->options->get_settings();
 
-		$slug    = $this->get_slug();
-		$license = ( isset( $settings[ "license_$slug" ] ) ) ? $settings[ "license_$slug" ] : '';
-		$status  = ( isset( $settings[ "license_{$slug}_status" ] ) ) ? $settings[ "license_{$slug}_status" ] : '';
-		$message = ( isset( $settings[ "license_{$slug}_message" ] ) ) ? $settings[ "license_{$slug}_message" ] : '';
+			$slug                      = $this->get_slug();
+			$this->license_key         = $settings[ "license_$slug" ] ?? '';
+			$this->license_key_status  = $settings[ "license_{$slug}_status" ] ?? '';
+			$this->license_key_message = $settings[ "license_{$slug}_message" ] ?? '';
+		}
 
 		$license_details = [
-			'license' => $license,
-			'status'  => $status,
-			'message' => $message,
+			'license' => $this->get_license_key(),
+			'status'  => $this->get_license_status(),
+			'message' => $this->get_license_message(),
 		];
 
 		$this->log->notice( 'Get plugin license details', $license_details );
@@ -551,18 +678,32 @@ abstract class Helper_Abstract_Addon {
 	 * Update the add-on license information stored in the database
 	 *
 	 * @param array $license_info
-	 *
-	 * @Internal If you don't want the add-on licensing handled automatically in the UI override this method
+	 * @param bool $use_database Whether to update the database or not. A DB update will auto-call Model_Settings::maybe_active_licenses(), which may not be ideal
 	 *
 	 * @since    4.2
+	 * @since 6.16.0 Added
 	 */
-	public function update_license_info( $license_info ) {
+	public function update_license_info( $license_info, $use_database = false ) {
+		$this->license_key         = $license_info['license'] ?? '';
+		$this->license_key_status  = $license_info['status'] ?? '';
+		$this->license_key_message = $license_info['message'] ?? '';
+
+		/* Check the update has been initialized before setting the license key */
+		if ( isset( $this->plugin_updater ) ) {
+			$this->plugin_updater->set_license_key( $this->license_key );
+			$this->plugin_updater->set_license_status( $this->license_key_status );
+		}
+
+		if ( ! $use_database ) {
+			return;
+		}
+
 		$settings = $this->options->get_settings();
 		$slug     = $this->get_slug();
 
-		$settings[ "license_$slug" ]           = $license_info['license'];
-		$settings[ "license_{$slug}_status" ]  = $license_info['status'];
-		$settings[ "license_{$slug}_message" ] = $license_info['message'];
+		$settings[ "license_$slug" ]           = $this->get_license_key();
+		$settings[ "license_{$slug}_status" ]  = $this->get_license_status();
+		$settings[ "license_{$slug}_message" ] = $this->get_license_message();
 
 		$this->log->notice( 'Update plugin license details', $license_info );
 
@@ -575,12 +716,23 @@ abstract class Helper_Abstract_Addon {
 	 * @since 4.2
 	 */
 	public function delete_license_info() {
+		$this->update_license_info( [] );
+
+		/* Check the update has been initialized before setting the license key */
+		if ( isset( $this->plugin_updater ) ) {
+			$this->plugin_updater->set_license_key( '' );
+		}
+
 		$settings = $this->options->get_settings();
 		$slug     = $this->get_slug();
 
-		unset( $settings[ "license_$slug" ] );
-		unset( $settings[ "license_{$slug}_status" ] );
-		unset( $settings[ "license_{$slug}_message" ] );
+		unset(
+			$settings[ "license_$slug" ],
+			$settings[ "license_{$slug}_status" ],
+			$settings[ "license_{$slug}_message" ]
+		);
+
+		wp_clear_scheduled_hook( 'gfpdf_' . $slug . '_license_check' );
 
 		$this->log->notice( 'Delete plugin license details' );
 
@@ -593,7 +745,44 @@ abstract class Helper_Abstract_Addon {
 	 * @since 4.2
 	 */
 	final public function get_license_key() {
-		return $this->get_license_info()['license'];
+		$hardcoded_license = $this->get_license_key_from_constant();
+
+		return $hardcoded_license ?: $this->license_key;
+	}
+
+	/**
+	 * Get a Gravity PDF license key defined in the `GPDF_LICENSE_KEY` PHP constant
+	 *
+	 * @return false|string
+	 *
+	 * @since 6.16.0
+	 */
+	final public function get_license_key_from_constant() {
+		$slug = $this->get_slug();
+
+		/** @var string|array $license_key */
+		$license_key = defined( 'GPDF_LICENSE_KEY' ) ? GPDF_LICENSE_KEY : null;
+		$license_key = apply_filters( 'gfpdf_addon_hardcoded_license_key', $license_key, $slug, $this );
+
+		if ( empty( $license_key ) ) {
+			return false;
+		}
+
+		/* universal license */
+		if ( is_string( $license_key ) ) {
+			return $license_key;
+		}
+
+		/* extension-specific license */
+		if ( is_array( $license_key ) && isset( $license_key[ $slug ] ) ) {
+			return $license_key[ $slug ];
+		}
+
+		if ( is_array( $license_key ) && isset( $license_key['*'] ) ) {
+			return $license_key['*'];
+		}
+
+		return false;
 	}
 
 	/**
@@ -602,7 +791,7 @@ abstract class Helper_Abstract_Addon {
 	 * @since 4.2
 	 */
 	final public function get_license_status() {
-		return $this->get_license_info()['status'];
+		return $this->license_key_status;
 	}
 
 	/**
@@ -611,7 +800,38 @@ abstract class Helper_Abstract_Addon {
 	 * @since 4.2
 	 */
 	final public function get_license_message() {
-		return $this->get_license_info()['message'];
+		return $this->license_key_message;
+	}
+
+	/**
+	 * Whether the addon activated the license based on another addon activation
+	 *
+	 * @return bool
+	 * @since 6.16.0
+	 */
+	final public function has_license_auto_activated() {
+		return $this->license_auto_activated;
+	}
+
+	/**
+	 * Whether the license key is controlled by the site rather than the settings form — a `GPDF_LICENSE_KEY`
+	 * constant or an auto-activated Access Pass. Such a key is authoritative: a submitted value must be ignored.
+	 *
+	 * @return bool
+	 * @since 6.16.0
+	 */
+	final public function is_license_admin_managed() {
+		return (bool) $this->get_license_key_from_constant() || $this->has_license_auto_activated();
+	}
+
+	/**
+	 * Whether the addon deactivated the license based on another addon deactivation.
+	 *
+	 * @return bool
+	 * @since 6.16.0
+	 */
+	final public function has_license_auto_deactivated() {
+		return $this->license_auto_deactivated;
 	}
 
 	/**
@@ -621,6 +841,8 @@ abstract class Helper_Abstract_Addon {
 	 *           and 2. Need to clear the scheduled hook when the plugin is deactivated
 	 *
 	 * @since    4.2
+	 *
+	 * @deprecated 6.16.0 Handled in bulk via Model_Settings::licensing_bulk_license_check()
 	 */
 	final public function maybe_schedule_license_check() {
 		if ( ! wp_next_scheduled( 'gfpdf_' . $this->get_slug() . '_license_check' ) ) {
@@ -631,15 +853,16 @@ abstract class Helper_Abstract_Addon {
 	/**
 	 * Makes an API call to check the status of the license and updates the license settings
 	 *
-	 * @Internal If you don't want the add-on licensing handled automatically in the UI override this method
-	 *
 	 * @since    4.2
 	 */
 	public function schedule_license_check() {
-		$license_info = $this->get_license_info();
+		/* On a network-activated Multisite, only the primary site runs the license check */
+		if ( \GPDFAPI::get_misc_class()->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return false;
+		}
 
-		/* If the license info is empty disable check */
-		if ( empty( array_filter( $license_info ) ) ) {
+		/* If there's no license key disable the check */
+		if ( empty( $this->get_license_key() ) ) {
 			return false;
 		}
 
@@ -647,52 +870,112 @@ abstract class Helper_Abstract_Addon {
 			$this->data->store_url,
 			[
 				'timeout' => 15,
-				'body'    => [
-					'edd_action'  => 'check_license',
-					'license'     => $license_info['license'],
-					'item_id'     => $this->get_edd_download_id(),
-					'item_name'   => rawurlencode( $this->get_short_name() ),
-					'url'         => home_url(),
-					'environment' => function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production',
-				],
+				'body'    => array_merge(
+					[ 'edd_action' => 'check_license' ],
+					$this->get_default_api_params()
+				),
 			]
 		);
 
-		/* If there was a problem with the request we'll try again in an hour */
+		/* Check for problems contacting the licensing server */
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
-			$this->log->error( 'Failed to contact remote API for license status check. Rescheduling.' );
-			wp_schedule_single_event( strtotime( '+ 1 hour' ), 'gfpdf_' . $this->get_slug() . '_license_check' );
+			$this->log->error(
+				'Failed to contact remote API for license status check.',
+				[
+					'slug'  => $this->get_slug(),
+					'error' => is_wp_error( $response ) ? $response->get_error_message() : wp_remote_retrieve_response_code( $response ),
+				]
+			);
+
+			wp_schedule_single_event( strtotime( '+3 hour' ), 'gfpdf_' . $this->get_slug() . '_license_check' );
 
 			return false;
 		}
 
+		/* Check for a malformed response */
 		$license_check = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( $license_check === null ) {
+			$this->log->error(
+				'Invalid response returned from license status check.',
+				[
+					'slug'     => $this->get_slug(),
+					'response' => wp_remote_retrieve_body( $response ),
+				]
+			);
 
-		/* License still valid, no need to do anything */
-		if ( isset( $license_check->license ) && $license_check->license === 'valid' ) {
-			$this->log->notice( 'License key still valid.' );
+			wp_schedule_single_event( strtotime( '+3 hour' ), 'gfpdf_' . $this->get_slug() . '_license_check' );
 
 			return false;
 		}
 
-		/* Error occurred. Update status and message in the license settings */
+		if ( isset( $license_check->license ) && $license_check->license === 'valid' ) {
+			/* License is still valid, do nothing */
+
+			return true;
+		}
+
+		/* License status has changed. Update database */
+		return $this->update_license_status_from_response( $this->get_license_key(), $response, true );
+	}
+
+	/**
+	 * Parse and extract the addon license status from the API response
+	 *
+	 * @param string $license_key Current license key
+	 * @param array|\WP_Error $response The raw response from wp_remote_*())
+	 * @param bool $use_database Whether to save the license info in the database
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	public function update_license_status_from_response( $license_key, $response, $use_database = false ) {
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( is_wp_error( $response ) || $response_code !== 200 ) {
+			$license_data = new \stdClass();
+
+			/* handle rate limiting */
+			if ( $response_code === 429 ) {
+				$license_data->error = 'rate_limit';
+			}
+		} else {
+			$license_data = json_decode( wp_remote_retrieve_body( $response ) );
+		}
+
 		$possible_responses = $this->data->addon_license_responses( $this->get_name() );
 
-		/* Ensure we have a known error */
-		if ( ! isset( $license_check->license ) || ! isset( $possible_responses[ $license_check->license ] ) ) {
-			$this->log->error( 'Unknown license status returned from remote API' );
-
-			return false;
+		$status = 'error';
+		if ( ! empty( $license_data->error ) ) {
+			$status = $license_data->error;
+		} elseif ( ! empty( $license_data->license ) ) {
+			$status = $license_data->license;
 		}
 
-		$license_info['status']  = $license_check->license;
-		$license_info['message'] = $possible_responses[ $license_check->license ];
+		/* Build the info fresh — all three fields are set here, so a get_license_info() read (and its per-call
+		   "Get plugin license details" notice) would be redundant */
+		$license_info = [
+			'license' => $license_key,
+			'status'  => $status,
+			'message' => $possible_responses[ $status ] ?? $possible_responses['generic'],
+		];
 
-		switch ( $license_check->license ) {
+		switch ( $license_info['status'] ) {
 			case 'expired':
 				$date_format = get_option( 'date_format' );
-				$dt          = new \DateTimeImmutable( $license_check->expires, wp_timezone() );
-				$date        = $dt === false ? gmdate( $date_format, false ) : $dt->format( $date_format );
+				$expires     = $license_data->expires ?? '';
+
+				if ( empty( $expires ) ) {
+					/* DateTimeImmutable('') silently resolves to "now", implying the key expired today; surface unknown */
+					$date = __( 'an unknown date', 'gravity-pdf' );
+				} else {
+					try {
+						$dt   = new \DateTimeImmutable( $expires, wp_timezone() );
+						$date = $dt->format( $date_format );
+					} catch ( \Exception $e ) {
+						/* gmdate() without a timestamp uses the current time, avoiding the 1 Jan 1970 gmdate(fmt, false) gives */
+						$date = gmdate( $date_format );
+					}
+				}
 
 				$url = add_query_arg(
 					[
@@ -711,7 +994,7 @@ abstract class Helper_Abstract_Addon {
 					[
 						'edd_action'            => 'add_to_cart',
 						'download_id'           => $this->get_edd_download_id(),
-						'edd_options[price_id]' => $license_check->price_id,
+						'edd_options[price_id]' => $license_data->price_id ?? '',
 					],
 					'https://gravitypdf.com/checkout/'
 				);
@@ -724,8 +1007,8 @@ abstract class Helper_Abstract_Addon {
 					[
 						'view'       => 'upgrades',
 						'action'     => 'manage_licenses',
-						'license_id' => $license_check->license_id,
-						'payment_id' => $license_check->payment_id,
+						'license_id' => $license_data->license_id ?? '',
+						'payment_id' => $license_data->payment_id ?? '',
 					],
 					'https://gravitypdf.com/account/'
 				);
@@ -734,10 +1017,12 @@ abstract class Helper_Abstract_Addon {
 				break;
 		}
 
-		$this->log->notice( 'License key no longer valid', $license_info );
-		$this->update_license_info( $license_info );
+		$this->log->notice( 'License key status', array_merge( $license_info, [ 'slug' => $this->get_slug() ] ) );
 
-		return true;
+		$this->update_license_info( $license_info, $use_database );
+		$this->flush_update_cache();
+
+		return in_array( $license_info['status'], [ 'active', 'valid' ], true );
 	}
 
 	/**
@@ -747,10 +1032,13 @@ abstract class Helper_Abstract_Addon {
 	 */
 	public function license_registration() {
 
-		$license_info = $this->get_license_info();
-		$edd_id       = $this->get_edd_download_id();
+		/* On a network-activated Multisite, the primary site manages licensing */
+		if ( \GPDFAPI::get_misc_class()->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return;
+		}
 
-		if ( $license_info['status'] === 'active' || empty( $edd_id ) ) {
+		$edd_id = $this->get_edd_download_id();
+		if ( in_array( $this->get_license_status(), [ 'active', 'valid' ], true ) || empty( $edd_id ) ) {
 			return;
 		}
 
@@ -805,5 +1093,181 @@ abstract class Helper_Abstract_Addon {
 		}
 
 		return (array) $links;
+	}
+
+	/**
+	 * Do API call to GravityPDF.com to activate the current add-on license key
+	 *
+	 * @param string $license_key The current license key for this add-on
+	 * @param bool $use_database Auto-update the database with the response
+	 *
+	 * @return array The API response and license status
+	 *
+	 * @since 6.16.0
+	 */
+	public function activate_license( $license_key = '', $use_database = false ) {
+
+		if ( empty( $license_key ) ) {
+			$license_key = $this->get_license_key();
+		}
+
+		$response = wp_remote_post(
+			$this->data->store_url,
+			[
+				'timeout' => 15,
+				'body'    => array_merge(
+					$this->get_default_api_params(),
+					[
+						'edd_action' => 'activate_license',
+						'license'    => $license_key,
+					],
+				),
+			]
+		);
+
+		$this->update_license_status_from_response( $license_key, $response, $use_database );
+
+		do_action( 'gfpdf_addon_post_license_activation', $response, $this, $use_database );
+
+		return $this->get_license_info();
+	}
+
+	/**
+	 * Listen for all license activations, and auto-activate addon if license supports it
+	 *
+	 * @param array $response
+	 * @param Helper_Abstract_Addon $addon
+	 *
+	 * @return void
+	 *
+	 * @since 6.16.0
+	 */
+	public function maybe_auto_activate_license( $response, $addon, $use_database = false ) {
+		/* The gfpdf_addon_post_license_activation action is public: a third-party do_action() may fire it with fewer
+		   args (default $use_database) or a non-addon second arg — bail before dereferencing it */
+		if ( ! $addon instanceof self ) {
+			return;
+		}
+
+		/* skip if current addon doing licence activation */
+		if ( $this->get_edd_download_id() === $addon->get_edd_download_id() ) {
+			return;
+		}
+
+		/* skip if invalid response, or not an Access Pass license */
+		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( ! $license_data ) {
+			return;
+		}
+
+		if ( ! isset( $license_data->products ) || ! is_array( $license_data->products ) ) {
+			return;
+		}
+
+		/* skip if addon not available in Access Pass */
+		if ( ! in_array( (int) $this->get_edd_download_id(), $license_data->products, true ) ) {
+			return;
+		}
+
+		$this->update_license_info( $addon->get_license_info(), $use_database );
+
+		$this->license_auto_activated = true;
+	}
+
+	/**
+	 * Do API call to GravityPDF.com to deactivate add-on license
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	public function deactivate_license() {
+		$response = wp_remote_post(
+			$this->data->store_url,
+			[
+				'timeout' => 15,
+				'body'    => array_merge(
+					[ 'edd_action' => 'deactivate_license' ],
+					$this->get_default_api_params()
+				),
+			]
+		);
+
+		/* Remove license data from database, no matter if the API request fails */
+		$this->delete_license_info();
+		$this->flush_update_cache();
+
+		/* If API error exit early */
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		/* Get API response and check license is now deactivated */
+		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( ! isset( $license_data->license ) || $license_data->license !== 'deactivated' ) {
+			return false;
+		}
+
+		$this->log->notice( 'License successfully deactivated', [ 'slug' => $this->get_slug() ] );
+
+		do_action( 'gfpdf_addon_post_license_deactivation', $response, $this );
+
+		return true;
+	}
+
+	/**
+	 * Listen for all license deactivations, and auto-deactivate addon if license supports it
+	 *
+	 * @param array $response
+	 * @param Helper_Abstract_Addon $addon
+	 *
+	 * @return void
+	 *
+	 * @since 6.16.0
+	 */
+	public function maybe_auto_deactivate_license( $response, $addon ) {
+		/* Public action (see maybe_auto_activate_license): guard against a non-addon second arg from a third-party do_action() */
+		if ( ! $addon instanceof self ) {
+			return;
+		}
+
+		/* skip if current addon doing licence activation */
+		if ( $this->get_edd_download_id() === $addon->get_edd_download_id() ) {
+			return;
+		}
+
+		/* skip if invalid response, or not an Access Pass license */
+		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( ! $license_data ) {
+			return;
+		}
+
+		if ( ! isset( $license_data->products ) || ! is_array( $license_data->products ) ) {
+			return;
+		}
+
+		/* skip if addon not available in Access Pass */
+		if ( ! in_array( (int) $this->get_edd_download_id(), $license_data->products, true ) ) {
+			return;
+		}
+
+		$this->update_license_info( $addon->get_license_info(), true );
+
+		$this->license_auto_deactivated = true;
+	}
+
+	/**
+	 * Delete the add-on update information
+	 *
+	 * @since 6.16.0
+	 * @return void
+	 */
+	public function flush_update_cache() {
+		if ( ! $this->plugin_updater ) {
+			return;
+		}
+
+		$this->plugin_updater->delete_version_info_cache();
+		$this->plugin_updater->delete_transient_plugin_info();
 	}
 }

--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -1715,9 +1715,17 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		/* get selected value (if any) */
 		$value = $this->get_form_value( $args );
 
-		$error_statuses = [ '', 'active' ];
-		$is_error       = ! in_array( $value['status'], $error_statuses, true );
-		$is_active      = $value['status'] === 'active';
+		/** @var Helper_Abstract_Addon|null $addon */
+		$addon             = $args['data'] ?? null;
+		$hardcoded_license = $addon instanceof Helper_Abstract_Addon ? $addon->get_license_key_from_constant() : '';
+		if ( $hardcoded_license ) {
+			$value['key']   = $hardcoded_license;
+			$args['desc2']  = __( 'License key set by the site administrator.', 'gravity-pdf' );
+			$args['desc2'] .= ' <a href="https://docs.gravitypdf.com/v6/extensions/installing-upgrading-extensions#hardcode-license-with-php-constant">' . __( 'Learn more.', 'gravity-pdf' ) . '</a>';
+		}
+
+		$is_error  = ! in_array( $value['status'], [ '', 'active', 'valid' ], true );
+		$is_active = in_array( $value['status'], [ 'active', 'valid' ], true );
 		?>
 
 		<?php if ( ! empty( $value['msg'] ) ): ?>
@@ -1742,9 +1750,10 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			   class="<?php echo esc_attr( 'gfpdf_settings_' . $args['id'] ); ?>"
 			   name="gfpdf_settings[<?php echo esc_attr( $args['id'] ); ?>]"
 			   value="<?php echo esc_attr( ! empty( $value['key'] ) ? sha1( $value['key'] ) : '' ); ?>"
+			   <?php echo $hardcoded_license ? 'readonly' : ''; ?>
 		/>
 
-		<?php if ( $is_active ): ?>
+		<?php if ( $is_active && ! $hardcoded_license ): ?>
 			<button type="button"
 					class="button primary white gfpdf-deactivate-license"
 					data-addon-name="<?php echo esc_attr( substr( $args['id'], 8 ) ); ?>"

--- a/src/Helper/Helper_Data.php
+++ b/src/Helper/Helper_Data.php
@@ -2,6 +2,8 @@
 
 namespace GFPDF\Helper;
 
+use GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater;
+
 /**
  * @package     Gravity PDF
  * @copyright   Copyright (c) 2026, Blue Liquid Designs
@@ -28,7 +30,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @property string  $upload_dir_url                  The current URL to the WP upload directory
  * @property string  $store_url                       The URL of our online store
  * @property array   $form_settings                   A cache of the current form's PDF settings
- * @property array   $addon                           An array of current active / registered add-ons
+ * @property EDD_SL_Plugin_Updater $updater           The core plugin update class
+ * @property array<Helper_Abstract_Addon> $addon      An array of current active / registered add-ons
  * @property string  $template_location               The current path to the PDF working directory
  * @property string  $template_location_url           The current URL to the PDF working directory
  * @property string  $template_font_location          The current path to the PDF font directory
@@ -175,6 +178,8 @@ class Helper_Data {
 	 */
 	public function addon_license_responses( $addon_name ) {
 		return [
+			'active'              => __( 'Your support license key has been activated for this domain.', 'gravity-pdf' ),
+			'valid'               => __( 'Your support license key has been activated for this domain.', 'gravity-pdf' ),
 			'expired'             => sprintf( __( 'This license key expired on %%s. %1$sPlease renew your license to continue receiving updates and support%2$s.', 'gravity-pdf' ), '<a href="%s">', '</a>' ),
 			'revoked'             => sprintf( __( 'This license key has been cancelled (most likely due to a refund request). %1$sPlease consider purchasing a new license%2$s.', 'gravity-pdf' ), '<a href="%s">', '</a>' ),
 			'disabled'            => sprintf( __( 'This license key has been cancelled (most likely due to a refund request). %1$sPlease consider purchasing a new license%2$s.', 'gravity-pdf' ), '<a href="%s">', '</a>' ),
@@ -184,8 +189,10 @@ class Helper_Data {
 			'item_name_mismatch'  => sprintf( __( 'This license key is not valid for %s. Please check your key is for this product.', 'gravity-pdf' ), $addon_name ),
 			'invalid_item_id'     => sprintf( __( 'This license key is not valid for %s. Please check your key is for this product.', 'gravity-pdf' ), $addon_name ),
 			'no_activations_left' => sprintf( __( 'This license key has reached its activation limit. %1$sPlease upgrade your license to increase the site limit (you only pay the difference)%2$s.', 'gravity-pdf' ), '<a href="%s">', '</a>' ),
-			'default'             => __( 'An error occurred, please try again.', 'gravity-pdf' ),
-			'generic'             => __( 'An error occurred, please try again.', 'gravity-pdf' ),
+			'default'             => __( 'An unknown error occurred while checking the license.', 'gravity-pdf' ),
+			'generic'             => __( 'An unknown error occurred while checking the license.', 'gravity-pdf' ),
+			'error'               => __( 'An unknown error occurred while checking the license.', 'gravity-pdf' ),
+			'rate_limit'          => __( 'The licensing server is temporarily unavailable.', 'gravity-pdf' ),
 		];
 	}
 
@@ -235,6 +242,7 @@ class Helper_Data {
 				'disable'                              => esc_html__( 'Disable', 'gravity-pdf' ),
 				'updateSuccess'                        => esc_html__( 'Successfully Updated', 'gravity-pdf' ),
 				'deleteSuccess'                        => esc_html__( 'Successfully Deleted', 'gravity-pdf' ),
+				'licenseDeactivationError'             => esc_html__( 'An error occurred and your license key may not have been deactivated. Reload the page and try again.', 'gravity-pdf' ),
 				'no'                                   => esc_html__( 'No', 'gravity-pdf' ),
 				'yes'                                  => esc_html__( 'Yes', 'gravity-pdf' ),
 				'standard'                             => esc_html__( 'Standard', 'gravity-pdf' ),

--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -1068,4 +1068,25 @@ class Helper_Misc {
 			wp_die( '401', 401 );
 		}
 	}
+
+	/**
+	 * Whether the current site is a secondary site on a Multisite network where the plugin is network activated
+	 *
+	 * Used to restrict license/update API checks to the primary site.
+	 *
+	 * @param string $plugin_basename The plugin to test for network activation (eg. PDF_PLUGIN_BASENAME)
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	public function is_secondary_network_site( $plugin_basename ) {
+		if ( ! is_multisite() || is_main_site() ) {
+			return false;
+		}
+
+		$network_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+
+		return isset( $network_plugins[ $plugin_basename ] );
+	}
 }

--- a/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
+++ b/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
@@ -2,8 +2,6 @@
 
 namespace GFPDF\Helper\Licensing;
 
-use stdClass;
-
 /**
  * @package     Gravity PDF
  * @author      Easy Digital Downloads
@@ -21,71 +19,53 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @author  Easy Digital Downloads
  * @version 1.9.4
+ * @since   6.16.0 Modified to make this class more useful for our plugin suite
  */
 class EDD_SL_Plugin_Updater {
 
-	private $api_url     = '';
-	private $api_data    = array();
-	private $plugin_file = '';
-	private $name        = '';
-	private $slug        = '';
-	private $version     = '';
-	private $wp_override = false;
-	private $beta        = false;
-	private $failed_request_cache_key;
+	protected $api_url     = '';
+	protected $api_data    = [];
+	protected $plugin_file = '';
+	protected $name        = '';
+	protected $slug        = '';
+	protected $version     = '';
+	protected $wp_override = false;
+	protected $beta        = false;
+	protected $failed_request_cache_key;
+
+	/* Local gate for sharing a package across a Multisite; kept off api_data so it never rides an outbound API request */
+	protected $license_status = '';
+
+	/* The network-shared package outlives the per-site 3h check cache so a quiet licensed site can't let it lapse */
+	protected const NETWORK_CACHE_TTL = 3 * DAY_IN_SECONDS;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @uses plugin_basename()
-	 * @uses hook()
-	 *
-	 * @param string  $_api_url     The URL pointing to the custom API endpoint.
-	 * @param string  $_plugin_file Path to the plugin file.
-	 * @param array   $_api_data    Optional data to send with API calls.
+	 * @param string $_api_url     The URL pointing to the custom API endpoint.
+	 * @param string $_plugin_file Path to the plugin file.
+	 * @param array  $_api_data    Optional data to send with API calls.
 	 */
 	public function __construct( $_api_url, $_plugin_file, $_api_data = null ) {
-
-		global $edd_plugin_data;
-
-		$this->api_url                  = $_api_url; // don't auto-trailingslashit
+		$this->api_url                  = trailingslashit( $_api_url );
 		$this->api_data                 = $_api_data;
 		$this->plugin_file              = $_plugin_file;
 		$this->name                     = plugin_basename( $_plugin_file );
 		$this->slug                     = basename( dirname( $_plugin_file ) );
-		$this->version                  = $_api_data['version'];
-		$this->wp_override              = isset( $_api_data['wp_override'] ) ? (bool) $_api_data['wp_override'] : false;
-		$this->beta                     = ! empty( $this->api_data['beta'] ) ? true : false;
-		$this->failed_request_cache_key = 'edd_sl_failed_http_' . md5( $this->api_url );
-
-		$edd_plugin_data[ $this->slug ] = $this->api_data;
-
-		/**
-		 * Fires after the $edd_plugin_data is setup.
-		 *
-		 * @since x.x.x
-		 *
-		 * @param array $edd_plugin_data Array of EDD SL plugin data.
-		 */
-		do_action( 'post_edd_sl_plugin_updater_setup', $edd_plugin_data );
-
-		// Set up hooks.
-		$this->init();
+		$this->version                  = $_api_data['version'] ?? 0;
+		$this->wp_override              = isset( $_api_data['wp_override'] ) && (bool) $_api_data['wp_override'];
+		$this->beta                     = ! empty( $this->api_data['beta'] );
+		$this->failed_request_cache_key = 'gpdf_sl_failed_http_' . md5( $this->api_url );
 	}
 
 	/**
 	 * Set up WordPress filters to hook into WP's update process.
-	 *
-	 * @uses add_filter()
-	 *
-	 * @return void
 	 */
 	public function init() {
-
-		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_update' ) );
-		add_filter( 'plugins_api', array( $this, 'plugins_api_filter' ), 10, 3 );
-		add_action( 'after_plugin_row', array( $this, 'show_update_notification' ), 10, 2 );
-		add_action( 'admin_init', array( $this, 'show_changelog' ) );
+		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ] );
+		add_filter( 'plugins_api', [ $this, 'plugins_api_filter' ], 10, 3 );
+		add_action( 'after_plugin_row', [ $this, 'show_update_notification' ], 10, 2 );
+		add_action( 'admin_init', [ $this, 'show_changelog' ] );
 	}
 
 	/**
@@ -96,19 +76,32 @@ class EDD_SL_Plugin_Updater {
 	 * It is reassembled from parts of the native WordPress plugin update code.
 	 * See wp-includes/update.php line 121 for the original wp_update_plugins() function.
 	 *
-	 * @uses api_request()
+	 * @param object $_transient_data Update array build by WordPress.
 	 *
-	 * @param array   $_transient_data Update array build by WordPress.
-	 * @return array Modified update array with custom plugin data.
+	 * @return object Modified update array with custom plugin data.
 	 */
 	public function check_update( $_transient_data ) {
 
 		if ( ! is_object( $_transient_data ) ) {
-			$_transient_data = new stdClass();
+			$_transient_data = new \stdClass();
 		}
 
-		if ( ! empty( $_transient_data->response ) && ! empty( $_transient_data->response[ $this->name ] ) && false === $this->wp_override ) {
-			return $_transient_data;
+		if ( ! empty( $_transient_data->response ) && ! empty( $_transient_data->response[ $this->name ] ) ) {
+			/* Do nothing, transient data already has product info */
+			if ( ! $this->wp_override ) {
+				return $_transient_data;
+			}
+
+			/* Overriding cache. Remove existing info */
+			unset( $_transient_data->response[ $this->name ] );
+		}
+
+		/* Overriding cache, delete secondary DB cache */
+		if ( $this->wp_override ) {
+			$this->delete_version_info_cache();
+
+			/* This filter runs multiple times in a single request. Disable override on the first run */
+			$this->wp_override = false;
 		}
 
 		$current = $this->get_update_transient_data();
@@ -130,77 +123,73 @@ class EDD_SL_Plugin_Updater {
 	 * Get repo API data from store.
 	 * Save to cache.
 	 *
-	 * @return \stdClass
+	 * @return \stdClass|false
 	 */
 	public function get_repo_api_data() {
 		$version_info = $this->get_cached_version_info();
-
 		if ( false === $version_info ) {
-			$version_info = $this->api_request(
-				'plugin_latest_version',
-				array(
-					'slug' => $this->slug,
-					'beta' => $this->beta,
-				)
-			);
-			if ( ! $version_info ) {
-				return false;
-			}
+			$version_info = $this->get_version_info();
+		}
 
-			// This is required for your plugin to support auto-updates in WordPress 5.5.
-			$version_info->plugin = $this->name;
-			$version_info->id     = $this->name;
-			$version_info->tested = $this->get_tested_version( $version_info );
-			if ( ! isset( $version_info->requires ) ) {
-				$version_info->requires = '';
-			}
-			if ( ! isset( $version_info->requires_php ) ) {
-				$version_info->requires_php = '';
-			}
+		return $this->maybe_apply_network_package( $version_info );
+	}
 
-			$this->set_version_info_cache( $version_info );
+	/**
+	 * Borrow a licensed download package cached by another site on the network
+	 *
+	 * On a Multisite where the plugin is activated per-site (not network-wide) each site checks for updates using its
+	 * own license. A site without a valid license still receives version info but an empty `package`, which would
+	 * otherwise overwrite the shared update_plugins transient and strip the download URL for every site. When any site
+	 * does hold a valid license it promotes its package to a network option (see set_version_info_cache()); here we fall
+	 * back to that package so the whole network can install the update.
+	 *
+	 * @param \stdClass|false $version_info
+	 *
+	 * @return \stdClass|false
+	 *
+	 * @since 6.16.0
+	 */
+	protected function maybe_apply_network_package( $version_info ) {
+		if ( ! is_multisite() || ! is_object( $version_info ) || ! empty( $version_info->package ) ) {
+			return $version_info;
+		}
+
+		$network = $this->get_network_cached_version_info();
+		if (
+			is_object( $network )
+			&& ! empty( $network->package )
+			&& ! empty( $version_info->new_version )
+			&& version_compare( $network->new_version ?? '', $version_info->new_version, '>=' )
+		) {
+			$version_info->package = $network->package;
 		}
 
 		return $version_info;
 	}
 
 	/**
-	 * Gets a limited set of data from the API response.
-	 * This is used for the update_plugins transient.
+	 * Always return the full data array, and not a subset of the data
+	 *
+	 * This is required so subsites in a Network can correctly display the changelog info
+	 *
+	 * @return \stdClass|false
 	 *
 	 * @since 3.8.12
-	 * @return \stdClass|false
 	 */
-	private function get_update_transient_data() {
-		$version_info = $this->get_repo_api_data();
-
-		if ( ! $version_info ) {
-			return false;
-		}
-
-		$limited_data               = new \stdClass();
-		$limited_data->slug         = $this->slug;
-		$limited_data->plugin       = $this->name;
-		$limited_data->url          = isset( $version_info->url ) ? $version_info->url : '';
-		$limited_data->package      = isset( $version_info->package ) ? $version_info->package : '';
-		$limited_data->icons        = $this->convert_object_to_array( $version_info->icons );
-		$limited_data->banners      = $this->convert_object_to_array( $version_info->banners );
-		$limited_data->new_version  = isset( $version_info->new_version ) ? $version_info->new_version : '';
-		$limited_data->tested       = isset( $version_info->tested ) ? $version_info->tested : '';
-		$limited_data->requires     = isset( $version_info->requires ) ? $version_info->requires : '';
-		$limited_data->requires_php = isset( $version_info->requires_php ) ? $version_info->requires_php : '';
-
-		return $limited_data;
+	public function get_update_transient_data() {
+		return $this->get_repo_api_data();
 	}
 
 	/**
 	 * Gets the plugin's tested version.
 	 *
-	 * @since 1.9.2
 	 * @param object $version_info
+	 *
 	 * @return null|string
+	 *
+	 * @since 1.9.2
 	 */
-	private function get_tested_version( $version_info ) {
+	public function get_tested_version( $version_info ) {
 
 		// There is no tested version.
 		if ( empty( $version_info->tested ) ) {
@@ -208,7 +197,7 @@ class EDD_SL_Plugin_Updater {
 		}
 
 		// Strip off extra version data so the result is x.y or x.y.z.
-		list( $current_wp_version ) = explode( '-', get_bloginfo( 'version' ) );
+		[ $current_wp_version ] = explode( '-', get_bloginfo( 'version' ) );
 
 		// The tested version is greater than or equal to the current WP version, no need to do anything.
 		if ( version_compare( $version_info->tested, $current_wp_version, '>=' ) ) {
@@ -228,8 +217,10 @@ class EDD_SL_Plugin_Updater {
 	/**
 	 * Show the update notification on multisite subsites.
 	 *
-	 * @param string  $file
-	 * @param array   $plugin
+	 * @param string $file
+	 * @param array  $plugin
+	 *
+	 * @return void
 	 */
 	public function show_update_notification( $file, $plugin ) {
 
@@ -252,7 +243,7 @@ class EDD_SL_Plugin_Updater {
 
 		if ( ! isset( $update_cache->response[ $this->name ] ) ) {
 			if ( ! is_object( $update_cache ) ) {
-				$update_cache = new stdClass();
+				$update_cache = new \stdClass();
 			}
 			$update_cache->response[ $this->name ] = $this->get_repo_api_data();
 		}
@@ -262,10 +253,12 @@ class EDD_SL_Plugin_Updater {
 			return;
 		}
 
+		$plugin_update = $update_cache->response[ $this->name ];
+
 		printf(
 			'<tr class="plugin-update-tr %3$s" id="%1$s-update" data-slug="%1$s" data-plugin="%2$s">',
-			$this->slug,
-			$file,
+			esc_attr( $this->slug ),
+			esc_attr( $file ),
 			in_array( $this->name, $this->get_active_plugins(), true ) ? 'active' : 'inactive'
 		);
 
@@ -273,24 +266,30 @@ class EDD_SL_Plugin_Updater {
 		echo '<div class="update-message notice inline notice-warning notice-alt"><p>';
 
 		$changelog_link = '';
-		if ( ! empty( $update_cache->response[ $this->name ]->sections->changelog ) ) {
+
+		$has_package   = ! empty( $plugin_update->package );
+		$has_changelog = ! empty( $plugin_update->changelog );
+
+		if ( $has_changelog ) {
 			$changelog_link = add_query_arg(
-				array(
-					'edd_sl_action' => 'view_plugin_changelog',
-					'plugin'        => urlencode( $this->name ),
-					'slug'          => urlencode( $this->slug ),
-					'TB_iframe'     => 'true',
-					'width'         => 77,
-					'height'        => 911,
-				),
+				[
+					'gpdf_sl_action' => 'view_plugin_changelog',
+					'gpdf_sl_nonce'  => wp_create_nonce( 'install-plugin_' . $this->slug ),
+					'plugin'         => rawurlencode( $this->slug ),
+					'section'        => 'changelog',
+					'TB_iframe'      => 'true',
+					'width'          => 77,
+					'height'         => 911,
+				],
 				self_admin_url( 'index.php' )
 			);
 		}
+
 		$update_link = add_query_arg(
-			array(
+			[
 				'action' => 'upgrade-plugin',
-				'plugin' => urlencode( $this->name ),
-			),
+				'plugin' => rawurlencode( $this->name ),
+			],
 			self_admin_url( 'update.php' )
 		);
 
@@ -303,35 +302,63 @@ class EDD_SL_Plugin_Updater {
 		if ( ! current_user_can( 'update_plugins' ) ) {
 			echo ' ';
 			esc_html_e( 'Contact your network administrator to install the update.', 'gravity-pdf' );
-		} elseif ( empty( $update_cache->response[ $this->name ]->package ) && ! empty( $changelog_link ) ) {
+		} elseif ( ! $has_package && $has_changelog ) {
 			echo ' ';
-			printf(
-			/* translators: 1. opening anchor tag, do not translate 2. the new plugin version 3. closing anchor tag, do not translate. */
-				__( '%1$sView version %2$s details%3$s.', 'gravity-pdf' ),
-				'<a target="_blank" class="thickbox open-plugin-details-modal" href="' . esc_url( $changelog_link ) . '">',
-				esc_html( $update_cache->response[ $this->name ]->new_version ),
-				'</a>'
+			echo wp_kses(
+				sprintf(
+				/* translators: 1. opening anchor tag, do not translate 2. the new plugin version 3. closing anchor tag, do not translate. */
+					__( '%1$sView version %2$s details%3$s.', 'gravity-pdf' ),
+					'<a target="_blank" class="thickbox open-plugin-details-modal" href="' . esc_url( $changelog_link ) . '">',
+					esc_html( $plugin_update->new_version ),
+					'</a>'
+				),
+				[
+					'a' => [
+						'href'   => [],
+						'target' => [],
+						'class'  => [],
+					],
+				]
 			);
-		} elseif ( ! empty( $changelog_link ) ) {
+		} elseif ( $has_package && $has_changelog ) {
 			echo ' ';
-			printf(
-				__( '%1$sView version %2$s details%3$s or %4$supdate now%5$s.', 'gravity-pdf' ),
-				'<a target="_blank" class="thickbox open-plugin-details-modal" href="' . esc_url( $changelog_link ) . '">',
-				esc_html( $update_cache->response[ $this->name ]->new_version ),
-				'</a>',
-				'<a target="_blank" class="update-link" href="' . esc_url( wp_nonce_url( $update_link, 'upgrade-plugin_' . $file ) ) . '">',
-				'</a>'
+			echo wp_kses(
+				sprintf(
+					/* translators: 1: Opening <a> tag, 2: Version number, 3: Closing </a> tag, 4: Opening <a> tag, 5: Closing </a> tag */
+					__( '%1$sView version %2$s details%3$s or %4$supdate now%5$s.', 'gravity-pdf' ),
+					'<a target="_blank" class="thickbox open-plugin-details-modal" href="' . esc_url( $changelog_link ) . '">',
+					esc_html( $plugin_update->new_version ),
+					'</a>',
+					'<a target="_blank" class="update-link" href="' . esc_url( wp_nonce_url( $update_link, 'upgrade-plugin_' . $file ) ) . '">',
+					'</a>'
+				),
+				[
+					'a' => [
+						'href'   => [],
+						'target' => [],
+						'class'  => [],
+					],
+				]
 			);
-		} else {
-			printf(
-				' %1$s%2$s%3$s',
-				'<a target="_blank" class="update-link" href="' . esc_url( wp_nonce_url( $update_link, 'upgrade-plugin_' . $file ) ) . '">',
-				esc_html__( 'Update now.', 'gravity-pdf' ),
-				'</a>'
+		} elseif ( $has_package && ! $has_changelog ) {
+			echo wp_kses(
+				sprintf(
+					' %1$s%2$s%3$s',
+					'<a target="_blank" class="update-link" href="' . esc_url( wp_nonce_url( $update_link, 'upgrade-plugin_' . $file ) ) . '">',
+					esc_html__( 'Update now.', 'gravity-pdf' ),
+					'</a>'
+				),
+				[
+					'a' => [
+						'href'   => [],
+						'target' => [],
+						'class'  => [],
+					],
+				]
 			);
 		}
 
-		do_action( "in_plugin_update_message-{$file}", $plugin, $plugin );
+		do_action( "in_plugin_update_message-{$file}", $plugin, $plugin ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
 		echo '</p></div></td></tr>';
 	}
@@ -341,7 +368,7 @@ class EDD_SL_Plugin_Updater {
 	 *
 	 * @return array
 	 */
-	private function get_active_plugins() {
+	public function get_active_plugins() {
 		$active_plugins         = (array) get_option( 'active_plugins' );
 		$active_network_plugins = (array) get_site_option( 'active_sitewide_plugins' );
 
@@ -351,47 +378,28 @@ class EDD_SL_Plugin_Updater {
 	/**
 	 * Updates information on the "View version x.x details" page with custom data.
 	 *
-	 * @uses api_request()
+	 * @param mixed  $_data
+	 * @param string $_action
+	 * @param object $_args
 	 *
-	 * @param mixed   $_data
-	 * @param string  $_action
-	 * @param object  $_args
 	 * @return object $_data
 	 */
 	public function plugins_api_filter( $_data, $_action = '', $_args = null ) {
 
 		if ( 'plugin_information' !== $_action ) {
-
 			return $_data;
-
 		}
 
 		if ( ! isset( $_args->slug ) || ( $_args->slug !== $this->slug ) ) {
-
 			return $_data;
-
 		}
-
-		$to_send = array(
-			'slug'   => $this->slug,
-			'is_ssl' => is_ssl(),
-			'fields' => array(
-				'banners' => array(),
-				'reviews' => false,
-				'icons'   => array(),
-			),
-		);
 
 		// Get the transient where we store the api request for this plugin for 24 hours
 		$edd_api_request_transient = $this->get_cached_version_info();
 
-		//If we have no transient-saved value, run the API, set a fresh transient with the API value, and return that value too right now.
+		//If we have no transient-saved value, run the API (which caches a successful response internally) and return it too right now.
 		if ( empty( $edd_api_request_transient ) ) {
-
-			$api_response = $this->api_request( 'plugin_information', $to_send );
-
-			// Expires in 3 hours
-			$this->set_version_info_cache( $api_response );
+			$api_response = $this->get_version_info();
 
 			if ( false !== $api_response ) {
 				$_data = $api_response;
@@ -400,32 +408,15 @@ class EDD_SL_Plugin_Updater {
 			$_data = $edd_api_request_transient;
 		}
 
-		// Convert sections into an associative array, since we're getting an object, but Core expects an array.
-		if ( isset( $_data->sections ) && ! is_array( $_data->sections ) ) {
-			$_data->sections = $this->convert_object_to_array( $_data->sections );
-		}
+		// $_data stays false when get_version_info() bails (API down, backoff, secondary site) — assigning to a bool fatals on PHP 8.
+		if ( is_object( $_data ) ) {
+			if ( ! isset( $_data->plugin ) ) {
+				$_data->plugin = $this->name;
+			}
 
-		// Convert banners into an associative array, since we're getting an object, but Core expects an array.
-		if ( isset( $_data->banners ) && ! is_array( $_data->banners ) ) {
-			$_data->banners = $this->convert_object_to_array( $_data->banners );
-		}
-
-		// Convert icons into an associative array, since we're getting an object, but Core expects an array.
-		if ( isset( $_data->icons ) && ! is_array( $_data->icons ) ) {
-			$_data->icons = $this->convert_object_to_array( $_data->icons );
-		}
-
-		// Convert contributors into an associative array, since we're getting an object, but Core expects an array.
-		if ( isset( $_data->contributors ) && ! is_array( $_data->contributors ) ) {
-			$_data->contributors = $this->convert_object_to_array( $_data->contributors );
-		}
-
-		if ( ! isset( $_data->plugin ) ) {
-			$_data->plugin = $this->name;
-		}
-
-		if ( ! isset( $_data->version ) && ! empty( $_data->new_version ) ) {
-			$_data->version = $_data->new_version;
+			if ( ! isset( $_data->version ) && ! empty( $_data->new_version ) ) {
+				$_data->version = $_data->new_version;
+			}
 		}
 
 		return $_data;
@@ -437,17 +428,17 @@ class EDD_SL_Plugin_Updater {
 	 * Some data like sections, banners, and icons are expected to be an associative array, however due to the JSON
 	 * decoding, they are objects. This method allows us to pass in the object and return an associative array.
 	 *
-	 * @since 3.6.5
-	 *
-	 * @param stdClass $data
+	 * @param \stdClass|array $data
 	 *
 	 * @return array
+	 *
+	 * @since 3.6.5
 	 */
-	private function convert_object_to_array( $data ) {
+	public function convert_object_to_array( $data ) {
 		if ( ! is_array( $data ) && ! is_object( $data ) ) {
-			return array();
+			return [];
 		}
-		$new_data = array();
+		$new_data = [];
 		foreach ( $data as $key => $value ) {
 			$new_data[ $key ] = is_object( $value ) ? $this->convert_object_to_array( $value ) : $value;
 		}
@@ -456,40 +447,49 @@ class EDD_SL_Plugin_Updater {
 	}
 
 	/**
-	 * Disable SSL verification in order to prevent download update failures
+	 * Normalize a sections/banners/icons value into an associative array.
 	 *
-	 * @param array   $args
-	 * @param string  $url
-	 * @return object $array
+	 * The store may hand these back as a JSON-encoded string, a legacy PHP-serialized array (a:N:{...}), or an
+	 * already-decoded object (some EDD endpoints). JSON is attempted first since it can't trigger object injection; a
+	 * serialized value is only unserialized when it is an array and with `allowed_classes => false`, so any nested
+	 * object is neutralized and a bare serialized-object payload (O:...) — the object-injection vector the earlier
+	 * hardening guarded against — is refused and collapses to an empty array.
+	 *
+	 * @param string|array|\stdClass $data
+	 *
+	 * @return array
+	 *
+	 * @since 6.16.0
 	 */
-	public function http_request_args( $args, $url ) {
+	public function normalize_api_collection( $data ) {
+		if ( is_string( $data ) ) {
+			$json = json_decode( $data );
 
-		if ( strpos( $url, 'https://' ) !== false && strpos( $url, 'edd_action=package_download' ) ) {
-			$args['sslverify'] = $this->verify_ssl();
+			if ( json_last_error() === JSON_ERROR_NONE && ( is_array( $json ) || is_object( $json ) ) ) {
+				$data = $json;
+			} elseif ( preg_match( '/^a:\d+:\{/', $data ) ) {
+				$data = unserialize( $data, [ 'allowed_classes' => false ] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- object injection is guarded by allowed_classes => false
+			}
 		}
-		return $args;
+
+		// A string we couldn't decode (or a failed unserialize) falls through here; convert_object_to_array() maps any
+		// non-array/object to [], so an unrecognized payload safely collapses to an empty collection.
+		return $this->convert_object_to_array( $data );
 	}
 
 	/**
-	 * Calls the API and, if successfull, returns the object delivered by the API.
+	 * Calls the API and, if successful, returns the object delivered by the API.
 	 *
-	 * @uses get_bloginfo()
-	 * @uses wp_remote_post()
-	 * @uses is_wp_error()
-	 *
-	 * @param string  $_action The requested action.
-	 * @param array   $_data   Parameters for the API action.
-	 * @return false|object|void
+	 * @return \stdClass|false
 	 */
-	private function api_request( $_action, $_data ) {
-		$data = array_merge( $this->api_data, $_data );
-
-		if ( $data['slug'] !== $this->slug ) {
-			return;
+	public function get_version_info() {
+		/* Don't allow a plugin to ping itself */
+		if ( trailingslashit( home_url() ) === $this->api_url ) {
+			return false;
 		}
 
-		// Don't allow a plugin to ping itself
-		if ( trailingslashit( home_url() ) === $this->api_url ) {
+		/* The primary site checks for updates on behalf of network-activated installs */
+		if ( \GPDFAPI::get_misc_class()->is_secondary_network_site( $this->name ) ) {
 			return false;
 		}
 
@@ -503,14 +503,14 @@ class EDD_SL_Plugin_Updater {
 	/**
 	 * Determines if a request has recently failed.
 	 *
-	 * @since 1.9.1
-	 *
 	 * @return bool
+	 *
+	 * @since 1.9.1
 	 */
-	private function request_recently_failed() {
+	public function request_recently_failed() {
 		$failed_request_details = get_option( $this->failed_request_cache_key );
 
-		// Request has never failed.
+		/* Request has never failed. */
 		if ( empty( $failed_request_details ) || ! is_numeric( $failed_request_details ) ) {
 			return false;
 		}
@@ -535,82 +535,105 @@ class EDD_SL_Plugin_Updater {
 	 * will be allowed again. This way if the site is down for some reason we don't bombard
 	 * it with failed API requests.
 	 *
-	 * @see EDD_SL_Plugin_Updater::request_recently_failed
+	 * @return void
 	 *
 	 * @since 1.9.1
 	 */
-	private function log_failed_request() {
-		update_option( $this->failed_request_cache_key, strtotime( '+1 hour' ) );
+	public function log_failed_request() {
+		update_option( $this->failed_request_cache_key, strtotime( '+1 hour' ), false );
 	}
 
 	/**
 	 * If available, show the changelog for sites in a multisite install.
+	 *
+	 * @return void
 	 */
 	public function show_changelog() {
 
-		if ( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' !== $_REQUEST['edd_sl_action'] ) {
+		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( empty( $_REQUEST['gpdf_sl_action'] ) || 'view_plugin_changelog' !== $_REQUEST['gpdf_sl_action'] ) {
 			return;
 		}
 
-		if ( empty( $_REQUEST['plugin'] ) ) {
+		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( empty( $_REQUEST['plugin'] ) || $this->slug !== $_REQUEST['plugin'] ) {
 			return;
 		}
 
-		if ( empty( $_REQUEST['slug'] ) || $this->slug !== $_REQUEST['slug'] ) {
-			return;
-		}
+		check_admin_referer( 'install-plugin_' . $this->slug, 'gpdf_sl_nonce' );
 
 		if ( ! current_user_can( 'update_plugins' ) ) {
-			wp_die( esc_html__( 'You do not have permission to install plugin updates', 'gravity-pdf' ), esc_html__( 'Error', 'gravity-pdf' ), array( 'response' => 403 ) );
+			wp_die( esc_html__( 'You do not have permission to install plugin updates', 'gravity-pdf' ), esc_html__( 'Error', 'gravity-pdf' ), [ 'response' => 403 ] );
 		}
 
-		$version_info = $this->get_repo_api_data();
-		if ( isset( $version_info->sections ) ) {
-			$sections = $this->convert_object_to_array( $version_info->sections );
-			if ( ! empty( $sections['changelog'] ) ) {
-				echo '<div style="background:#fff;padding:10px;">' . wp_kses_post( $sections['changelog'] ) . '</div>';
-			}
-		}
+		/* Masquerade as the plugin install screen */
+		global $hook_suffix, $body_id, $tab, $pagenow;
 
-		exit;
+		/* install_plugin_information() calls `exit;` so there isn't a conflict/compat risk */
+		$pagenow     = 'plugin-install.php'; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$hook_suffix = $pagenow; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$body_id     = 'plugin-information'; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$tab         = $body_id; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		set_current_screen( 'plugin-install' );
+
+		wp_enqueue_script( 'plugin-install' );
+		wp_enqueue_script( 'updates' );
+
+		/* Let WP output the changelog info */
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		install_plugin_information();
+	}
+
+	/**
+	 * Get the arguments required for the version API check
+	 *
+	 * @return array
+	 *
+	 * @since 6.16.0
+	 */
+	public function get_version_api_params() {
+		return [
+			'license'     => $this->api_data['license'] ?? '',
+			'item_name'   => $this->api_data['item_name'] ?? false,
+			'item_id'     => $this->api_data['item_id'] ?? false,
+			'version'     => $this->api_data['version'] ?? false,
+			'slug'        => $this->slug,
+			'author'      => $this->api_data['author'] ?? '',
+			'url'         => home_url(),
+			'beta'        => $this->beta,
+			'php_version' => phpversion(),
+			'wp_version'  => get_bloginfo( 'version' ),
+		];
 	}
 
 	/**
 	 * Gets the current version information from the remote site.
 	 *
-	 * @return array|false
+	 * @return \stdClass|false
 	 */
-	private function get_version_from_remote() {
-		$api_params = array(
-			'edd_action'  => 'get_version',
-			'license'     => ! empty( $this->api_data['license'] ) ? $this->api_data['license'] : '',
-			'item_name'   => isset( $this->api_data['item_name'] ) ? $this->api_data['item_name'] : false,
-			'item_id'     => isset( $this->api_data['item_id'] ) ? $this->api_data['item_id'] : false,
-			'version'     => isset( $this->api_data['version'] ) ? $this->api_data['version'] : false,
-			'slug'        => $this->slug,
-			'author'      => $this->api_data['author'],
-			'url'         => home_url(),
-			'beta'        => $this->beta,
-			'php_version' => phpversion(),
-			'wp_version'  => get_bloginfo( 'version' ),
+	public function get_version_from_remote() {
+		$api_params = array_merge(
+			[ 'edd_action' => 'get_version' ],
+			$this->get_version_api_params()
 		);
 
 		/**
 		 * Filters the parameters sent in the API request.
 		 *
-		 * @param array  $api_params        The array of data sent in the request.
-		 * @param array  $this->api_data    The array of data set up in the class constructor.
-		 * @param string $this->plugin_file The full path and filename of the file.
+		 * @param array  $api_params The array of data sent in the request.
+		 * @param array  $this       ->api_data    The array of data set up in the class constructor.
+		 * @param string $this       ->plugin_file The full path and filename of the file.
 		 */
-		$api_params = apply_filters( 'edd_sl_plugin_updater_api_params', $api_params, $this->api_data, $this->plugin_file );
+		$api_params = apply_filters( 'gpdf_sl_plugin_updater_api_params', $api_params, $this->api_data, $this->plugin_file );
 
 		$request = wp_remote_post(
 			$this->api_url,
-			array(
+			[
 				'timeout'   => 15,
 				'sslverify' => $this->verify_ssl(),
 				'body'      => $api_params,
-			)
+			]
 		);
 
 		if ( is_wp_error( $request ) || ( 200 !== wp_remote_retrieve_response_code( $request ) ) ) {
@@ -619,57 +642,68 @@ class EDD_SL_Plugin_Updater {
 			return false;
 		}
 
-		$request = json_decode( wp_remote_retrieve_body( $request ) );
+		$response = json_decode( wp_remote_retrieve_body( $request ) );
+		$response = apply_filters( 'gpdf_sl_plugin_updater_api_response', $response, $this->api_data, $this->plugin_file );
+		$response = $this->standardize_api_response( $response );
 
-		if ( $request && isset( $request->sections ) ) {
-			$request->sections = maybe_unserialize( $request->sections );
-		} else {
-			$request = false;
+		// A 200 with an empty/unparseable body yields false — back off like any other failure so we don't re-POST every call.
+		if ( false === $response ) {
+			$this->log_failed_request();
+
+			return false;
 		}
 
-		if ( $request && isset( $request->banners ) ) {
-			$request->banners = maybe_unserialize( $request->banners );
-		}
+		$this->set_version_info_cache( $response );
 
-		if ( $request && isset( $request->icons ) ) {
-			$request->icons = maybe_unserialize( $request->icons );
-		}
-
-		if ( ! empty( $request->sections ) ) {
-			foreach ( $request->sections as $key => $section ) {
-				$request->$key = (array) $section;
-			}
-		}
-
-		return $request;
+		return $response;
 	}
 
 	/**
 	 * Get the version info from the cache, if it exists.
 	 *
 	 * @param string $cache_key
-	 * @return object
+	 *
+	 * @return object|false
 	 */
 	public function get_cached_version_info( $cache_key = '' ) {
-
 		if ( empty( $cache_key ) ) {
 			$cache_key = $this->get_cache_key();
 		}
 
-		$cache = get_option( $cache_key );
+		return $this->read_timed_cache( get_option( $cache_key ) );
+	}
 
-		// Cache is expired
+	/**
+	 * Get the licensed version info promoted to the network cache by any site on a Multisite, if it exists
+	 *
+	 * @return \stdClass|false
+	 *
+	 * @since 6.16.0
+	 */
+	public function get_network_cached_version_info() {
+		return $this->read_timed_cache( get_site_option( $this->get_network_cache_key() ) );
+	}
+
+	/**
+	 * Decode a timed version-info cache payload, shared by the per-site and network cache readers
+	 *
+	 * @param mixed $cache The stored [ 'timeout' => int, 'value' => string ] payload
+	 *
+	 * @return \stdClass|false
+	 *
+	 * @since 6.16.0
+	 */
+	protected function read_timed_cache( $cache ) {
+		/* Guard against a corrupted scalar-string option: array access on a string throws a TypeError on PHP 8 */
+		if ( ! is_array( $cache ) ) {
+			return false;
+		}
+
 		if ( empty( $cache['timeout'] ) || time() > $cache['timeout'] ) {
 			return false;
 		}
 
-		// We need to turn the icons into an array, thanks to WP Core forcing these into an object at some point.
-		$cache['value'] = json_decode( $cache['value'] );
-		if ( ! empty( $cache['value']->icons ) ) {
-			$cache['value']->icons = (array) $cache['value']->icons;
-		}
-
-		return $cache['value'];
+		return $this->standardize_api_response( json_decode( $cache['value'] ) );
 	}
 
 	/**
@@ -677,43 +711,248 @@ class EDD_SL_Plugin_Updater {
 	 *
 	 * @param string $value
 	 * @param string $cache_key
+	 *
+	 * @return void
 	 */
 	public function set_version_info_cache( $value = '', $cache_key = '' ) {
+
+		/* Let cache be skipped when plugin not active on current multisite */
+		if ( $this->is_non_active_multisite() ) {
+			return;
+		}
 
 		if ( empty( $cache_key ) ) {
 			$cache_key = $this->get_cache_key();
 		}
 
-		$data = array(
+		$data = [
 			'timeout' => strtotime( '+3 hours', time() ),
 			'value'   => wp_json_encode( $value ),
+		];
+
+		update_option( $cache_key, $data, false );
+
+		/*
+		 * Promote the package to a network option so any site on the Multisite can install the update. The store can
+		 * return a package URL even when the license is inactive (that URL errors on access), so only an active license
+		 * is allowed to share its package.
+		 */
+		if ( is_multisite() && $this->is_license_active() && is_object( $value ) && ! empty( $value->package ) ) {
+			$network_data            = $data;
+			$network_data['timeout'] = time() + self::NETWORK_CACHE_TTL;
+			update_site_option( $this->get_network_cache_key(), $network_data );
+		}
+	}
+
+	/**
+	 * Delete the cached version info
+	 *
+	 * @param string $cache_key
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	public function delete_version_info_cache( $cache_key = '' ) {
+		if ( empty( $cache_key ) ) {
+			$cache_key = $this->get_cache_key();
+		}
+
+		return delete_option( $cache_key );
+	}
+
+	/**
+	 * Delete the cached update info without removing the entire update plugin data
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	public function delete_transient_plugin_info() {
+		$plugin_update = get_site_transient( 'update_plugins' );
+
+		if ( ! isset( $plugin_update->response[ $this->name ] ) ) {
+			return true;
+		}
+
+		unset(
+			$plugin_update->response[ $this->name ],
+			$plugin_update->no_update[ $this->name ],
+			$plugin_update->checked[ $this->name ],
 		);
 
-		update_option( $cache_key, $data, 'no' );
+		/* Prevent a version check API call right after the plugin data is removed */
+		remove_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ] );
 
-		// Delete the duplicate option
-		delete_option( 'edd_api_request_' . md5( serialize( $this->slug . $this->api_data['license'] . $this->beta ) ) );
+		$results = set_site_transient( 'update_plugins', $plugin_update );
+
+		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ] );
+
+		return $results;
 	}
 
 	/**
 	 * Returns if the SSL of the store should be verified.
 	 *
-	 * @since  1.6.13
 	 * @return bool
+	 *
+	 * @since  1.6.13
 	 */
-	private function verify_ssl() {
-		return (bool) apply_filters( 'edd_sl_api_request_verify_ssl', true, $this );
+	public function verify_ssl() {
+		return (bool) apply_filters( 'gpdf_sl_api_request_verify_ssl', true, $this );
 	}
 
 	/**
 	 * Gets the unique key (option name) for a plugin.
 	 *
-	 * @since 1.9.0
 	 * @return string
+	 *
+	 * @since 1.9.0
 	 */
-	private function get_cache_key() {
-		$string = $this->slug . $this->api_data['license'] . $this->beta;
+	public function get_cache_key() {
+		return 'gpdf_sl_' . md5( $this->slug );
+	}
 
-		return 'edd_sl_' . md5( serialize( $string ) );
+	/**
+	 * The network option name used to share a licensed package across a Multisite
+	 *
+	 * @return string
+	 *
+	 * @since 6.16.0
+	 */
+	public function get_network_cache_key() {
+		return 'gpdf_sl_net_' . md5( $this->slug );
+	}
+
+	/**
+	 * Allow the license key to be set mid-flight
+	 *
+	 * @param string $license_key
+	 *
+	 * @return void
+	 *
+	 * @since 6.16.0
+	 */
+	public function set_license_key( $license_key ) {
+		$this->api_data['license'] = $license_key;
+	}
+
+	/**
+	 * Allow the license status to be set mid-flight
+	 *
+	 * @param string $license_status
+	 *
+	 * @return void
+	 *
+	 * @since 6.16.0
+	 */
+	public function set_license_status( $license_status ) {
+		$this->license_status = $license_status;
+	}
+
+	/**
+	 * Whether the current site holds an active/valid license for this add-on
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	protected function is_license_active() {
+		return in_array( $this->license_status, [ 'active', 'valid' ], true );
+	}
+
+	/**
+	 * @param \StdClass|false|null $response
+	 *
+	 * @return false|\StdClass
+	 */
+	public function standardize_api_response( $response ) {
+		/* A non-object (false/null/scalar/array — from a filter or a malformed 200 body) would fatal on the property writes below (PHP 8) */
+		if ( ! is_object( $response ) ) {
+			return false;
+		}
+
+		// sections/banners/icons may arrive as a JSON string, a legacy serialized array, or an already-decoded object;
+		// normalize_api_collection() turns each into an array (see it for the object-injection guard on strings).
+		if ( isset( $response->sections ) ) {
+			$response->sections = $this->normalize_api_collection( $response->sections );
+		}
+
+		if ( isset( $response->banners ) ) {
+			$response->banners = $this->normalize_api_collection( $response->banners );
+		}
+
+		if ( isset( $response->icons ) ) {
+			$response->icons = $this->normalize_api_collection( $response->icons );
+		}
+
+		if ( ! empty( $response->sections ) ) {
+			foreach ( $response->sections as $key => $section ) {
+				$response->$key = (array) $section;
+			}
+		}
+
+		/* This is required for your plugin to support auto-updates in WordPress 5.5. */
+		$response->plugin = $this->name;
+		$response->id     = $this->name;
+		$response->tested = $this->get_tested_version( $response );
+
+		if ( ! isset( $response->requires ) ) {
+			$response->requires = '';
+		}
+
+		if ( ! isset( $response->requires_php ) ) {
+			$response->requires_php = '';
+		}
+
+		return $response;
+	}
+
+	/**
+	 * @return string
+	 *
+	 * @since 6.16.0
+	 */
+	public function get_plugin_file() {
+		return $this->plugin_file;
+	}
+
+	/**
+	 * The plugin-folder basename sent as `slug` in the version API request and echoed back in the response.
+	 *
+	 * @return string
+	 *
+	 * @since 6.16.0
+	 */
+	public function get_slug() {
+		return $this->slug;
+	}
+
+	/**
+	 * Detect if Multisite and the plugin not active on current site
+	 *
+	 * This might happen if `switch_to_blog()` is used on a site where the plugin was originally active
+	 * and the 'update_plugins' transient is set.
+	 *
+	 * @internal Controller_Settings::maybe_schedule_network_update_check() uses this feature to display a notice on the network admin about an update.
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	protected function is_non_active_multisite() {
+		if ( ! is_multisite() ) {
+			return false;
+		}
+
+		// is_plugin_active() is in wp-admin/includes/plugin.php, unloaded on the frontend and during WP-Cron.
+		$active_plugins  = (array) get_option( 'active_plugins', [] );
+		$network_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+
+		if ( in_array( $this->name, $active_plugins, true ) || isset( $network_plugins[ $this->name ] ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/src/Helper/Log/Logger.php
+++ b/src/Helper/Log/Logger.php
@@ -207,6 +207,9 @@ class Logger {
 
 		/* Add our log file stream */
 		$this->log->pushHandler( $stream );
+
+		/* Add a redact processor to mask secrets (license keys, signed update URLs, tokens) from the log */
+		$this->log->pushProcessor( new Redact_Processor( $this->slug ) );
 	}
 
 	/**

--- a/src/Helper/Log/Redact_Processor.php
+++ b/src/Helper/Log/Redact_Processor.php
@@ -1,0 +1,184 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Log;
+
+use GFPDF_Vendor\Monolog\Processor\ProcessorInterface;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Monolog processor that strips secrets and neutralises log-injection before a record is formatted.
+ *
+ * Gravity PDF logs licensing keys and signed EDD package/download URLs, so redaction is a real requirement.
+ * Two rules a purely keyed model can't satisfy:
+ *
+ *  - Pattern-based message redaction. The message is a free-form sprintf-baked string with no key to match on, so a
+ *    secret interpolated into it ("License $key rejected", a signed URL in an error, a Bearer token echoed from an
+ *    HTTP failure) is invisible to key redaction. So the message body is regex-scrubbed: license/hex shapes,
+ *    bearer/OAuth/secret-key tokens, and URL query strings (which carry signed-link secrets) are masked.
+ *  - Keyed, recursive context redaction. A default deny-key set covers what the plugin actually emits, recursing into
+ *    nested arrays and objects so ['response']['headers']['authorization'] is caught. String leaves under non-deny
+ *    keys are additionally scrub()'d (URL-query blanking + secret patterns), so a raw non-JSON API body or
+ *    string-encoded request body stored under a benign key ('response'/'body') can't leak a signed URL or echoed key.
+ *    The gfpdf_logging_redact_keys filter (passed the logger slug) may only add keys (merged over the defaults so a
+ *    host can't weaken them).
+ *
+ * Log-injection and CRLF forging: a newline in user-controlled message data would forge a second well-formed log line,
+ * so message() collapses \r\n|\r|\n to a space and strips non-printable control chars before redacting (the GF
+ * LineFormatter runs with allowInlineLineBreaks=false). Context is JSON-encoded to one line by the formatter, so it's
+ * safe.
+ *
+ * @since 6.16.0
+ */
+class Redact_Processor implements ProcessorInterface {
+
+	private const REPLACEMENT = '[redacted]';
+
+	/* Bound recursion so a circular or pathologically-deep context graph can't exhaust the stack (DoS). */
+	private const MAX_DEPTH = 10;
+
+	/**
+	 * Default deny-keys (lower-case) for keyed context redaction: what the plugin actually emits, not just licensing.
+	 */
+	private const DEFAULT_KEYS = [
+		'license',
+		'edd_license_key',
+		'package',
+		'download_link',
+		'access_token',
+		'refresh_token',
+		'authorization',
+		'password',
+		'secret',
+		'token',
+		'cookie',
+		'set-cookie',
+		'nonce',
+	];
+
+	/**
+	 * Message-body patterns masked wherever they appear.
+	 *
+	 * @var list<string>
+	 */
+	private const PATTERNS = [
+		'/\b[0-9a-f]{28,40}\b/i', // 28/32/40-hex license / signature shapes
+		'/Bearer\s+\S+/i',        // bearer tokens
+		'/ya29\.[\w\-]+/',        // Google OAuth access tokens
+		'/sk_[A-Za-z0-9]+/',      // Stripe-style secret keys
+	];
+
+	/**
+	 * The effective deny-keys as a lower-cased lookup map (defaults plus any added via the filter), for O(1) matching.
+	 *
+	 * @var array<string, true>
+	 */
+	private $keys;
+
+	/**
+	 * @param string $slug The logger slug, used to scope the redact-keys filter.
+	 *
+	 * @since 6.16.0
+	 */
+	public function __construct( string $slug ) {
+		$added = array_filter( (array) apply_filters( 'gfpdf_logging_redact_keys', self::DEFAULT_KEYS, $slug ), 'is_string' );
+
+		$keys = array_merge( self::DEFAULT_KEYS, array_map( 'strtolower', $added ) );
+
+		/* Flip to a lookup map so context() matches keys in O(1) on the per-record path; keys dedupe for free */
+		$this->keys = array_fill_keys( $keys, true );
+	}
+
+	/**
+	 * @param array $record
+	 *
+	 * @return array
+	 *
+	 * @since 6.16.0
+	 */
+	public function __invoke( array $record ) {
+		$record['message'] = $this->message( $record['message'] );
+		$record['context'] = $this->context( $record['context'] );
+
+		return $record;
+	}
+
+	/**
+	 * Normalise (anti log-forging) then pattern-redact the free-form message body.
+	 *
+	 * @param string $message
+	 *
+	 * @return string
+	 *
+	 * @since 6.16.0
+	 */
+	public function message( string $message ): string {
+		/* Collapse line breaks and strip control chars before redacting (Monolog allowInlineLineBreaks=false). */
+		$message = (string) preg_replace( '/\r\n|\r|\n/', ' ', $message );
+		$message = (string) preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $message );
+
+		return $this->scrub( $message );
+	}
+
+	/**
+	 * Mask secrets in a string: blank URL query strings (signed update/storage links carry secrets there — keep the
+	 * path, drop ?…) then apply the token/hex patterns.
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 *
+	 * @since 6.16.0
+	 */
+	private function scrub( string $value ): string {
+		$value = (string) preg_replace( '#(https?://[^\s?]+)\?\S*#i', '$1?', $value );
+
+		return (string) preg_replace( self::PATTERNS, self::REPLACEMENT, $value );
+	}
+
+	/**
+	 * Keyed-redact a context array, recursing into nested arrays and objects up to a bounded depth.
+	 *
+	 * @param array<array-key, mixed> $context
+	 * @param int                     $depth   Current recursion depth (internal).
+	 *
+	 * @return array<array-key, mixed>
+	 *
+	 * @since 6.16.0
+	 */
+	public function context( array $context, int $depth = 0 ): array {
+		$out = [];
+
+		foreach ( $context as $key => $value ) {
+			if ( is_string( $key ) && isset( $this->keys[ strtolower( $key ) ] ) ) {
+				$out[ $key ] = self::REPLACEMENT;
+				continue;
+			}
+
+			if ( is_array( $value ) || is_object( $value ) ) {
+				$out[ $key ] = $depth < self::MAX_DEPTH
+					? $this->context( (array) $value, $depth + 1 )
+					: self::REPLACEMENT;
+			} elseif ( is_string( $value ) ) {
+				/* Scrub string leaves too (a raw API body under a benign key like 'response' can carry a signed URL/key
+				   keyed redaction misses); scrub() not message() — the formatter one-lines context, so normalization is moot */
+				$out[ $key ] = $this->scrub( $value );
+			} else {
+				$out[ $key ] = $value;
+			}
+		}
+
+		return $out;
+	}
+}

--- a/src/Model/Model_Settings.php
+++ b/src/Model/Model_Settings.php
@@ -249,6 +249,7 @@ class Model_Settings extends Helper_Abstract_Model {
 				'id'   => 'license_' . $slug,
 				'name' => $addon->get_short_name(),
 				'type' => 'license',
+				'data' => $addon,
 			];
 
 			$fields[ 'license_' . $slug . '_message' ] = [
@@ -288,146 +289,58 @@ class Model_Settings extends Helper_Abstract_Model {
 				continue;
 			}
 
+			/* An admin-managed key is authoritative — ignore the submitted value and don't burn an activation */
+			if ( $addon->is_license_admin_managed() ) {
+				continue;
+			}
+
 			/* Check if the license key is now empty */
 			if ( trim( $input[ $option_key ] ) === '' ) {
 				$input[ $option_key . '_message' ] = '';
 				$input[ $option_key . '_status' ]  = '';
 
+				/* Sync the in-memory copy too, else get_license_status() returns the stale prior value this request */
+				$addon->update_license_info(
+					[
+						'license' => '',
+						'status'  => '',
+						'message' => '',
+					]
+				);
+
 				continue;
 			}
 
-			/* Ensure the un-hashed license key saved in the database is not overridden by the hashed license when resbumitting form */
+			/* Ensure the un-hashed license key saved in the database is not overridden by the hashed license when resubmitting form */
 			if ( isset( $settings[ $option_key ] ) && sha1( $settings[ $option_key ] ) === $input[ $option_key ] ) {
 				$input[ $option_key ] = $settings[ $option_key ];
 			}
 
-			/* Check this add-on key was submitted, it isn't the same as previously, or it's not active */
+			/* Run license activation if a new key was submitted, or the existing key isn't valid */
 			if (
-				$input[ $option_key . '_status' ] !== 'active' ||
+				! in_array( $input[ $option_key . '_status' ] ?? '', [ 'active', 'valid' ], true ) ||
 				( isset( $settings[ $option_key ] ) && $settings[ $option_key ] !== $input[ $option_key ] )
 			) {
-				$results = $this->activate_license( $addon, $input[ $option_key ] );
+				$results = $addon->activate_license( $input[ $option_key ] );
 
 				$input[ $option_key . '_message' ] = $results['message'];
 				$input[ $option_key . '_status' ]  = $results['status'];
 			}
 		}
 
-		return $input;
-	}
-
-	/**
-	 * Do API call to GravityPDF.com to activate the current add-on license key
-	 *
-	 * @param Helper_Abstract_Addon $addon       The current add-on class (stored in $data->addon)
-	 * @param string                $license_key The current license key for this add-on
-	 *
-	 * @return array The API response and license status
-	 *
-	 * @since 4.2
-	 */
-	protected function activate_license( Helper_Abstract_Addon $addon, $license_key ) {
-
-		$response = wp_remote_post(
-			$this->data->store_url,
-			[
-				'timeout' => 15,
-				'body'    => [
-					'edd_action'  => 'activate_license',
-					'license'     => $license_key,
-					'item_id'     => $addon->get_edd_download_id(),
-					'item_name'   => rawurlencode( $addon->get_short_name() ), // the name of our product in EDD
-					'url'         => home_url(),
-					'environment' => function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production',
-				],
-			]
-		);
-
-		$possible_responses = $this->data->addon_license_responses( $addon->get_name() );
-
-		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
-			$message = ( is_wp_error( $response ) ) ? $response->get_error_message() : $possible_responses['generic'];
-			$status  = 'error';
-
-			$this->log->error(
-				'License activation failure',
-				[
-					'data' => $message,
-				]
-			);
-		} else {
-			$license_data = json_decode( wp_remote_retrieve_body( $response ) );
-			$message      = __( 'Your support license key has been activated for this domain.', 'gravity-pdf' );
-			$status       = 'active';
-
-			if ( ! isset( $license_data->success ) || false === $license_data->success ) {
-				$message = $possible_responses['generic'];
-				$status  = 'error';
-
-				if ( isset( $license_data->error, $possible_responses[ $license_data->error ] ) ) {
-					$message = $possible_responses[ $license_data->error ];
-					$status  = $license_data->error;
-
-					switch ( $license_data->error ) {
-						case 'expired':
-							$date_format = get_option( 'date_format' );
-							$dt          = new \DateTimeImmutable( $license_data->expires, wp_timezone() );
-							$date        = $dt === false ? gmdate( $date_format, false ) : $dt->format( $date_format );
-
-							$url = add_query_arg(
-								[
-									'edd_license_key' => $license_key,
-									'download_id'     => $addon->get_edd_download_id(),
-								],
-								'https://gravitypdf.com/checkout/'
-							);
-
-							$message = sprintf( $message, $date, $url );
-							break;
-
-						case 'revoked':
-						case 'disabled':
-							$url = add_query_arg(
-								[
-									'edd_action'  => 'add_to_cart',
-									'download_id' => $addon->get_edd_download_id(),
-									'edd_options[price_id]' => $license_data->price_id,
-								],
-								'https://gravitypdf.com/checkout/'
-							);
-
-							$message = sprintf( $message, $url );
-							break;
-
-						case 'no_activations_left':
-							$url = add_query_arg(
-								[
-									'view'       => 'upgrades',
-									'action'     => 'manage_licenses',
-									'license_id' => $license_data->license_id,
-									'payment_id' => $license_data->payment_id,
-								],
-								'https://gravitypdf.com/account/'
-							);
-
-							$message = sprintf( $message, $url );
-							break;
-					}
-				}
-
-				$this->log->error(
-					'License activation failure',
-					[
-						'data' => $license_data,
-					]
-				);
+		/* Persist the authoritative key/status for admin-managed addons */
+		foreach ( $this->data->addon as $addon ) {
+			if ( ! $addon->is_license_admin_managed() ) {
+				continue;
 			}
+
+			$option_key                        = 'license_' . $addon->get_slug();
+			$input[ $option_key ]              = $addon->get_license_key();
+			$input[ $option_key . '_message' ] = $addon->get_license_message();
+			$input[ $option_key . '_status' ]  = $addon->get_license_status();
 		}
 
-		return [
-			'message' => $message,
-			'status'  => $status,
-		];
+		return $input;
 	}
 
 	/**
@@ -449,45 +362,330 @@ class Model_Settings extends Helper_Abstract_Model {
 		$addon = $this->data->addon[ ( $_POST['addon_name'] ?? '' ) ] ?? false;
 
 		/* Check add-on currently installed */
-		if ( ! empty( $addon ) ) {
-			if ( $this->deactivate_license_key( $addon, $addon->get_license_key() ) ) {
-				$this->log->notice( 'AJAX – Successfully Deactivated License' );
-				echo wp_json_encode(
-					[
-						'success' => esc_html__( 'License deactivated.', 'gravity-pdf' ),
-					]
-				);
+		if ( empty( $addon ) ) {
+			$this->log->error( 'AJAX Endpoint Error' );
 
-				wp_die();
-			} elseif ( $addon->schedule_license_check() ) {
-				$license_info = $addon->get_license_info();
+			echo wp_json_encode(
+				[
+					'error' => wp_kses(
+						sprintf(
+							__( 'An unknown error occurred, and your license key may not have been correctly deactivated. %1$sLogin to your GravityPDF.com account%2$s and check if your site has been unlinked from the key.', 'gravity-pdf' ),
+							'<a href="https://gravitypdf.com/account/licenses/">',
+							'</a>'
+						),
+						[ 'a' => [ 'href' => [] ] ]
+					),
+				]
+			);
 
-				echo wp_json_encode(
-					[
-						'error' => $license_info['message'],
-					]
-				);
-
-				wp_die();
-			}
+			wp_die();
 		}
 
-		$this->log->error( 'AJAX Endpoint Error' );
+		if ( ! empty( $addon->get_license_status() ) && ! $addon->deactivate_license() ) {
+			echo wp_json_encode(
+				[
+					'error' => wp_kses(
+						sprintf(
+							__( 'An API error occurred and your license key may not have been correctly deactivated. %1$sLogin to your GravityPDF.com account%2$s and check if your site has been unlinked from the key.', 'gravity-pdf' ),
+							'<a href="https://gravitypdf.com/account/licenses/">',
+							'</a>'
+						),
+						[ 'a' => [ 'href' => [] ] ]
+					),
+				]
+			);
+
+			wp_die();
+		}
+
+		/* All Access Pass licenses are site-activated, not product-activated. Deactivate other addons linked to license */
+		$extra = [];
+		foreach ( $this->data->addon as $addon ) {
+			if ( ! $addon->has_license_auto_deactivated() ) {
+				continue;
+			}
+
+			$extra[] = $addon->get_slug();
+		}
+
+		$this->log->notice( 'AJAX – Successfully Deactivated License' );
+
+		$message = empty( $extra ) ?
+			esc_html__( 'License key deactivated.', 'gravity-pdf' ) :
+			esc_html__( 'Access Pass license key deactivated.', 'gravity-pdf' );
 
 		echo wp_json_encode(
 			[
-				'error' => wp_kses(
-					sprintf(
-						__( 'An unknown error occurred, and your license key may not have been correctly deactivated. %1$sLogin to your GravityPDF.com account%2$s and check if your site has been unlinked from the key.', 'gravity-pdf' ),
-						'<a href="https://gravitypdf.com/account/licenses/">',
-						'</a>'
-					),
-					[ 'a' => [ 'href' => [] ] ]
-				),
+				'success' => $message,
+				'extra'   => $extra,
 			]
 		);
 
 		wp_die();
+	}
+
+	/**
+	 * Optimize plugin version checks by combining them into a single request
+	 *
+	 * @param array $api_params
+	 *
+	 * @return array
+	 *
+	 * @since 6.16.0
+	 */
+	public function licensing_bulk_get_version_api_params( $api_params ) {
+		/* Collect each add-on updater, dropping any that haven't been initialized (a third-party subclass may return null) */
+		$products = array_filter(
+			array_map(
+				function ( $addon ) {
+					return $addon->get_plugin_updater();
+				},
+				$this->data->addon
+			)
+		);
+
+		/* Include the core plugin only when its updater exists (absent on the non-canonical wordpress.org build) */
+		if ( ! empty( $this->data->updater ) ) {
+			$products = array_merge( [ 'gravity-pdf' => $this->data->updater ], $products );
+		}
+
+		/* Nothing to bundle — leave the individual request untouched */
+		if ( empty( $products ) ) {
+			return $api_params;
+		}
+
+		$bulk_api_params = [];
+		foreach ( $products as $product ) {
+			$bulk_api_params[] = $product->get_version_api_params();
+		}
+
+		return [
+			'edd_action' => 'get_version',
+			'products'   => $bulk_api_params,
+		];
+	}
+
+	/**
+	 * Handle the bulk get_version API response: cache each bundled product against its own updater and hand back the
+	 * product that initiated the request for its normal caching path.
+	 *
+	 * @param mixed  $response    The decoded API response — an array of product objects, or a non-array passed straight through
+	 * @param array  $api_data    The initiating updater's API data (part of the filter signature; unused here)
+	 * @param string $plugin_file The initiating plugin file, used to single out which product to hand back
+	 *
+	 * @return \stdClass|mixed|null The initiating product object, null when it isn't in the response, or $response unchanged when not an array
+	 *
+	 * @since 6.16.0
+	 */
+	public function licensing_bulk_get_version_api_response( $response, $api_data, $plugin_file ) {
+		if ( ! is_array( $response ) ) {
+			return $response;
+		}
+
+		/* Map each bundled updater by the slug it sent (the plugin-folder basename the API echoes back), so a response
+		   links to the right product even when an add-on's registered slug differs from its folder — e.g. a renamed folder. */
+		$updaters = [];
+		foreach ( $this->data->addon as $addon ) {
+			$updater = $addon->get_plugin_updater();
+			if ( $updater ) {
+				$updaters[ $updater->get_slug() ] = $updater;
+			}
+		}
+
+		if ( ! empty( $this->data->updater ) ) {
+			$updaters[ $this->data->updater->get_slug() ] = $this->data->updater;
+		}
+
+		$initial_request_data = null;
+
+		foreach ( $response as $product ) {
+			if ( ! isset( $product->slug, $updaters[ $product->slug ] ) ) {
+				continue; // couldn't link response to a product, skip.
+			}
+
+			$updater = $updaters[ $product->slug ];
+
+			/* skip the product that initialized the request, as it'll be handled in the return method */
+			if ( $updater->get_plugin_file() !== $plugin_file ) {
+				$updater->set_version_info_cache( $updater->standardize_api_response( $product ) );
+			} else {
+				$initial_request_data = $product;
+			}
+		}
+
+		return $initial_request_data;
+	}
+
+	/**
+	 * Check the status of licenses from the API in bulk
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	public function licensing_bulk_license_check() {
+		if ( $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return false;
+		}
+
+		$addons = $this->data->addon;
+		if ( empty( $addons ) ) {
+			return false;
+		}
+
+		$bulk_api_params = [];
+		$grouped_addons  = [];
+
+		foreach ( $addons as $addon ) {
+			/* Skip if no license key has been saved */
+			if ( empty( $addon->get_license_key() ) ) {
+				continue;
+			}
+
+			$updater = $addon->get_plugin_updater();
+			if ( ! $updater ) {
+				continue;
+			}
+
+			$bulk_api_params[]                               = $updater->get_version_api_params();
+			$grouped_addons[ $addon->get_edd_download_id() ] = $addon;
+		}
+
+		if ( empty( $bulk_api_params ) ) {
+			return false;
+		}
+
+		$response = wp_remote_post(
+			$this->data->store_url,
+			[
+				'timeout' => 15,
+				'body'    => [
+					'edd_action' => 'check_license',
+					'products'   => $bulk_api_params,
+				],
+			]
+		);
+
+		/* Check for problems contacting the licensing server */
+		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
+			$this->log->error(
+				'Failed to contact remote API for bulk license status check.',
+				[
+					'error' => is_wp_error( $response ) ? $response->get_error_message() : wp_remote_retrieve_response_code( $response ),
+				]
+			);
+
+			wp_schedule_single_event( strtotime( '+3 hour' ), 'gfpdf_bulk_license_check' );
+
+			return false;
+		}
+
+		/* Check for a malformed response */
+		$body          = wp_remote_retrieve_body( $response );
+		$license_check = json_decode( $body );
+		if ( ! is_array( $license_check ) ) {
+			/* Log the decoded body so the redactor can traverse nested keys; cap the raw fallback to bound any leak */
+			$this->log->error(
+				'Invalid response returned from bulk license status check.',
+				[ 'response' => $license_check ?? substr( $body, 0, 500 ) ]
+			);
+
+			wp_schedule_single_event( strtotime( '+3 hour' ), 'gfpdf_bulk_license_check' );
+
+			return false;
+		}
+
+		/* Loop over the response and update any licenses that have changed */
+		foreach ( $license_check as $addon_response ) {
+			if ( ! isset( $addon_response->item_id, $addon_response->license, $grouped_addons[ $addon_response->item_id ] ) ) {
+				$this->log->error( 'Invalid response for individual addon during bulk license status check.', [ 'response' => $addon_response ] );
+
+				continue;
+			}
+
+			$addon = $grouped_addons[ $addon_response->item_id ];
+			if ( $addon->get_license_status() === $addon_response->license ) {
+				$this->log->notice(
+					'License status has not changed.',
+					[
+						'response' => $addon_response,
+						'slug'     => $addon->get_slug(),
+					]
+				);
+
+				continue;
+			}
+
+			$addon->update_license_status_from_response(
+				$addon->get_license_key(),
+				[
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode( $addon_response ),
+				],
+				true
+			);
+
+		}
+
+		return true;
+	}
+
+	/**
+	 * Force the network to display update nags when the plugin is only activated on a subsite
+	 *
+	 * @return void
+	 *
+	 * @since 6.16.0
+	 */
+	public function run_network_update_check() {
+		if ( ! is_multisite() || is_main_site() ) {
+			return;
+		}
+
+		/* Network-activated installs receive update checks through the normal flow, so don't re-arm the event there */
+		if ( $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return;
+		}
+
+		/*
+		 * Skip a full wp_plugin_update() check and instead force the `pre_set_site_transient_update_plugins` filter to
+		 * do its job, which many addons (including Gravity PDF) use to inject update info. Run in the current (subsite)
+		 * context, not the main site: update_plugins is network-global, so re-injecting here fires check_update() where
+		 * the per-site add-on is active and its cached network package is found — no per-updater API request.
+		 */
+		$update_info = get_site_transient( 'update_plugins' );
+		if ( $update_info !== false ) {
+			set_site_transient( 'update_plugins', $update_info );
+		}
+
+		/* Re-arm the one-off event so the next run re-syncs to the primary site's plugin update schedule */
+		$this->schedule_network_update_check();
+	}
+
+	/**
+	 * Schedule the next one-off network update check, one minute after the primary site's plugin update check
+	 *
+	 * A self-rescheduling single event (rather than a fixed recurring one) recomputes the offset every cycle, so it
+	 * re-syncs whenever WordPress reschedules its own plugin update check.
+	 *
+	 * @return void
+	 *
+	 * @since 6.16.0
+	 */
+	public function schedule_network_update_check() {
+		switch_to_blog( get_main_site_id() );
+		$timestamp = wp_next_scheduled( 'wp_update_plugins' );
+		restore_current_blog();
+
+		if ( $timestamp === false ) {
+			$timestamp = time() + 12 * HOUR_IN_SECONDS;
+		}
+
+		/* wp_next_scheduled() returns a past time when the primary site's cron is quiet; floor to the future so the
+		   self-rescheduling event isn't perpetually due (which would re-fire on every cron spawn). */
+		$timestamp = max( $timestamp, time() + HOUR_IN_SECONDS );
+
+		wp_schedule_single_event( $timestamp + 60, 'gfpdf_network_update_check' );
 	}
 
 	/**
@@ -499,47 +697,10 @@ class Model_Settings extends Helper_Abstract_Model {
 	 * @return bool
 	 *
 	 * @since 4.2
+	 * @deprecated 6.16.0 Moved to Addon framework
 	 */
-	public function deactivate_license_key( Helper_Abstract_Addon $addon, $license_key ) {
-
-		/* Remove license data from database, no matter if the API request fails */
-		$addon->delete_license_info();
-
-		$response = wp_remote_post(
-			$this->data->store_url,
-			[
-				'timeout' => 15,
-				'body'    => [
-					'edd_action'  => 'deactivate_license',
-					'license'     => $license_key,
-					'item_id'     => $addon->get_edd_download_id(),
-					'item_name'   => rawurlencode( $addon->get_short_name() ), // the name of our product in EDD
-					'url'         => home_url(),
-					'environment' => function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production',
-				],
-			]
-		);
-
-		/* If API error exit early */
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return false;
-		}
-
-		/* Get API response and check license is now deactivated */
-		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
-		if ( ! isset( $license_data->license ) || $license_data->license !== 'deactivated' ) {
-			return false;
-		}
-
-		$this->log->notice(
-			'License successfully deactivated',
-			[
-				'slug'    => $addon->get_slug(),
-				'license' => $license_key,
-			]
-		);
-
-		return true;
+	public function deactivate_license_key( Helper_Abstract_Addon $addon, $license_key = '' ) {
+		return $addon->deactivate_license();
 	}
 
 	/**

--- a/src/Model/Model_Uninstall.php
+++ b/src/Model/Model_Uninstall.php
@@ -103,6 +103,8 @@ class Model_Uninstall extends Helper_Abstract_Model {
 				$this->remove_plugin_form_settings();
 			}
 			restore_current_blog();
+
+			$this->remove_plugin_network_options();
 		} else {
 			$this->remove_plugin_options();
 			$this->remove_plugin_form_settings();
@@ -130,6 +132,23 @@ class Model_Uninstall extends Helper_Abstract_Model {
 		delete_option( 'gfpdf_is_installed' );
 		delete_option( 'gfpdf_current_version' );
 		delete_option( 'gfpdf_settings' );
+
+		/* Remove license API data */
+		global $wpdb;
+		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'gpdf_sl_%'" );
+	}
+
+	/**
+	 * Remove the network-shared license package cache stored in sitemeta on a Multisite
+	 *
+	 * The per-site caches removed by remove_plugin_options() live in each site's options table; the network cache
+	 * (see EDD_SL_Plugin_Updater::get_network_cache_key()) is a single network option, so it's cleaned up once here.
+	 *
+	 * @since 6.16.0
+	 */
+	public function remove_plugin_network_options() {
+		global $wpdb;
+		$wpdb->query( "DELETE FROM $wpdb->sitemeta WHERE meta_key LIKE 'gpdf_sl_net_%'" );
 	}
 
 	/**

--- a/src/View/View_Settings.php
+++ b/src/View/View_Settings.php
@@ -186,8 +186,8 @@ class View_Settings extends Helper_Abstract_View {
 			],
 		];
 
-		/* Add License tab if necessary */
-		if ( count( $this->data->addon ) > 0 ) {
+		/* Add License tab if necessary (skip on secondary network sites — the primary site manages licensing) */
+		if ( count( $this->data->addon ) > 0 && ! $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
 			$navigation[10] = [
 				'name' => esc_html__( 'License', 'gravity-pdf' ),
 				'id'   => 'license',

--- a/src/View/html/Settings/licence-info.php
+++ b/src/View/html/Settings/licence-info.php
@@ -19,13 +19,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 <p>
 	<?php
 	printf(
-		esc_html__( 'To take advantage of automatic updates for your Gravity PDF extension(s), enter and save your license key(s) below. %1$sYou can find your purchased licenses in your GravityPDF.com account%2$s.', 'gravity-pdf' ),
+		esc_html__( 'To take advantage of automatic updates enter and save your license key(s) below. %1$sYou can find your purchased licenses in your GravityPDF.com account%2$s.', 'gravity-pdf' ),
 		'<a href="https://gravitypdf.com/account/licenses/">',
 		'</a>'
 	);
 	?>
-</p>
-
-<p>
-	<?php esc_html_e( 'When a Gravity PDF extension is enabled, the plugin periodically polls GravityPDF.com over HTTPS for your license status and plugin updates. The only data sent is your website domain name and license key (if provided). To opt-out you need to deactivate all Gravity PDF extensions.', 'gravity-pdf' ); ?>
 </p>

--- a/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
+++ b/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
@@ -8,22 +8,30 @@ import { spinner } from '../../helper/spinner'
  */
 export function setupLicenseDeactivation () {
   $('.gfpdf-deactivate-license').on('click', function () {
+    const $button = $(this)
+
+    /* Ignore repeat clicks while a deactivation request is already in flight */
+    if ($button.prop('disabled')) {
+      return false
+    }
+    $button.prop('disabled', true)
+
     /* Do AJAX call so user can deactivate license */
-    const $container = $(this).parent()
+    const $container = $button.parent()
 
     /* Add spinner */
     const $spinner = spinner('gfpdf-spinner')
 
     /* Add our spinner */
-    $(this).append($spinner)
+    $button.append($spinner)
 
     /* Set up ajax data */
-    const slug = $(this).data('addon-name')
+    const slug = $button.data('addon-name')
 
     const data = {
       action: 'gfpdf_deactivate_license',
       addon_name: slug,
-      nonce: $(this).data('nonce')
+      nonce: $button.data('nonce')
     }
 
     /* Do ajax call */
@@ -31,28 +39,44 @@ export function setupLicenseDeactivation () {
       /* Remove our loading spinner */
       $spinner.remove()
 
-      /* cleanup inputs */
-      $('#gfpdf_settings\\[license_' + slug + '\\]').val('')
-      $('#gfpdf_settings\\[license_' + slug + '_message\\]').val('')
-      $('#gfpdf_settings\\[license_' + slug + '_status\\]').val('')
-      $container.find('button').remove()
+      /* Our endpoint always returns a `success` or `error` string. A transport/auth failure (eg. a 500, or the 401
+         from handle_ajax_authentication) instead hits jQuery's error handler with the raw jqXHR, so neither is set. */
+      const successMessage = typeof response?.success === 'string' ? response.success : null
+      if (successMessage === null) {
+        /* Deactivation didn't complete — re-enable the button and surface the error so the user can retry */
+        $button.prop('disabled', false)
+        const error = typeof response?.error === 'string' ? response.error : GFPDF.licenseDeactivationError
+        showLicenseMessage($container, error, false)
+        return
+      }
 
-      if (response.success) {
-        $container
-          .find('#message')
-          .removeClass('error')
-          .addClass('success')
-          .html(response.success)
-      } else {
-        /* Show error message */
-        $container
-          .find('#message')
-          .removeClass('success')
-          .addClass('error')
-          .html(response.error)
+      /* update UI to reflect deactivation */
+      postLicenseDeactivation(slug, $container, successMessage)
+
+      /* handle any shared licenses that were also deactivated */
+      if (Array.isArray(response.extra)) {
+        response.extra.forEach(item => postLicenseDeactivation(item, $('#gfpdf-settings-field-wrapper-license_' + item), successMessage))
       }
     })
 
     return false
   })
+}
+
+function postLicenseDeactivation (slug, $container, message) {
+  /* cleanup inputs */
+  $('#gfpdf_settings\\[license_' + slug + '\\]').val('')
+  $('#gfpdf_settings\\[license_' + slug + '_message\\]').val('')
+  $('#gfpdf_settings\\[license_' + slug + '_status\\]').val('')
+  $container.find('button').remove()
+
+  showLicenseMessage($container, message, true)
+}
+
+function showLicenseMessage ($container, message, success) {
+  $container
+    .find('#message')
+    .toggleClass('success', success)
+    .toggleClass('error', !success)
+    .html(message)
 }

--- a/tests/js-unit/admin/settings/common/setupLicenseDeactivation.test.js
+++ b/tests/js-unit/admin/settings/common/setupLicenseDeactivation.test.js
@@ -1,0 +1,115 @@
+import $ from 'jquery'
+import { setupLicenseDeactivation } from '../../../../../src/assets/js/admin/settings/common/setupLicenseDeactivation'
+import { ajaxCall } from '../../../../../src/assets/js/admin/helper/ajaxCall'
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       6.16.0
+ */
+
+jest.mock('../../../../../src/assets/js/admin/helper/ajaxCall')
+jest.mock('../../../../../src/assets/js/admin/helper/spinner', () => ({
+  /* jquery is required lazily: a jest.mock factory can't close over the module-scope `$` import */
+  spinner: () => require('jquery')('<span class="gfpdf-spinner" />')
+}))
+
+/* Build the license field wrapper the way license_callback() renders it: message div, key/message/status inputs, and
+   the Deactivate button, all inside the #gfpdf-settings-field-wrapper-license_<slug> container. */
+function renderLicenseField (slug) {
+  return $(
+    `<div id="gfpdf-settings-field-wrapper-license_${slug}">
+      <div id="message" class="success">existing message</div>
+      <input id="gfpdf_settings[license_${slug}]" value="a-real-license-key" />
+      <input id="gfpdf_settings[license_${slug}_message]" value="stored message" />
+      <input id="gfpdf_settings[license_${slug}_status]" value="active" />
+      <button class="gfpdf-deactivate-license" data-addon-name="${slug}" data-nonce="nonce-123">Deactivate License</button>
+    </div>`
+  )
+}
+
+/* Trigger the click, then hand the wired callback whatever the endpoint (or jQuery's error handler) would return. */
+function deactivate (respondWith) {
+  $('.gfpdf-deactivate-license').first().trigger('click')
+  const callback = ajaxCall.mock.calls[0][1]
+  callback(respondWith)
+}
+
+const fieldValue = (slug, suffix = '') => $(`#gfpdf_settings\\[license_${slug}${suffix}\\]`).val()
+
+describe('setupLicenseDeactivation', () => {
+  beforeEach(() => {
+    $('body').append(renderLicenseField('sample'))
+    setupLicenseDeactivation()
+  })
+
+  afterEach(() => {
+    $('body').empty()
+  })
+
+  describe('on success', () => {
+    it('clears the stored key/message/status, removes the button, and shows the success message', () => {
+      deactivate({ success: 'License key deactivated.', extra: [] })
+
+      expect(fieldValue('sample')).toBe('')
+      expect(fieldValue('sample', '_message')).toBe('')
+      expect(fieldValue('sample', '_status')).toBe('')
+      expect($('.gfpdf-deactivate-license').length).toBe(0)
+
+      const $message = $('#gfpdf-settings-field-wrapper-license_sample #message')
+      expect($message.hasClass('success')).toBe(true)
+      expect($message.hasClass('error')).toBe(false)
+      expect($message.html()).toBe('License key deactivated.')
+    })
+
+    it('also tears down any All Access Pass siblings returned in extra', () => {
+      $('body').append(renderLicenseField('sibling'))
+
+      deactivate({ success: 'Access Pass license key deactivated.', extra: ['sibling'] })
+
+      expect(fieldValue('sibling')).toBe('')
+      expect($('#gfpdf-settings-field-wrapper-license_sibling button').length).toBe(0)
+    })
+  })
+
+  describe('on an application error (HTTP 200 { error })', () => {
+    it('keeps the field and button so the user can retry, and shows the error', () => {
+      deactivate({ error: 'An API error occurred.' })
+
+      expect(fieldValue('sample')).toBe('a-real-license-key')
+      expect($('.gfpdf-deactivate-license').length).toBe(1)
+      expect($('.gfpdf-deactivate-license').prop('disabled')).toBe(false)
+
+      const $message = $('#gfpdf-settings-field-wrapper-license_sample #message')
+      expect($message.hasClass('error')).toBe(true)
+      expect($message.hasClass('success')).toBe(false)
+      expect($message.html()).toBe('An API error occurred.')
+    })
+  })
+
+  describe('on a transport/auth failure (jqXHR, not our JSON)', () => {
+    it('does not clear the field or remove the button, and shows the generic fallback message', () => {
+      /* jQuery's error handler passes the raw jqXHR — neither success nor error is a string */
+      deactivate({ readyState: 4, status: 401, statusText: 'Unauthorized' })
+
+      expect(fieldValue('sample')).toBe('a-real-license-key')
+      expect($('.gfpdf-deactivate-license').length).toBe(1)
+      expect($('.gfpdf-deactivate-license').prop('disabled')).toBe(false)
+
+      const $message = $('#gfpdf-settings-field-wrapper-license_sample #message')
+      expect($message.hasClass('error')).toBe(true)
+      expect($message.hasClass('success')).toBe(false)
+      expect($message.html()).toBe(GFPDF.licenseDeactivationError)
+    })
+  })
+
+  describe('on a repeat click while a request is in flight', () => {
+    it('ignores the second click so only one deactivation request is sent', () => {
+      $('.gfpdf-deactivate-license').first().trigger('click')
+      $('.gfpdf-deactivate-license').first().trigger('click')
+
+      expect(ajaxCall).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/tests/js-unit/setupTests.js
+++ b/tests/js-unit/setupTests.js
@@ -17,6 +17,7 @@ window.GFPDF = {
   noResultText: 'It doesn\'t look like there are any topics related to your issue.',
   coreFontGithubError: 'Could not download Core Font list. Try again.',
   getSearchResultError: 'An error occurred. Please try again',
+  licenseDeactivationError: 'An error occurred and your license key may not have been deactivated. Reload the page and try again.',
   userCapabilities: { administrator: true },
   // Font manager component
   fontListInstalledFonts: 'Installed Fonts',

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Settings.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Settings.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use GFPDF\Helper\Helper_Abstract_Addon;
+use GFPDF\Helper\Helper_Logger;
+use GFPDF\Helper\Helper_Notices;
+use GFPDF\Helper\Helper_Singleton;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2025, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @package GFPDF\Controller
+ *
+ * @group   controller
+ * @group   settings
+ */
+class Test_Controller_Settings extends WP_UnitTestCase {
+	/**
+	 * @var Controller_Settings
+	 */
+	public $controller;
+
+	/**
+	 * The WP Unit Test Set up function
+	 */
+	public function set_up() {
+		global $gfpdf;
+
+		parent::set_up();
+
+		$model = $gfpdf->singleton->get_class( 'Model_Settings' );
+		$view  = $gfpdf->singleton->get_class( 'View_Settings' );
+
+		$this->controller = new Controller_Settings( $model, $view, $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->data, $gfpdf->misc );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		$data        = \GPDFAPI::get_data_class();
+		$data->addon = [];
+
+		/* Creating a subsite dirties process globals WP_UnitTestCase won't roll back; reset so later tests aren't polluted */
+		global $wp_settings_errors, $wp_rewrite;
+		$wp_settings_errors = [];
+		$wp_rewrite->init();
+	}
+
+	public function test_bulk_license_check_schedule_with_no_addons() {
+		$this->controller->add_filters();
+		do_action( 'init' );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+	}
+
+	public function test_bulk_license_check_schedule_with_addons() {
+		$addon = new ControllerSettingsAddon(
+			'my-custom-plugin',
+			'My Custom Plugin',
+			'Gravity PDF',
+			'1.0',
+			'/path/to/plugin/file.php',
+			\GPDFAPI::get_data_class(),
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'my-custom-plugin', 'My Custom Plugin' ),
+			new Helper_Notices()
+		);
+
+		$addon->init();
+		$this->controller->add_filters();
+		do_action( 'init' );
+
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+	}
+
+	public function test_bulk_license_check_not_scheduled_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		$addon = new ControllerSettingsAddon(
+			'my-custom-plugin',
+			'My Custom Plugin',
+			'Gravity PDF',
+			'1.0',
+			'/path/to/plugin/file.php',
+			\GPDFAPI::get_data_class(),
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'my-custom-plugin', 'My Custom Plugin' ),
+			new Helper_Notices()
+		);
+		$addon->init();
+
+		/* Pose as a secondary site with Gravity PDF network-activated; scheduling reads the per-blog cron, so use a real blog */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( $this->factory()->blog->create() );
+
+		$this->controller->add_filters();
+		do_action( 'init' );
+
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+	}
+
+	/*
+	 * maybe_schedule_network_update_check() runs on every request via after_setup_theme, including the frontend and
+	 * WP-Cron, where wp-admin/includes/plugin.php (which defines is_plugin_active_for_network()) isn't loaded. That
+	 * fatal can't be reproduced here because the PHPUnit bootstrap always loads the file, so guard the contract by
+	 * scanning the source. php_strip_whitespace() drops comments so only real code is matched.
+	 */
+	public function test_network_update_check_avoids_admin_only_plugin_functions() {
+		$source = php_strip_whitespace( ( new \ReflectionClass( Controller_Settings::class ) )->getFileName() );
+		$this->assertStringNotContainsString( 'is_plugin_active_for_network(', $source );
+	}
+
+	/*
+	 * The updater fires gpdf_sl_plugin_updater_api_response with ($response, $api_data, $plugin_file). If the filter
+	 * isn't registered with accepted_args of 3, $plugin_file arrives null, licensing_bulk_get_version_api_response()
+	 * can't identify the initiating product, and that plugin's own update is silently lost while every response-shape
+	 * test still passes. Pin the arg-count.
+	 */
+	public function test_bulk_get_version_response_filter_registered_with_plugin_file_arg() {
+		$this->controller->add_filters();
+
+		$hook = $GLOBALS['wp_filter']['gpdf_sl_plugin_updater_api_response'] ?? null;
+		$this->assertNotNull( $hook );
+
+		$registered = null;
+		foreach ( $hook->callbacks[10] as $callback ) {
+			if ( is_array( $callback['function'] ) && $callback['function'][1] === 'licensing_bulk_get_version_api_response' ) {
+				$registered = $callback;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $registered, 'The bulk get_version response filter was not registered' );
+		$this->assertSame( 3, $registered['accepted_args'] );
+	}
+}
+
+class ControllerSettingsAddon extends Helper_Abstract_Addon {
+}

--- a/tests/phpunit/unit-tests/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
+++ b/tests/phpunit/unit-tests/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
@@ -1,0 +1,1068 @@
+<?php
+
+namespace GFPDF\Helper\Licensing;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2025, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   licensing
+ */
+class Test_EDD_SL_Plugin_Updater extends WP_UnitTestCase {
+	/**
+	 * @var EDD_SL_Plugin_Updater
+	 */
+	protected $class;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->class = new EDD_SL_Plugin_Updater(
+			'http://store.com',
+			'test-plugin/test-plugin.php',
+			[
+				'version'   => '0.1',
+				'license'   => 'abc123',
+				'item_name' => 'Test Plugin',
+				'item_id'   => 57,
+				'author'    => 'Gravity PDF',
+				'beta'      => false,
+			] );
+
+		remove_all_filters( 'pre_set_site_transient_update_plugins' );
+		remove_all_filters( 'plugins_api' );
+		remove_all_filters( 'pre_http_request' );
+
+		$active_plugins = get_option( 'active_plugins', array() );
+		$active_plugins[] = 'test-plugin/test-plugin.php';
+		update_option( 'active_plugins', $active_plugins );
+	}
+
+	public function test_check_update_with_new_version() {
+		$this->class->init();
+
+		$api_response = function ( $pre, $parsed_args, $url ) {
+			/* API response */
+			if ( $url === 'http://store.com/' ) {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => json_encode( [
+						'new_version'    => '0.2',
+						'stable_version' => '0.2',
+						'name'           => 'Test Plugin',
+						'slug'           => 'test-plugin',
+						'package'        => 'https://store.com/download/123',
+						'sections'       => [
+							'description' => 'Excerpt here',
+							'changelog'   => 'Changelog here',
+						],
+						'banners'        => [
+							'high' => 'https://store.com/banner-large.png',
+							'low'  => 'https://store.com/banner-small.png',
+						],
+						'icons'          => [
+							'1x' => 'https://store.com/icon-1.png',
+							'2x' => 'https://store.com/icon-2.png',
+						],
+						'requires'       => '6.4',
+						'requires_php'   => '7.3',
+						'tested'         => '10.1',
+					] ),
+				];
+			}
+
+			/* WP.org response */
+
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'plugins'      => [],
+					'translations' => [],
+					'no_update'    => [],
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response, 10, 3 );
+
+		wp_update_plugins();
+
+		/* Verify expected result */
+		$updates = get_site_transient( 'update_plugins' );
+
+		$this->assertSame( '0.1', $updates->checked['test-plugin/test-plugin.php'] );
+		$this->assertArrayHasKey( 'test-plugin/test-plugin.php', $updates->response );
+		$this->assertSame( '0.2', $updates->response['test-plugin/test-plugin.php']->new_version );
+		$this->assertSame( '0.2', $updates->response['test-plugin/test-plugin.php']->stable_version );
+		$this->assertSame( 'Test Plugin', $updates->response['test-plugin/test-plugin.php']->name );
+		$this->assertSame( 'test-plugin', $updates->response['test-plugin/test-plugin.php']->slug );
+		$this->assertSame( 'https://store.com/download/123', $updates->response['test-plugin/test-plugin.php']->package );
+		$this->assertSame( 'https://store.com/banner-large.png', $updates->response['test-plugin/test-plugin.php']->banners['high'] );
+		$this->assertSame( 'https://store.com/icon-1.png', $updates->response['test-plugin/test-plugin.php']->icons['1x'] );
+		$this->assertSame( '6.4', $updates->response['test-plugin/test-plugin.php']->requires );
+		$this->assertSame( '7.3', $updates->response['test-plugin/test-plugin.php']->requires_php );
+		$this->assertSame( '10.1', $updates->response['test-plugin/test-plugin.php']->tested );
+		$this->assertSame( 'Excerpt here', $updates->response['test-plugin/test-plugin.php']->sections['description'] );
+		$this->assertSame( 'Changelog here', $updates->response['test-plugin/test-plugin.php']->sections['changelog'] );
+		$this->assertSame( 'Excerpt here', $updates->response['test-plugin/test-plugin.php']->description[0] );
+		$this->assertSame( 'Changelog here', $updates->response['test-plugin/test-plugin.php']->changelog[0] );
+
+		/* Verify cleanup */
+		$this->class->delete_transient_plugin_info();
+
+		$updates = get_site_transient( 'update_plugins' );
+
+		$this->assertArrayNotHasKey( 'test-plugin/test-plugin.php', $updates->checked );
+		$this->assertArrayNotHasKey( 'test-plugin/test-plugin.php', $updates->response );
+		$this->assertArrayNotHasKey( 'test-plugin/test-plugin.php', $updates->no_update );
+
+		$this->assertNotEmpty( get_option( $this->class->get_cache_key() ) );
+		$this->class->delete_version_info_cache();
+		$this->assertEmpty( get_option( $this->class->get_cache_key() ) );
+	}
+
+	public function test_check_update_with_current_version() {
+		$this->class->init();
+
+		$api_response = function ( $pre, $parsed_args, $url ) {
+			/* API response */
+			if ( $url === 'http://store.com/' ) {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => json_encode( [
+						'new_version'    => '0.1',
+						'stable_version' => '0.1',
+						'name'           => 'Test Plugin',
+						'slug'           => 'test-plugin',
+						'sections'       => [
+							'description' => 'Excerpt here',
+							'changelog'   => 'Changelog here',
+						],
+						'banners'        => [
+							'high' => 'https://store.com/banner-large.png',
+							'low'  => 'https://store.com/banner-small.png',
+						],
+						'icons'          => [
+							'1x' => 'https://store.com/icon-1.png',
+							'2x' => 'https://store.com/icon-2.png',
+						],
+						'requires'       => '6.4',
+						'requires_php'   => '7.3',
+						'tested'         => '10.1',
+					] ),
+				];
+			}
+
+			/* WP.org response */
+
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'plugins'      => [],
+					'translations' => [],
+					'no_update'    => [],
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response, 10, 3 );
+
+		wp_update_plugins();
+
+		/* Verify expected result */
+		$updates = get_site_transient( 'update_plugins' );
+
+		$this->assertSame( '0.1', $updates->checked['test-plugin/test-plugin.php'] );
+		$this->assertArrayNotHasKey( 'test-plugin/test-plugin.php', $updates->response );
+		$this->assertSame( '0.1', $updates->no_update['test-plugin/test-plugin.php']->new_version );
+		$this->assertSame( '0.1', $updates->no_update['test-plugin/test-plugin.php']->stable_version );
+		$this->assertSame( 'Test Plugin', $updates->no_update['test-plugin/test-plugin.php']->name );
+		$this->assertSame( 'test-plugin', $updates->no_update['test-plugin/test-plugin.php']->slug );
+		$this->assertSame( 'https://store.com/banner-large.png', $updates->no_update['test-plugin/test-plugin.php']->banners['high'] );
+		$this->assertSame( 'https://store.com/icon-1.png', $updates->no_update['test-plugin/test-plugin.php']->icons['1x'] );
+		$this->assertSame( '6.4', $updates->no_update['test-plugin/test-plugin.php']->requires );
+		$this->assertSame( '7.3', $updates->no_update['test-plugin/test-plugin.php']->requires_php );
+		$this->assertSame( '10.1', $updates->no_update['test-plugin/test-plugin.php']->tested );
+		$this->assertSame( 'Excerpt here', $updates->no_update['test-plugin/test-plugin.php']->sections['description'] );
+		$this->assertSame( 'Changelog here', $updates->no_update['test-plugin/test-plugin.php']->sections['changelog'] );
+		$this->assertSame( 'Excerpt here', $updates->no_update['test-plugin/test-plugin.php']->description[0] );
+		$this->assertSame( 'Changelog here', $updates->no_update['test-plugin/test-plugin.php']->changelog[0] );
+	}
+
+	public function test_check_update_with_api_failure() {
+		$this->class->init();
+
+		$api_response = function ( $pre, $parsed_args, $url ) {
+			/* API response */
+			if ( $url === 'http://store.com/' ) {
+				return [
+					'response' => [ 'code' => 500 ],
+				];
+			}
+
+			/* WP.org response */
+
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'plugins'      => [],
+					'translations' => [],
+					'no_update'    => [],
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response, 10, 3 );
+
+		wp_update_plugins();
+
+		/* Verify expected result */
+		$updates = get_site_transient( 'update_plugins' );
+
+		$this->assertSame( '0.1', $updates->checked['test-plugin/test-plugin.php'] );
+		$this->assertArrayNotHasKey( 'test-plugin/test-plugin.php', $updates->response );
+		$this->assertArrayNotHasKey( 'test-plugin/test-plugin.php', $updates->no_update );
+
+		$this->assertTrue( $this->class->request_recently_failed() );
+
+		/* test expired */
+		update_option( 'gpdf_sl_failed_http_' . md5( 'http://store.com/' ), time() - 60 );
+
+		$this->assertFalse( $this->class->request_recently_failed() );
+	}
+
+	public function test_get_version_from_remote_backs_off_on_malformed_200() {
+		$this->class->init();
+
+		/* 200 status but an empty body standardizes to false; without a recorded failure it would re-POST every call */
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => '',
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->assertFalse( $this->class->request_recently_failed() );
+		$this->assertFalse( $this->class->get_version_from_remote() );
+		$this->assertTrue( $this->class->request_recently_failed() );
+	}
+
+	public function test_standardize_api_response_does_not_unserialize_sections() {
+		/* A serialized-object string in a JSON field is an object-injection payload; it must not be unserialized */
+		$response           = new \stdClass();
+		$response->sections = 'O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}';
+
+		$result = $this->class->standardize_api_response( $response );
+
+		$this->assertSame( [], $result->sections );
+	}
+
+	public function test_standardize_api_response_unserializes_serialized_array_sections() {
+		/* Regression: serialized-array sections were dropped by the object-injection hardening, blanking the changelog modal */
+		$response           = new \stdClass();
+		$response->sections = serialize( [ 'description' => 'Excerpt here', 'changelog' => 'Changelog here' ] );
+		$response->banners  = serialize( [ 'high' => 'https://store.com/banner-large.png' ] );
+		$response->icons    = serialize( [ '1x' => 'https://store.com/icon-1.png' ] );
+
+		$result = $this->class->standardize_api_response( $response );
+
+		$this->assertSame( 'Excerpt here', $result->sections['description'] );
+		$this->assertSame( 'Changelog here', $result->sections['changelog'] );
+		$this->assertSame( 'https://store.com/banner-large.png', $result->banners['high'] );
+		$this->assertSame( 'https://store.com/icon-1.png', $result->icons['1x'] );
+		$this->assertSame( 'Excerpt here', $result->description[0] );
+		$this->assertSame( 'Changelog here', $result->changelog[0] );
+	}
+
+	public function test_standardize_api_response_serialized_array_neutralizes_nested_objects() {
+		/* A serialized array that nests an object must still not instantiate the class — objects stay disallowed */
+		$response           = new \stdClass();
+		$response->sections = 'a:1:{s:9:"changelog";O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}}';
+
+		$result = $this->class->standardize_api_response( $response );
+
+		$this->assertArrayHasKey( 'changelog', $result->sections );
+		$this->assertNotInstanceOf( \stdClass::class, $result->sections['changelog'] );
+		$this->assertIsArray( $result->sections['changelog'] );
+	}
+
+	public function test_standardize_api_response_decodes_json_string_sections() {
+		/* The store may JSON-encode sections/banners/icons instead of serializing them; both must resolve to arrays */
+		$response           = new \stdClass();
+		$response->sections = wp_json_encode( [ 'description' => 'Excerpt here', 'changelog' => 'Changelog here' ] );
+		$response->banners  = wp_json_encode( [ 'high' => 'https://store.com/banner-large.png' ] );
+		$response->icons    = wp_json_encode( [ '1x' => 'https://store.com/icon-1.png' ] );
+
+		$result = $this->class->standardize_api_response( $response );
+
+		$this->assertSame( 'Excerpt here', $result->sections['description'] );
+		$this->assertSame( 'Changelog here', $result->sections['changelog'] );
+		$this->assertSame( 'https://store.com/banner-large.png', $result->banners['high'] );
+		$this->assertSame( 'https://store.com/icon-1.png', $result->icons['1x'] );
+		$this->assertSame( 'Changelog here', $result->changelog[0] );
+	}
+
+	public function test_standardize_api_response_returns_false_for_non_object_payload() {
+		/* A non-empty, non-object payload passes empty() but the property writes below fatal on PHP 8; each must bail
+		   to false. Reachable via a third-party gpdf_sl_plugin_updater_api_response filter or a malformed 200 body. */
+		$this->assertFalse( $this->class->standardize_api_response( json_decode( '"a bare string"' ) ) );
+		$this->assertFalse( $this->class->standardize_api_response( json_decode( '[1,2,3]' ) ) );
+		$this->assertFalse( $this->class->standardize_api_response( 42 ) );
+		$this->assertFalse( $this->class->standardize_api_response( true ) );
+	}
+
+	public function test_get_cached_version_info_returns_false_for_corrupted_scalar_option() {
+		/* A corrupted scalar-string option (e.g. a network option edited by a super-admin) would throw a TypeError on
+		   the array access inside read_timed_cache() without the is_array() guard */
+		update_option( $this->class->get_cache_key(), 'corrupted-not-an-array' );
+
+		$this->assertFalse( $this->class->get_cached_version_info() );
+	}
+
+	public function test_check_update_already_exists() {
+		$updates           = new \stdClass();
+		$updates->response = [
+			'test-plugin' => 'yes',
+		];
+
+		$this->assertSame( $updates, $this->class->check_update( $updates ) );
+		$this->assertEmpty( get_option( $this->class->get_cache_key() ) );
+	}
+
+	public function test_check_update_override() {
+		$updater = new EDD_SL_Plugin_Updater(
+			'http://store.com',
+			'test-plugin/test-plugin.php',
+			[
+				'version'     => '0.1',
+				'license'     => 'abc123',
+				'item_name'   => 'Test Plugin',
+				'item_id'     => 57,
+				'author'      => 'Gravity PDF',
+				'beta'        => false,
+				'wp_override' => true,
+			] );
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'new_version'    => '0.1',
+					'stable_version' => '0.1',
+					'name'           => 'Test Plugin',
+					'slug'           => 'test-plugin',
+					'sections'       => [
+						'description' => 'Excerpt here',
+						'changelog'   => 'Changelog here',
+					],
+					'banners'        => [
+						'high' => 'https://store.com/banner-large.png',
+						'low'  => 'https://store.com/banner-small.png',
+					],
+					'icons'          => [
+						'1x' => 'https://store.com/icon-1.png',
+						'2x' => 'https://store.com/icon-2.png',
+					],
+					'requires'       => '6.4',
+					'requires_php'   => '7.3',
+					'tested'         => '10.1',
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response, 10, 3 );
+
+		$updates           = new \stdClass();
+		$updates->response = [
+			'test-plugin/test-plugin.php' => 'yes',
+		];
+
+		/* Verify expected result */
+		$updates = $updater->check_update( $updates );
+
+		$this->assertSame( '0.1', $updates->checked['test-plugin/test-plugin.php'] );
+		$this->assertArrayNotHasKey( 'test-plugin/test-plugin.php', $updates->response );
+		$this->assertSame( '0.1', $updates->no_update['test-plugin/test-plugin.php']->new_version );
+		$this->assertSame( '0.1', $updates->no_update['test-plugin/test-plugin.php']->stable_version );
+		$this->assertSame( 'Test Plugin', $updates->no_update['test-plugin/test-plugin.php']->name );
+		$this->assertSame( 'test-plugin', $updates->no_update['test-plugin/test-plugin.php']->slug );
+	}
+
+	public function test_get_version_info_with_matching_store_url() {
+		$updater = new EDD_SL_Plugin_Updater( home_url(), 'test-plugin/test-plugin.php' );
+
+		$this->assertFalse( $updater->get_version_info() );
+	}
+
+	public function test_get_version_info_skipped_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP in tests' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		/* Pose as a secondary site with the add-on network-activated; only a network option is read, so no real blog is needed */
+		$network_plugins = static function () { return [ 'test-plugin/test-plugin.php' => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		$this->assertFalse( $this->class->get_version_info() );
+		$this->assertFalse( $http_called );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		remove_filter( 'pre_http_request', $spy );
+	}
+
+	public function test_get_tested_version() {
+		global $wp_version;
+
+		$wp_version = '6.5.6';
+
+		$version_info         = new \stdClass();
+		$version_info->tested = '6.5';
+		$this->assertSame( $wp_version, $this->class->get_tested_version( $version_info ) );
+
+		$version_info->tested = '6.5.2';
+		$this->assertSame( $wp_version, $this->class->get_tested_version( $version_info ) );
+
+		$version_info->tested = '6.5.8';
+		$this->assertSame( '6.5.8', $this->class->get_tested_version( $version_info ) );
+
+		$version_info->tested = '6.4';
+
+		$this->assertSame( '6.4', $this->class->get_tested_version( $version_info ) );
+	}
+
+	public function test_set_license_key() {
+		$params = $this->class->get_version_api_params();
+		$this->assertSame( 'abc123', $params['license'] );
+
+		$this->class->set_license_key( 'zxy987' );
+
+		$params = $this->class->get_version_api_params();
+		$this->assertSame( 'zxy987', $params['license'] );
+	}
+
+	public function test_get_plugin_file() {
+		$this->assertSame( 'test-plugin/test-plugin.php', $this->class->get_plugin_file() );
+	}
+
+	public function test_plugins_api_filter() {
+		$this->class->init();
+
+		$args       = new \stdClass();
+		$args->slug = 'test-plugin';
+
+		$results = apply_filters( 'plugins_api', 'input123', 'hot_tags', $args );
+		$this->assertSame( 'input123', $results );
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'new_version'    => '0.2',
+					'stable_version' => '0.2',
+					'name'           => 'Test Plugin',
+					'slug'           => 'test-plugin',
+					'package'        => 'https://store.com/download/123',
+					'sections'       => [
+						'description' => 'Excerpt here',
+						'changelog'   => 'Changelog here',
+					],
+					'banners'        => [
+						'high' => 'https://store.com/banner-large.png',
+						'low'  => 'https://store.com/banner-small.png',
+					],
+					'icons'          => [
+						'1x' => 'https://store.com/icon-1.png',
+						'2x' => 'https://store.com/icon-2.png',
+					],
+					'requires'       => '6.4',
+					'requires_php'   => '7.3',
+					'tested'         => '10.1',
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$results = apply_filters( 'plugins_api', 'input123', 'plugin_information', $args );
+
+		$this->assertSame( '0.2', $results->version );
+		$this->assertSame( 'test-plugin/test-plugin.php', $results->plugin );
+		$this->assertSame( '0.2', $results->new_version );
+		$this->assertSame( '0.2', $results->stable_version );
+		$this->assertSame( 'Test Plugin', $results->name );
+		$this->assertSame( 'test-plugin', $results->slug );
+		$this->assertSame( 'https://store.com/banner-large.png', $results->banners['high'] );
+		$this->assertSame( 'https://store.com/icon-1.png', $results->icons['1x'] );
+		$this->assertSame( '6.4', $results->requires );
+		$this->assertSame( '7.3', $results->requires_php );
+		$this->assertSame( '10.1', $results->tested );
+		$this->assertSame( 'Excerpt here', $results->sections['description'] );
+		$this->assertSame( 'Changelog here', $results->sections['changelog'] );
+	}
+
+	public function test_plugins_api_filter_api_failed() {
+		$this->class->init();
+
+		$args       = new \stdClass();
+		$args->slug = 'test-plugin';
+
+		$results = apply_filters( 'plugins_api', 'input123', 'hot_tags', $args );
+		$this->assertSame( 'input123', $results );
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 500 ],
+				'body'     => '',
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$results = apply_filters( 'plugins_api', new \stdClass(), 'plugin_information', $args );
+
+		$this->assertCount( 1, (array) $results ); // "plugin" key
+	}
+
+	public function test_plugins_api_filter_returns_false_when_api_unreachable() {
+		$this->class->init();
+
+		$args       = new \stdClass();
+		$args->slug = 'test-plugin';
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 500 ],
+				'body'     => '',
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		/* WP core passes $_data = false by default; a failed API leaves it false — assigning $_data->plugin on that bool fatals on PHP 8 */
+		$results = apply_filters( 'plugins_api', false, 'plugin_information', $args );
+
+		$this->assertFalse( $results );
+	}
+
+	public function test_plugins_api_filter_with_cache() {
+		$this->class->init();
+
+		$args       = new \stdClass();
+		$args->slug = 'test-plugin';
+
+		$results = apply_filters( 'plugins_api', 'input123', 'hot_tags', $args );
+		$this->assertSame( 'input123', $results );
+
+		$results = apply_filters( 'plugins_api', 'input123', 'plugin_information', new \stdClass() );
+		$this->assertSame( 'input123', $results );
+
+		update_option( $this->class->get_cache_key(), [
+			'timeout' => time() + 60,
+			'value'   => json_encode( [
+				'new_version'    => '0.1',
+				'stable_version' => '0.1',
+				'name'           => 'Test Plugin',
+				'slug'           => 'test-plugin',
+				'sections'       => [
+					'description' => 'Excerpt here',
+					'changelog'   => 'Changelog here',
+				],
+				'banners'        => [
+					'high' => 'https://store.com/banner-large.png',
+					'low'  => 'https://store.com/banner-small.png',
+				],
+				'icons'          => [
+					'1x' => 'https://store.com/icon-1.png',
+					'2x' => 'https://store.com/icon-2.png',
+				],
+				'requires'       => '6.4',
+				'requires_php'   => '7.3',
+				'tested'         => '10.1',
+			] ),
+		] );
+
+		$results = apply_filters( 'plugins_api', 'input123', 'plugin_information', $args );
+
+		$this->assertSame( '0.1', $results->version );
+		$this->assertSame( 'test-plugin/test-plugin.php', $results->plugin );
+		$this->assertSame( '0.1', $results->new_version );
+		$this->assertSame( '0.1', $results->stable_version );
+		$this->assertSame( 'Test Plugin', $results->name );
+		$this->assertSame( 'test-plugin', $results->slug );
+		$this->assertSame( 'https://store.com/banner-large.png', $results->banners['high'] );
+		$this->assertSame( 'https://store.com/icon-1.png', $results->icons['1x'] );
+		$this->assertSame( '6.4', $results->requires );
+		$this->assertSame( '7.3', $results->requires_php );
+		$this->assertSame( '10.1', $results->tested );
+		$this->assertSame( 'Excerpt here', $results->sections['description'] );
+		$this->assertSame( 'Changelog here', $results->sections['changelog'] );
+	}
+
+	public function test_show_update_notification_non_multisite() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped(
+				'Not running multisite tests'
+			);
+		}
+
+		$this->class->init();
+
+		ob_start();
+		do_action( 'after_plugin_row', 'test-plugin/test-plugin.php', [] );
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	public function test_show_update_notification_no_privs() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped(
+				'Not running multisite tests'
+			);
+		}
+
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$this->assertIsInt( $user_id );
+		wp_set_current_user( $user_id );
+
+		$this->class->init();
+
+		ob_start();
+		do_action( 'after_plugin_row', 'test-plugin/test-plugin.php', [ 'Name' => 'Test Plugin' ] );
+
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	public function test_show_update_notification_no_update() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped(
+				'Not running multisite tests'
+			);
+		}
+
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$this->assertIsInt( $user_id );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$this->class->init();
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'new_version'    => '0.1',
+					'stable_version' => '0.1',
+					'name'           => 'Test Plugin',
+					'slug'           => 'test-plugin',
+					'package'        => 'https://store.com/download/123',
+					'sections'       => [
+						'description' => 'Excerpt here',
+						'changelog'   => 'Changelog here',
+					],
+					'banners'        => [
+						'high' => 'https://store.com/banner-large.png',
+						'low'  => 'https://store.com/banner-small.png',
+					],
+					'icons'          => [
+						'1x' => 'https://store.com/icon-1.png',
+						'2x' => 'https://store.com/icon-2.png',
+					],
+					'requires'       => '6.4',
+					'requires_php'   => '7.3',
+					'tested'         => '10.1',
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		ob_start();
+		do_action( 'after_plugin_row', 'test-plugin/test-plugin.php', [] );
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	public function test_show_update_notification_with_update_no_privs() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped(
+				'Not running multisite tests'
+			);
+		}
+
+		update_site_option( 'menu_items', [ 'plugins' => true ] );
+
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$this->assertIsInt( $user_id );
+		wp_set_current_user( $user_id );
+
+		$this->class->init();
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'new_version'    => '0.2',
+					'stable_version' => '0.2',
+					'name'           => 'Test Plugin',
+					'slug'           => 'test-plugin',
+					'package'        => 'https://store.com/download/123',
+					'sections'       => [
+						'description' => 'Excerpt here',
+						'changelog'   => 'Changelog here',
+					],
+					'banners'        => [
+						'high' => 'https://store.com/banner-large.png',
+						'low'  => 'https://store.com/banner-small.png',
+					],
+					'icons'          => [
+						'1x' => 'https://store.com/icon-1.png',
+						'2x' => 'https://store.com/icon-2.png',
+					],
+					'requires'       => '6.4',
+					'requires_php'   => '7.3',
+					'tested'         => '10.1',
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		ob_start();
+		do_action( 'after_plugin_row', 'test-plugin/test-plugin.php', [ 'Name' => 'Test Plugin' ] );
+
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'There is a new version of Test Plugin available.', $output );
+		$this->assertStringContainsString( 'Contact your network administrator to install the update.', $output );
+	}
+
+	public function test_show_update_notification_with_update() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped(
+				'Not running multisite tests'
+			);
+		}
+
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$this->assertIsInt( $user_id );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$this->class->init();
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'new_version'    => '0.2',
+					'stable_version' => '0.2',
+					'name'           => 'Test Plugin',
+					'slug'           => 'test-plugin',
+					'package'        => 'https://store.com/download/123',
+					'sections'       => [
+						'description' => 'Excerpt here',
+						'changelog'   => 'Changelog here',
+					],
+					'banners'        => [
+						'high' => 'https://store.com/banner-large.png',
+						'low'  => 'https://store.com/banner-small.png',
+					],
+					'icons'          => [
+						'1x' => 'https://store.com/icon-1.png',
+						'2x' => 'https://store.com/icon-2.png',
+					],
+					'requires'       => '6.4',
+					'requires_php'   => '7.3',
+					'tested'         => '10.1',
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		ob_start();
+		do_action( 'after_plugin_row', 'test-plugin/test-plugin.php', [ 'Name' => 'Test Plugin' ] );
+
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'There is a new version of Test Plugin available.', $output );
+		$this->assertStringContainsString( 'View version 0.2 details', $output );
+		$this->assertStringContainsString( 'update now', $output );
+	}
+
+	public function test_show_update_notification_with_update_no_changelog() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped(
+				'Not running multisite tests'
+			);
+		}
+
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$this->assertIsInt( $user_id );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$this->class->init();
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'new_version'    => '0.2',
+					'stable_version' => '0.2',
+					'name'           => 'Test Plugin',
+					'slug'           => 'test-plugin',
+					'package'        => 'https://store.com/download/123',
+					'sections'       => [
+						'description' => 'Excerpt here',
+					],
+					'banners'        => [
+						'high' => 'https://store.com/banner-large.png',
+						'low'  => 'https://store.com/banner-small.png',
+					],
+					'icons'          => [
+						'1x' => 'https://store.com/icon-1.png',
+						'2x' => 'https://store.com/icon-2.png',
+					],
+					'requires'       => '6.4',
+					'requires_php'   => '7.3',
+					'tested'         => '10.1',
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		ob_start();
+		do_action( 'after_plugin_row', 'test-plugin/test-plugin.php', [ 'Name' => 'Test Plugin' ] );
+
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'There is a new version of Test Plugin available.', $output );
+		$this->assertStringNotContainsString( 'View version 0.2 details', $output );
+		$this->assertStringContainsString( 'Update now.', $output );
+	}
+
+	public function test_show_update_notification_with_update_with_changelog_no_package() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped(
+				'Not running multisite tests'
+			);
+		}
+
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$this->assertIsInt( $user_id );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$this->class->init();
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'new_version'    => '0.2',
+					'stable_version' => '0.2',
+					'name'           => 'Test Plugin',
+					'slug'           => 'test-plugin',
+					'sections'       => [
+						'description' => 'Excerpt here',
+						'changelog'   => 'Changelog here',
+					],
+					'banners'        => [
+						'high' => 'https://store.com/banner-large.png',
+						'low'  => 'https://store.com/banner-small.png',
+					],
+					'icons'          => [
+						'1x' => 'https://store.com/icon-1.png',
+						'2x' => 'https://store.com/icon-2.png',
+					],
+					'requires'       => '6.4',
+					'requires_php'   => '7.3',
+					'tested'         => '10.1',
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		ob_start();
+		do_action( 'after_plugin_row', 'test-plugin/test-plugin.php', [ 'Name' => 'Test Plugin' ] );
+
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'There is a new version of Test Plugin available.', $output );
+		$this->assertStringContainsString( 'View version 0.2 details', $output );
+		$this->assertStringNotContainsString( 'update now', $output );
+		$this->assertStringNotContainsString( 'Update now.', $output );
+	}
+
+	public function test_is_non_active_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not running multisite tests' );
+		}
+
+		$plugin          = 'test-plugin/test-plugin.php';
+		$active_plugins  = [];
+		$network_plugins = [];
+
+		/* Fake the per-site and network plugin lists without touching the shared options */
+		$site_filter = static function () use ( &$active_plugins ) {
+			return $active_plugins;
+		};
+		$network_filter = static function () use ( &$network_plugins ) {
+			return $network_plugins;
+		};
+		add_filter( 'pre_option_active_plugins', $site_filter );
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_filter );
+
+		$method = new \ReflectionMethod( $this->class, 'is_non_active_multisite' );
+		$method->setAccessible( true );
+
+		/* Active on the current site */
+		$active_plugins = [ $plugin ];
+		$this->assertFalse( $method->invoke( $this->class ) );
+
+		/* Network activated */
+		$active_plugins  = [];
+		$network_plugins = [ $plugin => time() ];
+		$this->assertFalse( $method->invoke( $this->class ) );
+
+		/* Not active anywhere -> non-active multisite */
+		$active_plugins  = [];
+		$network_plugins = [];
+		$this->assertTrue( $method->invoke( $this->class ) );
+
+		remove_filter( 'pre_option_active_plugins', $site_filter );
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_filter );
+	}
+
+	/*
+	 * The update check runs under WP-Cron and on the frontend, where wp-admin/includes/plugin.php (which defines
+	 * is_plugin_active()) isn't loaded. That fatal can't be reproduced here because the PHPUnit bootstrap always loads
+	 * the file, so guard the contract by scanning the source. php_strip_whitespace() drops comments so only real code
+	 * is matched.
+	 */
+	public function test_multisite_check_avoids_admin_only_plugin_functions() {
+		$source = php_strip_whitespace( ( new \ReflectionClass( EDD_SL_Plugin_Updater::class ) )->getFileName() );
+		$this->assertStringNotContainsString( 'is_plugin_active(', $source );
+	}
+
+	public function test_set_version_info_cache_promotes_active_licensed_package_to_network() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'valid' );
+
+		$licensed              = new \stdClass();
+		$licensed->new_version = '0.2';
+		$licensed->package     = 'https://store.com/download/licensed-123';
+		$this->class->set_version_info_cache( $licensed );
+
+		$cache = get_site_option( $this->class->get_network_cache_key() );
+		$this->assertNotEmpty( $cache );
+		$this->assertSame( 'https://store.com/download/licensed-123', json_decode( $cache['value'] )->package );
+	}
+
+	public function test_set_version_info_cache_skips_promotion_when_license_inactive() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'expired' );
+
+		/* The store can return a package even for an inactive license; that URL errors, so it must not be shared */
+		$response              = new \stdClass();
+		$response->new_version = '0.2';
+		$response->package     = 'https://store.com/download/inactive-123';
+		$this->class->set_version_info_cache( $response );
+
+		$this->assertFalse( get_site_option( $this->class->get_network_cache_key() ) );
+	}
+
+	public function test_get_repo_api_data_borrows_network_package_when_site_unlicensed() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* A licensed site elsewhere on the network has shared its package */
+		$network              = new \stdClass();
+		$network->new_version = '0.2';
+		$network->package     = 'https://store.com/download/licensed-123';
+		update_site_option(
+			$this->class->get_network_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( $network ) ]
+		);
+
+		/* This site sees the update but has no package of its own (missing/invalid license) */
+		$local              = new \stdClass();
+		$local->new_version = '0.2';
+		$local->package     = '';
+		$this->class->set_version_info_cache( $local );
+
+		$result = $this->class->get_repo_api_data();
+
+		$this->assertSame( '0.2', $result->new_version );
+		$this->assertSame( 'https://store.com/download/licensed-123', $result->package );
+	}
+
+	public function test_set_version_info_cache_network_ttl_outlives_per_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		delete_option( $this->class->get_cache_key() );
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'valid' );
+
+		$licensed              = new \stdClass();
+		$licensed->new_version = '0.2';
+		$licensed->package     = 'https://store.com/download/licensed-123';
+		$this->class->set_version_info_cache( $licensed );
+
+		$per_site = get_option( $this->class->get_cache_key() );
+		$network  = get_site_option( $this->class->get_network_cache_key() );
+
+		/* The shared package must survive quiet stretches between licensed-site checks, so it outlives the per-site cache */
+		$this->assertGreaterThan( $per_site['timeout'], $network['timeout'] );
+	}
+
+	public function test_get_repo_api_data_does_not_borrow_expired_network_package() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* A licensed site shared a package, but the network cache has since expired */
+		$network              = new \stdClass();
+		$network->new_version = '0.2';
+		$network->package     = 'https://store.com/download/licensed-123';
+		update_site_option(
+			$this->class->get_network_cache_key(),
+			[ 'timeout' => time() - 60, 'value' => wp_json_encode( $network ) ]
+		);
+
+		/* This site sees the update but has no package of its own (missing/invalid license) */
+		$local              = new \stdClass();
+		$local->new_version = '0.2';
+		$local->package     = '';
+		$this->class->set_version_info_cache( $local );
+
+		$result = $this->class->get_repo_api_data();
+
+		$this->assertSame( '0.2', $result->new_version );
+		$this->assertEmpty( $result->package );
+	}
+}

--- a/tests/phpunit/unit-tests/Helper/Log/Test_Redact_Processor.php
+++ b/tests/phpunit/unit-tests/Helper/Log/Test_Redact_Processor.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace GFPDF\Helper\Log;
+
+use GFPDF_Vendor\Monolog\DateTimeImmutable;
+use GFPDF_Vendor\Monolog\Handler\TestHandler;
+use GFPDF_Vendor\Monolog\Logger as MonoLogger;
+use WP_UnitTestCase;
+
+/**
+ * @group logger
+ */
+class Test_Redact_Processor extends WP_UnitTestCase {
+
+	protected function processor( $slug = 'test-plugin' ) {
+		return new Redact_Processor( $slug );
+	}
+
+	/**
+	 * Keyed context redaction replaces the whole value with the placeholder, case-insensitively.
+	 */
+	public function test_redacts_context_by_key() {
+		$context = $this->processor()->context(
+			[
+				'license'       => 'abc123',
+				'Authorization' => 'Bearer xyz',
+				'status'        => 'valid',
+			]
+		);
+
+		$this->assertSame( '[redacted]', $context['license'] );
+		$this->assertSame( '[redacted]', $context['Authorization'] );
+		$this->assertSame( 'valid', $context['status'] );
+	}
+
+	/**
+	 * Recurses into nested arrays so deeply-nested secrets (eg. HTTP response headers) are caught.
+	 */
+	public function test_redacts_nested_arrays() {
+		$context = $this->processor()->context(
+			[
+				'response' => [
+					'headers' => [
+						'authorization' => 'Bearer xyz',
+						'content-type'  => 'application/json',
+					],
+				],
+			]
+		);
+
+		$this->assertSame( '[redacted]', $context['response']['headers']['authorization'] );
+		$this->assertSame( 'application/json', $context['response']['headers']['content-type'] );
+	}
+
+	/**
+	 * Objects are cast to arrays and recursed so an object-valued context can't smuggle secrets past redaction.
+	 */
+	public function test_redacts_nested_objects() {
+		$obj          = new \stdClass();
+		$obj->token   = 'secret-value';
+		$obj->harmless = 'keep-me';
+
+		$context = $this->processor()->context( [ 'data' => $obj ] );
+
+		$this->assertSame( '[redacted]', $context['data']['token'] );
+		$this->assertSame( 'keep-me', $context['data']['harmless'] );
+	}
+
+	/**
+	 * A circular reference must not recurse forever — the depth cap replaces the value instead of exhausting the stack.
+	 */
+	public function test_caps_recursion_on_circular_references() {
+		$node        = new \stdClass();
+		$node->child = $node;
+
+		/* Without the depth cap this overflows the stack before returning; reaching the assertion proves it terminates. */
+		$result = $this->processor()->context( [ 'root' => $node ] );
+
+		/* Follow the self-referential chain; it must bottom out at the marker rather than loop. */
+		$cursor = $result['root'];
+		while ( is_array( $cursor ) ) {
+			$cursor = $cursor['child'];
+		}
+
+		$this->assertSame( '[redacted]', $cursor );
+	}
+
+	/**
+	 * Non-string keys and scalar values that don't match a deny-key pass through untouched.
+	 */
+	public function test_preserves_untargeted_values() {
+		$context = $this->processor()->context(
+			[
+				0        => 'positional',
+				'count'  => 5,
+				'enabled' => true,
+				'nothing' => null,
+			]
+		);
+
+		$this->assertSame( [ 0 => 'positional', 'count' => 5, 'enabled' => true, 'nothing' => null ], $context );
+	}
+
+	/**
+	 * The filter may add deny-keys.
+	 */
+	public function test_filter_adds_keys() {
+		add_filter(
+			'gfpdf_logging_redact_keys',
+			function ( $keys ) {
+				$keys[] = 'my_custom_secret';
+
+				return $keys;
+			}
+		);
+
+		$context = $this->processor()->context( [ 'my_custom_secret' => 'hunter2', 'license' => 'abc' ] );
+
+		$this->assertSame( '[redacted]', $context['my_custom_secret'] );
+		$this->assertSame( '[redacted]', $context['license'] );
+	}
+
+	/**
+	 * The filter may only add keys — returning an empty set can't weaken the defaults.
+	 */
+	public function test_filter_cannot_remove_defaults() {
+		add_filter(
+			'gfpdf_logging_redact_keys',
+			function () {
+				return [];
+			}
+		);
+
+		$context = $this->processor()->context( [ 'license' => 'abc123' ] );
+
+		$this->assertSame( '[redacted]', $context['license'] );
+	}
+
+	/**
+	 * A raw non-JSON API body stored under a benign key (eg. 'response'/'body') isn't caught by keyed redaction, so
+	 * its string value is run through the same message() pattern scrub — masking the signed URLs and echoed keys the
+	 * raw-body fallback path would otherwise leak.
+	 */
+	public function test_pattern_scrubs_context_string_leaves() {
+		$context = $this->processor()->context(
+			[
+				'response' => 'package https://store.com/download/file.zip?signature=deadbeef',
+				'body'     => 'license 098f6bcd4621d373cade4e832627b4f6 rejected',
+			]
+		);
+
+		$this->assertSame( 'package https://store.com/download/file.zip?', $context['response'] );
+		$this->assertSame( 'license [redacted] rejected', $context['body'] );
+	}
+
+	/**
+	 * set-cookie is a deny-key: a Set-Cookie header can carry a session secret.
+	 */
+	public function test_redacts_set_cookie_key() {
+		$context = $this->processor()->context( [ 'set-cookie' => 'session=abc; HttpOnly' ] );
+
+		$this->assertSame( '[redacted]', $context['set-cookie'] );
+	}
+
+	/**
+	 * @dataProvider provider_message_patterns
+	 */
+	public function test_redacts_message_patterns( $message, $expected ) {
+		$this->assertSame( $expected, $this->processor()->message( $message ) );
+	}
+
+	public function provider_message_patterns() {
+		return [
+			'hex license'  => [ 'License 098f6bcd4621d373cade4e832627b4f6 rejected', 'License [redacted] rejected' ],
+			'bearer token' => [ 'Auth failed: Bearer abc.def.ghi', 'Auth failed: [redacted]' ],
+			'google oauth' => [ 'token ya29.a0AfB_xyz-123 expired', 'token [redacted] expired' ],
+			'stripe key'   => [ 'using sk_4eC39HqLyjWDarjtT1zdp7dc', 'using [redacted]' ],
+			'plain text'   => [ 'nothing sensitive here', 'nothing sensitive here' ],
+		];
+	}
+
+	/**
+	 * Signed-link secrets live in the query string, so keep the path and drop everything after the ?.
+	 */
+	public function test_blanks_url_query_strings() {
+		$this->assertSame(
+			'Download failed https://example.com/file.zip?',
+			$this->processor()->message( 'Download failed https://example.com/file.zip?token=secret&exp=123' )
+		);
+	}
+
+	/**
+	 * A newline in message data must not be able to forge a second log line.
+	 */
+	public function test_collapses_line_breaks() {
+		$this->assertSame(
+			'line one line two line three',
+			$this->processor()->message( "line one\r\nline two\nline three" )
+		);
+	}
+
+	/**
+	 * Non-printable control characters are stripped before redaction.
+	 */
+	public function test_strips_control_characters() {
+		$this->assertSame( 'clean', $this->processor()->message( "cl\x00ea\x07n" ) );
+	}
+
+	/**
+	 * __invoke redacts both the message body and the context in a single pass.
+	 */
+	public function test_invoke_redacts_message_and_context() {
+		$record = [
+			'message'  => 'License 098f6bcd4621d373cade4e832627b4f6 rejected',
+			'context'  => [ 'license' => 'abc123', 'status' => 'invalid' ],
+			'level'    => MonoLogger::toMonologLevel( MonoLogger::WARNING ),
+			'channel'  => 'test',
+			'datetime' => new DateTimeImmutable( true ),
+			'extra'    => [],
+		];
+
+		$processed = ( $this->processor() )( $record );
+
+		$this->assertSame( 'License [redacted] rejected', $processed['message'] );
+		$this->assertSame( '[redacted]', $processed['context']['license'] );
+		$this->assertSame( 'invalid', $processed['context']['status'] );
+	}
+
+	/**
+	 * Works as a pushed Monolog processor end-to-end.
+	 */
+	public function test_works_as_monolog_processor() {
+		$handler = new TestHandler();
+		$logger  = new MonoLogger( 'Test', [ $handler ], [ $this->processor() ] );
+
+		$logger->info( 'Key 098f6bcd4621d373cade4e832627b4f6', [ 'token' => 'shhh' ] );
+
+		$this->assertTrue(
+			$handler->hasRecordThatPasses(
+				function ( $record ): bool {
+					return $record['message'] === 'Key [redacted]' && $record['context']['token'] === '[redacted]';
+				},
+				MonoLogger::INFO
+			)
+		);
+	}
+}

--- a/tests/phpunit/unit-tests/Model/Test_Model_Settings.php
+++ b/tests/phpunit/unit-tests/Model/Test_Model_Settings.php
@@ -1,0 +1,639 @@
+<?php
+declare( strict_types=1 );
+
+namespace GFPDF\Model;
+
+use GFPDF\Helper\Helper_Abstract_Addon;
+use GFPDF\Helper\Helper_Logger;
+use GFPDF\Helper\Helper_Notices;
+use GFPDF\Helper\Helper_Singleton;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2025, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @package GFPDF\Model
+ *
+ * @group   model
+ * @group   settings
+ */
+class Test_Model_Settings extends WP_UnitTestCase {
+
+	/**
+	 * @var Model_Settings
+	 */
+	protected $model;
+
+	/**
+	 * @var Helper_Abstract_Addon
+	 */
+	protected $addon;
+
+	/**
+	 * @var Helper_Abstract_Addon
+	 */
+	protected $addon1;
+
+	/**
+	 * The WP Unit Test Set up function
+	 */
+	public function set_up() {
+		global $gfpdf;
+
+		parent::set_up();
+
+		$this->model = new Model_Settings( $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->templates );
+
+		$this->addon = new ModelSettingsAddon(
+			'my-custom-plugin',
+			'My Custom Plugin',
+			'Gravity PDF',
+			'1.0',
+			'/path/to/plugin/file.php',
+			\GPDFAPI::get_data_class(),
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'my-custom-plugin', 'My Custom Plugin' ),
+			new Helper_Notices()
+		);
+
+		$this->addon->set_edd_download_id( 5 );
+
+		$this->addon1 = new ModelSettingsAddon(
+			'my-other-plugin',
+			'Other Plugin',
+			'Gravity PDF',
+			'1.2',
+			'/path/to/plugin/file.php',
+			\GPDFAPI::get_data_class(),
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'my-other-plugin', 'My Custom Plugin' ),
+			new Helper_Notices()
+		);
+
+		$this->addon1->set_edd_download_id( 10 );
+
+		$this->addon->init();
+		$this->addon1->init();
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		$data        = \GPDFAPI::get_data_class();
+		$data->addon = [];
+
+		/* Creating a subsite dirties process globals WP_UnitTestCase won't roll back; reset so later tests aren't polluted */
+		global $wp_settings_errors, $wp_rewrite;
+		$wp_settings_errors = [];
+		$wp_rewrite->init();
+	}
+
+	public function test_license_bulk_get_version_api_params_skipped() {
+		/* Check skipped when not initialized */
+		$data          = \GPDFAPI::get_data_class();
+		$data->updater = null;
+		$data->addon   = [];
+		$this->assertTrue( $this->model->licensing_bulk_get_version_api_params( true ) );
+	}
+
+	public function test_license_bulk_get_version_api_params_missing_updater() {
+		/* Non-canonical build (updater key never registered): bulk the add-ons only, without throwing from Helper_Data::__get() */
+		do_action( 'init' );
+
+		$data = \GPDFAPI::get_data_class();
+		unset( $data->updater );
+
+		$this->assertNotEmpty( $data->addon );
+
+		$params = $this->model->licensing_bulk_get_version_api_params( [] );
+		$this->assertArrayHasKey( 'edd_action', $params );
+		$this->assertCount( count( $data->addon ), $params['products'] );
+	}
+
+	public function test_license_bulk_get_version_api_params_skips_uninitialized_addon() {
+		$this->setExpectedIncorrectUsage( 'GFPDF\Helper\Helper_Abstract_Addon::get_plugin_updater' );
+
+		do_action( 'init' );
+
+		/* Register an add-on whose updater was never initialized — get_plugin_updater() returns null */
+		$data          = \GPDFAPI::get_data_class();
+		$uninitialized = new ModelSettingsAddon(
+			'uninitialized-plugin',
+			'Uninitialized Plugin',
+			'Gravity PDF',
+			'1.0',
+			'/path/to/plugin/file.php',
+			\GPDFAPI::get_data_class(),
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'uninitialized-plugin', 'Uninitialized Plugin' ),
+			new Helper_Notices()
+		);
+		$data->add_addon( $uninitialized );
+
+		/* Core + the two initialized add-ons; the uninitialized one is skipped rather than fataling */
+		$params = $this->model->licensing_bulk_get_version_api_params( [] );
+		$this->assertCount( 3, $params['products'] );
+	}
+
+	public function test_license_bulk_get_version_api_params_core_plugin() {
+		$data        = \GPDFAPI::get_data_class();
+		$data->addon = [];
+		do_action( 'init' );
+
+		$params = $this->model->licensing_bulk_get_version_api_params( [] );
+		$this->assertArrayHasKey( 'edd_action', $params );
+		$this->assertArrayHasKey( 'products', $params );
+		$this->assertCount( 1, $params['products'] );
+		$this->assertArrayHasKey( 'license', $params['products'][0] );
+		$this->assertArrayHasKey( 'item_id', $params['products'][0] );
+		$this->assertArrayHasKey( 'url', $params['products'][0] );
+	}
+
+	public function test_licensing_bulk_get_version_api_response() {
+		do_action( 'init' );
+
+		$params = $this->model->licensing_bulk_get_version_api_params( [] );
+		$this->assertArrayHasKey( 'edd_action', $params );
+		$this->assertArrayHasKey( 'products', $params );
+		$this->assertCount( 3, $params['products'] );
+		$this->assertArrayHasKey( 'license', $params['products'][0] );
+		$this->assertArrayHasKey( 'item_id', $params['products'][0] );
+		$this->assertArrayHasKey( 'url', $params['products'][0] );
+		$this->assertArrayHasKey( 'license', $params['products'][1] );
+		$this->assertArrayHasKey( 'item_id', $params['products'][1] );
+		$this->assertArrayHasKey( 'url', $params['products'][1] );
+		$this->assertArrayHasKey( 'license', $params['products'][2] );
+		$this->assertArrayHasKey( 'item_id', $params['products'][2] );
+		$this->assertArrayHasKey( 'url', $params['products'][2] );
+	}
+
+	public function test_licensing_bulk_get_version_api_response_maps_by_folder_slug() {
+		$data          = \GPDFAPI::get_data_class();
+		$data->addon   = [];
+		$data->updater = null;
+
+		/*
+		 * Registered slug deliberately differs from the plugin-folder basename (e.g. a user-renamed folder). The API
+		 * echoes back the folder slug the updater sent, not the registered slug — the exact mismatch L8 dropped.
+		 */
+		$initiator = new ModelSettingsAddon(
+			'registered-initiator',
+			'Initiator',
+			'Gravity PDF',
+			'1.0',
+			'/plugins/folder-initiator/main.php',
+			$data,
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'registered-initiator', 'Initiator' ),
+			new Helper_Notices()
+		);
+
+		$sibling = new ModelSettingsAddon(
+			'registered-sibling',
+			'Sibling',
+			'Gravity PDF',
+			'1.0',
+			'/plugins/folder-sibling/main.php',
+			$data,
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'registered-sibling', 'Sibling' ),
+			new Helper_Notices()
+		);
+
+		$initiator->init();
+		$sibling->init();
+		do_action( 'init' );
+
+		$initiator_updater = $data->addon['registered-initiator']->get_plugin_updater();
+		$sibling_updater   = $data->addon['registered-sibling']->get_plugin_updater();
+
+		/* The sibling add-on is an active plugin in reality; mark it so the multisite cache gate doesn't skip its caching */
+		update_option( 'active_plugins', [ plugin_basename( $sibling_updater->get_plugin_file() ) ] );
+
+		/* The bulk response is a list of product objects identified only by the folder slug echoed back */
+		$response = [
+			(object) [ 'slug' => 'folder-initiator', 'new_version' => '9.9.9', 'stable_version' => '9.9.9' ],
+			(object) [ 'slug' => 'folder-sibling', 'new_version' => '8.8.8', 'stable_version' => '8.8.8' ],
+		];
+
+		/* Fire the response filter as the initiator's own updater would — its plugin file identifies the initiator */
+		$initial = $this->model->licensing_bulk_get_version_api_response( $response, [], $initiator_updater->get_plugin_file() );
+
+		/* The initiator's own product is handed back for its normal caching path */
+		$this->assertIsObject( $initial );
+		$this->assertSame( 'folder-initiator', $initial->slug );
+		$this->assertSame( '9.9.9', $initial->new_version );
+
+		/* The sibling was linked by its folder slug (not its registered slug) and cached — this is what L8 dropped */
+		$cached = $sibling_updater->get_cached_version_info();
+		$this->assertIsObject( $cached );
+		$this->assertSame( '8.8.8', $cached->new_version );
+	}
+
+	public function test_licensing_bulk_license_check_success() {
+		do_action( 'init' );
+
+		$data = \GPDFAPI::get_data_class();
+		foreach ( $data->addon as $addon ) {
+			$addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+		}
+
+		/* Do a good request */
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					[
+						'item_id' => 5,
+						'license' => 'invalid',
+					],
+
+					[
+						'item_id' => 10,
+						'license' => 'valid',
+					],
+				] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->assertTrue( $this->model->licensing_bulk_license_check() );
+		$this->assertSame( 'invalid', $this->addon->get_license_status() );
+		$this->assertSame( 'valid', $this->addon1->get_license_status() );
+
+		remove_filter( 'pre_http_request', $api_response );
+	}
+
+	public function test_licensing_bulk_license_check_no_addons() {
+		$data        = \GPDFAPI::get_data_class();
+		$data->addon = [];
+
+		$this->assertFalse( $this->model->licensing_bulk_license_check() );
+	}
+
+	public function test_licensing_bulk_license_check_bad_status_code() {
+		do_action( 'init' );
+
+		wp_clear_scheduled_hook( 'gfpdf_bulk_license_check' );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+
+		$data = \GPDFAPI::get_data_class();
+		foreach ( $data->addon as $addon ) {
+			$addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+		}
+
+		/* Do a bad request */
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 401 ],
+				'body'     => '',
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->assertFalse( $this->model->licensing_bulk_license_check() );
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+
+		remove_filter( 'pre_http_request', $api_response );
+	}
+
+	public function test_licensing_bulk_license_check_bad_response() {
+		do_action( 'init' );
+
+		wp_clear_scheduled_hook( 'gfpdf_bulk_license_check' );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+
+		$data = \GPDFAPI::get_data_class();
+		foreach ( $data->addon as $addon ) {
+			$addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+		}
+
+		/* Do a malformed request */
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => '<!DOCTYPE />',
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->assertFalse( $this->model->licensing_bulk_license_check() );
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+
+		remove_filter( 'pre_http_request', $api_response );
+	}
+
+	public function test_licensing_bulk_license_check_skipped_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		do_action( 'init' );
+
+		$data = \GPDFAPI::get_data_class();
+		foreach ( $data->addon as $addon ) {
+			/* In-memory keys + updaters so the check would otherwise build params and POST — proving the gate is what stops it */
+			$addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+		}
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP in tests' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		/* Pose as a secondary site with Gravity PDF network-activated; only a network option is read, so no real blog is needed */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		$this->assertFalse( $this->model->licensing_bulk_license_check() );
+		$this->assertFalse( $http_called );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		remove_filter( 'pre_http_request', $spy );
+	}
+
+	public function test_schedule_network_update_check_uses_single_event_synced_to_wp_update_plugins() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'wp_update_plugins' );
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		$wp_check = time() + 3 * HOUR_IN_SECONDS;
+		wp_schedule_event( $wp_check, 'twicedaily', 'wp_update_plugins' );
+
+		$this->model->schedule_network_update_check();
+
+		/* One minute after the primary site's plugin update check */
+		$this->assertSame( $wp_check + 60, wp_next_scheduled( 'gfpdf_network_update_check' ) );
+
+		/* A one-off event (wp_get_schedule() is false for single events) so the offset is recomputed each run */
+		$this->assertFalse( wp_get_schedule( 'gfpdf_network_update_check' ) );
+	}
+
+	public function test_schedule_network_update_check_falls_back_when_wp_update_plugins_unscheduled() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'wp_update_plugins' );
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		$before = time();
+		$this->model->schedule_network_update_check();
+
+		/* Falls back to ~12 hours out so the self-rescheduling chain survives a missing primary-site check */
+		$this->assertGreaterThanOrEqual( $before + 12 * HOUR_IN_SECONDS, wp_next_scheduled( 'gfpdf_network_update_check' ) );
+		$this->assertFalse( wp_get_schedule( 'gfpdf_network_update_check' ) );
+	}
+
+	public function test_schedule_network_update_check_floors_overdue_wp_update_plugins_to_future() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'wp_update_plugins' );
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		/* wp_update_plugins only advances when the primary site runs cron, so it reports a PAST time when that site is
+		   quiet. Left as-is the offset would be in the past and the self-rescheduling event would fire every cron spawn. */
+		wp_schedule_event( time() - HOUR_IN_SECONDS, 'twicedaily', 'wp_update_plugins' );
+
+		$before = time();
+		$this->model->schedule_network_update_check();
+
+		/* Floored to the future rather than immediately due */
+		$this->assertGreaterThan( $before, wp_next_scheduled( 'gfpdf_network_update_check' ) );
+	}
+
+	public function test_run_network_update_check_reinjects_transient_in_subsite_context() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* A per-site-activated subsite (not network-activated) is the path this method targets */
+		$blog_id = $this->factory()->blog->create();
+		switch_to_blog( $blog_id );
+
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		/* Isolate the transient round-trip to our own spy: real listeners (Gravity Forms' check_update on the read
+		   filter, stale add-on updaters) would otherwise run their own version checks and hit the network. We only
+		   care which blog the re-injection fires in. */
+		remove_all_filters( 'site_transient_update_plugins' );
+		remove_all_filters( 'transient_update_plugins' );
+		remove_all_filters( 'pre_set_site_transient_update_plugins' );
+
+		/* Seed a non-false update_plugins transient so the round-trip has something to re-inject */
+		set_site_transient( 'update_plugins', (object) [ 'checked' => [] ] );
+
+		/* Record the blog context in which check_update() (pre_set_site_transient_update_plugins) fires */
+		$fired_on_blog = null;
+		$spy           = function ( $value ) use ( &$fired_on_blog ) {
+			$fired_on_blog = get_current_blog_id();
+			return $value;
+		};
+		add_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		$this->model->run_network_update_check();
+
+		remove_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		/* The re-injection must fire in the subsite context (where the per-site add-on's cache lives), not the main
+		   site — switching to the main site would miss that cache and force an uncached API request per updater (H1) */
+		$this->assertSame( $blog_id, $fired_on_blog );
+		$this->assertNotSame( get_main_site_id(), $fired_on_blog );
+
+		/* And it re-arms the self-rescheduling event into the future (H2) */
+		$this->assertGreaterThan( time(), wp_next_scheduled( 'gfpdf_network_update_check' ) );
+
+		restore_current_blog();
+	}
+
+	public function test_run_network_update_check_skips_on_main_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+		remove_all_filters( 'pre_set_site_transient_update_plugins' );
+		set_site_transient( 'update_plugins', (object) [ 'checked' => [] ] );
+
+		$fired = false;
+		$spy   = function ( $value ) use ( &$fired ) {
+			$fired = true;
+			return $value;
+		};
+		add_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		/* The main site receives update checks through the normal flow, so the forced check is skipped */
+		$this->model->run_network_update_check();
+
+		remove_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		$this->assertFalse( $fired );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_network_update_check' ) );
+	}
+
+	public function test_run_network_update_check_skips_on_network_activated_secondary_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		/* Network-activated secondary sites are served by the normal flow, so the forced check must not re-arm here */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		remove_all_filters( 'pre_set_site_transient_update_plugins' );
+		set_site_transient( 'update_plugins', (object) [ 'checked' => [] ] );
+
+		$fired = false;
+		$spy   = function ( $value ) use ( &$fired ) {
+			$fired = true;
+			return $value;
+		};
+		add_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		$this->model->run_network_update_check();
+
+		remove_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		$this->assertFalse( $fired );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_network_update_check' ) );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+	}
+
+	public function test_maybe_active_licenses_ignores_submitted_value_for_constant_managed_addon() {
+		$slug = $this->addon->get_slug();
+
+		/* A hardcoded constant key makes the add-on admin-managed: the submitted value must be ignored and the
+		   authoritative constant value persisted, without burning an activation against the key */
+		add_filter( 'gfpdf_addon_hardcoded_license_key', static function () { return 'CONSTANT-KEY'; } );
+		$this->addon->update_license_info( [ 'license' => 'CONSTANT-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		$input = $this->model->maybe_active_licenses(
+			[
+				"license_$slug"           => 'forged-attacker-key',
+				"license_{$slug}_status"  => 'active',
+				"license_{$slug}_message" => 'forged',
+			]
+		);
+
+		remove_filter( 'pre_http_request', $spy );
+		remove_all_filters( 'gfpdf_addon_hardcoded_license_key' );
+
+		$this->assertFalse( $http_called );
+		$this->assertSame( 'CONSTANT-KEY', $input[ "license_$slug" ] );
+		$this->assertSame( 'active', $input[ "license_{$slug}_status" ] );
+	}
+
+	public function test_maybe_active_licenses_ignores_submitted_value_for_auto_activated_addon() {
+		$slug = $this->addon->get_slug();
+
+		/* Give the sibling a real Access Pass license, then auto-activate our add-on off it (its EDD id is in the pass) */
+		$this->addon1->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid', 'products' => [ 5 ] ] ) ];
+		$this->addon->maybe_auto_activate_license( $response, $this->addon1, false );
+		$this->assertTrue( $this->addon->is_license_admin_managed() );
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		$input = $this->model->maybe_active_licenses(
+			[
+				"license_$slug"           => 'forged-attacker-key',
+				"license_{$slug}_status"  => 'active',
+				"license_{$slug}_message" => 'forged',
+			]
+		);
+
+		remove_filter( 'pre_http_request', $spy );
+
+		/* The auto-activated (admin-managed) key is authoritative — no activation POST, forged value overwritten */
+		$this->assertFalse( $http_called );
+		$this->assertSame( 'AP-KEY', $input[ "license_$slug" ] );
+		$this->assertSame( 'active', $input[ "license_{$slug}_status" ] );
+	}
+
+	public function test_maybe_active_licenses_clears_in_memory_status_on_empty_key() {
+		$slug = $this->addon->get_slug();
+
+		$this->addon->update_license_info( [ 'license' => 'old-key', 'status' => 'active', 'message' => 'ok' ] );
+
+		$this->model->maybe_active_licenses(
+			[
+				"license_$slug"          => '   ',
+				"license_{$slug}_status" => 'active',
+			]
+		);
+
+		/* Clearing the field must sync the cached model, not just the persisted array (L5) */
+		$this->assertSame( '', $this->addon->get_license_status() );
+		$this->assertSame( '', $this->addon->get_license_key() );
+	}
+
+	public function test_licensing_bulk_license_check_skips_malformed_and_unknown_items() {
+		do_action( 'init' );
+
+		$data = \GPDFAPI::get_data_class();
+		foreach ( $data->addon as $addon ) {
+			$addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+		}
+
+		/* item 5 = our add-on (valid → expired); the other two rows are malformed / unknown and must be skipped
+		   without fataling, while the valid row still applies */
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					[ 'item_id' => 5, 'license' => 'expired' ],
+					[ 'license' => 'valid' ],                       // missing item_id
+					[ 'item_id' => 99999, 'license' => 'valid' ],   // unknown add-on
+				] ),
+			];
+		};
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->assertTrue( $this->model->licensing_bulk_license_check() );
+		$this->assertSame( 'expired', $this->addon->get_license_status() );
+
+		remove_filter( 'pre_http_request', $api_response );
+	}
+
+}
+
+class ModelSettingsAddon extends Helper_Abstract_Addon {
+}

--- a/tests/phpunit/unit-tests/test-addon.php
+++ b/tests/phpunit/unit-tests/test-addon.php
@@ -87,6 +87,15 @@ class Test_Addon extends WP_UnitTestCase {
 		remove_all_actions( 'init' );
 	}
 
+	public function tear_down() {
+		parent::tear_down();
+
+		$data = \GPDFAPI::get_data_class();
+		$data->addon = [];
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	/**
 	 * @since 4.2
 	 */
@@ -134,8 +143,6 @@ class Test_Addon extends WP_UnitTestCase {
 		$this->addon->init( [ $sub_addon ] );
 
 		$this->assertTrue( $sub_addon->run );
-		$this->assertEquals( 10, has_action( 'init', [ $this->addon, 'plugin_updater' ] ) );
-		$this->assertEquals( 10, has_action( 'admin_init', [ $this->addon, 'maybe_schedule_license_check' ] ) );
 		$this->assertEquals(
 			10,
 			has_action(
@@ -185,6 +192,49 @@ class Test_Addon extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'license_' . $this->addon->get_slug(), $settings );
 		$this->assertArrayNotHasKey( 'license_' . $this->addon->get_slug() . '_status', $settings );
 		$this->assertArrayNotHasKey( 'license_' . $this->addon->get_slug() . '_message', $settings );
+	}
+
+	public function test_get_license_key_from_constant() {
+		$this->assertFalse( $this->addon->get_license_key_from_constant() );
+		$this->assertFalse( $this->addon2->get_license_key_from_constant() );
+
+		add_filter( 'gfpdf_addon_hardcoded_license_key', function ( $key ) {
+			return 'abc123';
+		} );
+
+		$this->assertSame( 'abc123', $this->addon->get_license_key_from_constant() );
+		$this->assertSame( 'abc123', $this->addon2->get_license_key_from_constant() );
+
+		remove_all_filters( 'gfpdf_addon_hardcoded_license_key' );
+
+		add_filter( 'gfpdf_addon_hardcoded_license_key', function ( $key ) {
+			return [ 'my-custom-plugin' => 'abc456', 'my-custom-plugin2' => 'xyz987' ];
+		} );
+
+		$this->assertSame( 'abc456', $this->addon->get_license_key_from_constant() );
+		$this->assertSame( 'xyz987', $this->addon2->get_license_key_from_constant() );
+	}
+
+	public function test_license_constant_overrides_database() {
+		$this->addon->update_license_info(
+			[
+				'license' => 'my key',
+				'status'  => 'active',
+				'message' => 'Success!',
+			]
+		);
+
+		$license = $this->addon->get_license_info();
+
+		$this->assertSame( 'my key', $license['license'] );
+
+		add_filter( 'gfpdf_addon_hardcoded_license_key', function ( $key ) {
+			return 'abc123';
+		} );
+
+		$license = $this->addon->get_license_info();
+
+		$this->assertSame( 'abc123', $license['license'] );
 	}
 
 	/*
@@ -251,9 +301,10 @@ class Test_Addon extends WP_UnitTestCase {
 	 * @since 4.2
 	 */
 	public function test_schedule_license_check() {
+		/* Test a bad request */
 		$api_response = function() {
 			return [
-				'response' => [ 'code' => 201 ],
+				'response' => [ 'code' => 301 ],
 			];
 		};
 
@@ -262,7 +313,7 @@ class Test_Addon extends WP_UnitTestCase {
 		$this->addon->update_license_info( [
 			'license' => '12345',
 			'status'  => 'active',
-			'message' => '',
+			'message' => 'Your license key is valid!',
 		] );
 
 		$this->assertFalse( wp_next_scheduled( 'gfpdf_' . $this->addon->get_slug() . '_license_check' ) );
@@ -271,6 +322,22 @@ class Test_Addon extends WP_UnitTestCase {
 
 		remove_filter( 'pre_http_request', $api_response );
 
+		/* Do a good request */
+		$api_response = function() {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [ 'license' => 'valid' ] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->assertTrue( $this->addon->schedule_license_check() );
+		$this->assertSame(  'Your license key is valid!', $this->addon->get_license_message() );
+
+		remove_filter( 'pre_http_request', $api_response );
+
+		/* Test with a revoked license */
 		$api_response = function() {
 			return [
 				'response' => [ 'code' => 200 ],
@@ -280,10 +347,42 @@ class Test_Addon extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', $api_response );
 
-		$this->assertTrue( $this->addon->schedule_license_check() );
+		$this->assertFalse( $this->addon->schedule_license_check() );
 		$this->assertStringContainsString( 'This license key has been cancelled', $this->addon->get_license_message() );
 
 		remove_filter( 'pre_http_request', $api_response );
+		$this->addon->delete_license_info();
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_schedule_license_check_skipped_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* A valid key so the check would otherwise build params and POST — proving the gate is what stops it */
+		$this->addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP in tests' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		/* Pose as a secondary site with Gravity PDF network-activated; only a network option is read, so no real blog is needed */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		$this->assertFalse( $this->addon->schedule_license_check() );
+		$this->assertFalse( $http_called );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		remove_filter( 'pre_http_request', $spy );
 		$this->addon->delete_license_info();
 	}
 
@@ -376,6 +475,267 @@ class Test_Addon extends WP_UnitTestCase {
 		/* Check we can access the saved settings without using the prefix */
 		$this->assertSame( 'Use Fallback', $this->addon2->get_addon_setting_value( 'addon_field', 'Use Fallback' ) );
 		$this->assertSame( 'Loading1', $this->addon2->get_addon_setting_value( 'string_loading_title' ) );
+	}
+
+	public function test_central_plugin_updater() {
+		$this->setExpectedIncorrectUsage( 'GFPDF\Helper\Helper_Abstract_Addon::get_plugin_updater' );
+		$this->assertNull( $this->addon->get_plugin_updater() );
+
+		$this->addon->init();
+		do_action( 'init' );
+		$this->assertNotNull( $this->addon->get_plugin_updater() );
+	}
+
+	public function test_auto_activate_license_constant() {
+		/* Set admin screen */
+		set_current_screen( 'index.php' );
+
+		$this->assertEmpty( $this->addon->get_license_status() );
+
+		add_filter( 'gfpdf_addon_hardcoded_license_key', function ( $key ) {
+			return 'abc123';
+		} );
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode(
+					[
+						'error' => 'missing',
+					]
+				),
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->addon->init();
+		do_action( 'init' );
+
+		$this->assertNotEmpty( $this->addon->get_license_key() );
+		$this->assertNotEmpty( $this->addon->get_license_status() );
+	}
+
+	public function test_hardcoded_license_retries_after_failed_activation() {
+		set_current_screen( 'index.php' );
+
+		add_filter( 'gfpdf_addon_hardcoded_license_key', function () {
+			return 'abc123';
+		} );
+
+		$http_calls = 0;
+		$ok         = false;
+		$api        = function () use ( &$http_calls, &$ok ) {
+			$http_calls++;
+
+			return $ok
+				? [ 'response' => [ 'code' => 200 ], 'body' => json_encode( [ 'license' => 'valid' ] ) ]
+				: new \WP_Error( 'down', 'API unreachable' );
+		};
+
+		add_filter( 'pre_http_request', $api );
+
+		$this->addon->init();
+		$backoff = 'gfpdf_license_activation_' . $this->addon->get_slug();
+
+		/* First attempt: the API is down, so activation fails and isn't stored as active */
+		do_action( 'init' );
+		$this->assertSame( 1, $http_calls );
+		$this->assertNotContains( $this->addon->get_license_status(), [ 'active', 'valid' ] );
+
+		/* Backoff blocks an immediate retry so a bad/unreachable key doesn't POST on every request */
+		do_action( 'init' );
+		$this->assertSame( 1, $http_calls );
+
+		/* Once the backoff elapses the activation is retried — the old key-equality guard never retried */
+		delete_transient( $backoff );
+		$ok = true;
+		do_action( 'init' );
+		$this->assertSame( 2, $http_calls );
+		$this->assertSame( 'valid', $this->addon->get_license_status() );
+
+		remove_all_filters( 'gfpdf_addon_hardcoded_license_key' );
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_hardcoded_license_activation_skipped_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		set_current_screen( 'index.php' );
+
+		add_filter( 'gfpdf_addon_hardcoded_license_key', static function () {
+			return 'abc123';
+		} );
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP in tests' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		/* Pose as a secondary site with Gravity PDF network-activated; the primary handles activation */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		$this->addon->init();
+		do_action( 'init' );
+
+		$this->assertFalse( $http_called );
+		$this->assertEmpty( $this->addon->get_license_status() );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		remove_filter( 'pre_http_request', $spy );
+		remove_all_filters( 'gfpdf_addon_hardcoded_license_key' );
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_license_registration_notice_hidden_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* Preconditions that would otherwise render the notice: a known EDD ID and an unregistered license */
+		$this->addon->set_edd_download_id( '123' );
+
+		/* Primary site shows the "Register your copy" prompt */
+		ob_start();
+		$this->addon->license_registration();
+		$this->assertStringContainsString( 'Register your copy', ob_get_clean() );
+
+		/* Pose as a secondary site with Gravity PDF network-activated; the primary handles licensing */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		ob_start();
+		$this->addon->license_registration();
+		$this->assertEmpty( ob_get_clean() );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+	}
+
+	/**
+	 * An Access Pass activation on one add-on shares the license with every sibling whose EDD id is in the pass.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_activate_license_shares_across_access_pass() {
+		$this->addon->set_edd_download_id( 10 );
+		$this->addon2->set_edd_download_id( 20 );
+
+		$this->addon->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid', 'products' => [ 10, 20 ] ] ) ];
+
+		$this->assertFalse( $this->addon2->has_license_auto_activated() );
+		$this->addon2->maybe_auto_activate_license( $response, $this->addon, false );
+
+		$this->assertTrue( $this->addon2->has_license_auto_activated() );
+		$this->assertTrue( $this->addon2->is_license_admin_managed() );
+		$this->assertSame( 'AP-KEY', $this->addon2->get_license_key() );
+		$this->assertSame( 'active', $this->addon2->get_license_status() );
+
+		$this->addon->delete_license_info();
+		$this->addon2->delete_license_info();
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_activate_license_skips_addon_not_in_access_pass() {
+		$this->addon->set_edd_download_id( 10 );
+		$this->addon2->set_edd_download_id( 99 );
+
+		$this->addon->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		/* addon2's EDD id (99) isn't among the pass's products, so it must not adopt the license */
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid', 'products' => [ 10, 20 ] ] ) ];
+		$this->addon2->maybe_auto_activate_license( $response, $this->addon, false );
+
+		$this->assertFalse( $this->addon2->has_license_auto_activated() );
+		$this->assertEmpty( $this->addon2->get_license_status() );
+
+		$this->addon->delete_license_info();
+	}
+
+	/**
+	 * A plain (non-Access-Pass) activation response has no products array, so nothing is shared.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_activate_license_ignores_non_access_pass_response() {
+		$this->addon->set_edd_download_id( 10 );
+		$this->addon2->set_edd_download_id( 20 );
+		$this->addon->update_license_info( [ 'license' => 'KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid' ] ) ];
+		$this->addon2->maybe_auto_activate_license( $response, $this->addon, false );
+
+		$this->assertFalse( $this->addon2->has_license_auto_activated() );
+
+		$this->addon->delete_license_info();
+	}
+
+	/**
+	 * The gfpdf_addon_post_license_activation action is public: a third-party do_action() may pass a non-addon second
+	 * arg (or omit the third), which must not fatal.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_activate_license_ignores_non_addon_arg() {
+		$this->addon->set_edd_download_id( 10 );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid', 'products' => [ 10 ] ] ) ];
+		$this->addon->maybe_auto_activate_license( $response, 'not-an-addon' );
+
+		$this->assertFalse( $this->addon->has_license_auto_activated() );
+	}
+
+	/**
+	 * An Access Pass deactivation on one add-on cascades to every sibling in the pass.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_deactivate_license_shares_across_access_pass() {
+		$this->addon->set_edd_download_id( 10 );
+		$this->addon2->set_edd_download_id( 20 );
+
+		$this->addon2->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		/* The initiator has already wiped its own license before firing the action */
+		$this->addon->delete_license_info();
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'deactivated', 'products' => [ 10, 20 ] ] ) ];
+
+		$this->assertFalse( $this->addon2->has_license_auto_deactivated() );
+		$this->addon2->maybe_auto_deactivate_license( $response, $this->addon );
+
+		$this->assertTrue( $this->addon2->has_license_auto_deactivated() );
+		$this->assertEmpty( $this->addon2->get_license_status() );
+
+		$this->addon2->delete_license_info();
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_deactivate_license_ignores_non_addon_arg() {
+		$this->addon->set_edd_download_id( 10 );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'deactivated', 'products' => [ 10 ] ] ) ];
+		$this->addon->maybe_auto_deactivate_license( $response, 'not-an-addon' );
+
+		$this->assertFalse( $this->addon->has_license_auto_deactivated() );
 	}
 }
 

--- a/tests/phpunit/unit-tests/test-ajax.php
+++ b/tests/phpunit/unit-tests/test-ajax.php
@@ -3,6 +3,10 @@
 namespace GFPDF\Tests;
 
 use GFAPI;
+use GFPDF\Helper\Helper_Abstract_Addon;
+use GFPDF\Helper\Helper_Logger;
+use GFPDF\Helper\Helper_Notices;
+use GFPDF\Helper\Helper_Singleton;
 use WP_Ajax_UnitTestCase;
 use WPAjaxDieContinueException;
 use WPAjaxDieStopException;
@@ -501,6 +505,95 @@ class Test_PDF_Ajax extends WP_Ajax_UnitTestCase {
 		$this->assertStringContainsString( 'An unknown error occurred', json_decode( $this->_last_response )->error );
 	}
 
+	public function test_ajax_process_license_deactivation_shares_access_pass_siblings() {
+		global $gfpdf;
+
+		$this->_setRole( 'administrator' );
+
+		$master  = $this->register_deactivation_addon( 'master-plugin', 'Master', '/master/file.php', 5 );
+		$sibling = $this->register_deactivation_addon( 'sibling-plugin', 'Sibling', '/sibling/file.php', 10 );
+		$master->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+		$sibling->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		/* The API confirms deactivation and reports the pass products, so the sibling auto-deactivates too */
+		$api = static function () {
+			return [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'deactivated', 'products' => [ 5, 10 ] ] ) ];
+		};
+		add_filter( 'pre_http_request', $api );
+
+		$_POST['nonce']      = wp_create_nonce( 'gfpdf_deactivate_license' );
+		$_POST['addon_name'] = 'master-plugin';
+
+		try {
+			$this->_handleAjax( 'gfpdf_deactivate_license' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			/* do nothing (wp_die expected) */
+		}
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertTrue( isset( $response->success ), 'Expected a success response' );
+		$this->assertContains( 'sibling-plugin', $response->extra );
+
+		remove_filter( 'pre_http_request', $api );
+		remove_all_actions( 'gfpdf_addon_post_license_deactivation' );
+		$gfpdf->data->addon = [];
+	}
+
+	public function test_ajax_process_license_deactivation_api_failure() {
+		global $gfpdf;
+
+		$this->_setRole( 'administrator' );
+
+		$master = $this->register_deactivation_addon( 'master-plugin', 'Master', '/master/file.php', 5 );
+		$master->update_license_info( [ 'license' => 'KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		/* API unreachable → deactivate_license() returns false → the API-error branch responds */
+		$api = static function () {
+			return new \WP_Error( 'down', 'API unreachable' );
+		};
+		add_filter( 'pre_http_request', $api );
+
+		$_POST['nonce']      = wp_create_nonce( 'gfpdf_deactivate_license' );
+		$_POST['addon_name'] = 'master-plugin';
+
+		try {
+			$this->_handleAjax( 'gfpdf_deactivate_license' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			/* do nothing (wp_die expected) */
+		}
+
+		$this->assertStringContainsString( 'An API error occurred', json_decode( $this->_last_response )->error );
+
+		remove_filter( 'pre_http_request', $api );
+		$gfpdf->data->addon = [];
+	}
+
+	/**
+	 * Build and register an add-on for the license-deactivation AJAX tests.
+	 */
+	private function register_deactivation_addon( $slug, $name, $file, $edd_id ) {
+		global $gfpdf;
+
+		$addon = new AjaxDeactivationAddon(
+			$slug,
+			$name,
+			'Gravity PDF',
+			'1.0',
+			$file,
+			$gfpdf->data,
+			$gfpdf->options,
+			new Helper_Singleton(),
+			new Helper_Logger( $slug, $name ),
+			new Helper_Notices()
+		);
+
+		$addon->set_edd_download_id( $edd_id );
+		$addon->init();
+
+		return $addon;
+	}
+
 	public function test_ajax_save_core_font() {
 		/* set up our post data and role */
 		$this->_setRole( 'administrator' );
@@ -549,4 +642,7 @@ class Test_PDF_Ajax extends WP_Ajax_UnitTestCase {
 
 		$this->assertTrue( json_decode( $this->_last_response ) );
 	}
+}
+
+class AjaxDeactivationAddon extends Helper_Abstract_Addon {
 }

--- a/tests/phpunit/unit-tests/test-form-settings.php
+++ b/tests/phpunit/unit-tests/test-form-settings.php
@@ -297,6 +297,7 @@ class Test_Form_Settings extends WP_UnitTestCase {
 	public function test_process_list_view() {
 		$GLOBALS['plugin_page'] = '';
 		$GLOBALS['hook_suffix'] = '';
+		$GLOBALS['plugin_page'] = '';
 
 		require_once( GFCommon::get_base_path() . '/form_settings.php' );
 
@@ -335,6 +336,8 @@ class Test_Form_Settings extends WP_UnitTestCase {
 	public function test_show_edit_view() {
 		$GLOBALS['plugin_page'] = '';
 		$GLOBALS['hook_suffix'] = '';
+
+		$GLOBALS['plugin_page'] = '';
 
 		require_once( GFCommon::get_base_path() . '/form_settings.php' );
 

--- a/tests/phpunit/unit-tests/test-helper-misc.php
+++ b/tests/phpunit/unit-tests/test-helper-misc.php
@@ -778,4 +778,50 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 		$this->assertDirectoryExists( $path );
 		rmdir( $path );
 	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_is_secondary_network_site_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Not running single site tests' );
+		}
+
+		$this->assertFalse( $this->misc->is_secondary_network_site( 'gravity-pdf/pdf.php' ) );
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_is_secondary_network_site_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not running multisite tests' );
+		}
+
+		$plugin          = 'gravity-pdf/pdf.php';
+		$network_plugins = [ $plugin => time() ];
+
+		/* Fake the network-activated plugin list without touching the shared option */
+		$filter = static function () use ( &$network_plugins ) {
+			return $network_plugins;
+		};
+		add_filter( 'pre_site_option_active_sitewide_plugins', $filter );
+
+		/* The primary site is never treated as secondary, even when the plugin is network activated */
+		$this->assertFalse( $this->misc->is_secondary_network_site( $plugin ) );
+
+		/* Pose as a secondary site — we only read a network option, so no real blog is needed */
+		switch_to_blog( PHP_INT_MAX );
+
+		/* Secondary site, plugin not network activated */
+		$network_plugins = [];
+		$this->assertFalse( $this->misc->is_secondary_network_site( $plugin ) );
+
+		/* Secondary site, plugin network activated */
+		$network_plugins = [ $plugin => time() ];
+		$this->assertTrue( $this->misc->is_secondary_network_site( $plugin ) );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $filter );
+	}
 }

--- a/tests/phpunit/unit-tests/test-settings.php
+++ b/tests/phpunit/unit-tests/test-settings.php
@@ -290,6 +290,37 @@ class Test_Settings extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The License tab is removed on secondary network sites — licensing is managed by the primary site
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_license_tab_hidden_on_secondary_network_site() {
+		global $gfpdf;
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		$this->add_addon_1();
+
+		/* Primary site: the License tab is present */
+		$tabs = wp_list_pluck( $this->view->get_available_tabs(), 'id' );
+		$this->assertContains( 'license', $tabs );
+
+		/* Pose as a secondary site with Gravity PDF network-activated */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		$tabs = wp_list_pluck( $this->view->get_available_tabs(), 'id' );
+		$this->assertNotContains( 'license', $tabs );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		$gfpdf->data->addon = [];
+	}
+
+	/**
 	 * Verify errors are highlighted appropriately
 	 *
 	 * @since 4.0
@@ -535,18 +566,28 @@ class Test_Settings extends WP_UnitTestCase {
 			],
 
 			[
-				'An error occurred, please try again',
+				'An unknown error occurred while checking the license.',
 				[ 'error' => 'default', 'price_id' => 1 ],
 			],
 
 			[
-				'An error occurred, please try again',
+				'An unknown error occurred while checking the license.',
 				[ 'error' => 'generic', 'price_id' => 1 ],
 			],
 
 			[
+				'An unknown error occurred while checking the license.',
+				[ 'error' => 'error', 'price_id' => 1 ],
+			],
+
+			[
 				'Your support license key has been activated for this domain',
-				[ 'success' => 'true' ],
+				[ 'license' => 'valid' ],
+			],
+
+			[
+				'Your support license key has been activated for this domain',
+				[ 'license' => 'active' ],
 			],
 		];
 	}
@@ -591,6 +632,62 @@ class Test_Settings extends WP_UnitTestCase {
 			[ false, [ 'license' => '' ], 200 ],
 			[ false, [ 'license' => 'deactivated' ], 500 ],
 		];
+	}
+
+	public function test_api_status_error() {
+		global $gfpdf;
+
+		$this->add_addon_1();
+
+		$api_response = function() {
+			return [
+				'response' => [ 'code' => 401 ],
+				'body'     => ''
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$results = $this->model->maybe_active_licenses(
+			[
+				'license_my-custom-plugin'         => 'user license key',
+				'license_my-custom-plugin_message' => '',
+				'license_my-custom-plugin_status'  => '',
+			]
+		);
+
+		$this->assertSame( 'An unknown error occurred while checking the license.', $results['license_my-custom-plugin_message'] );
+
+		remove_filter( 'pre_http_request', $api_response );
+		$gfpdf->data->addon = [];
+	}
+
+	public function test_api_body_error() {
+		global $gfpdf;
+
+		$this->add_addon_1();
+
+		$api_response = function() {
+			return [
+				'response' => [ 'code' => 201 ],
+				'body'     => '<!Doctype html>'
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$results = $this->model->maybe_active_licenses(
+			[
+				'license_my-custom-plugin'         => 'user license key',
+				'license_my-custom-plugin_message' => '',
+				'license_my-custom-plugin_status'  => '',
+			]
+		);
+
+		$this->assertSame( 'An unknown error occurred while checking the license.', $results['license_my-custom-plugin_message'] );
+
+		remove_filter( 'pre_http_request', $api_response );
+		$gfpdf->data->addon = [];
 	}
 }
 

--- a/tests/phpunit/unit-tests/test-uninstaller.php
+++ b/tests/phpunit/unit-tests/test-uninstaller.php
@@ -131,18 +131,48 @@ class Test_Uninstaller extends WP_UnitTestCase {
 		$installer->check_install_status();
 
 		update_option( 'gfpdf_settings', [] );
+		update_option( 'gpdf_sl_abc_123', true );
+		update_option( 'gpdf_sl_failed_123', true );
 
 		$this->assertNotFalse( get_option( 'gfpdf_is_installed' ) );
 		$this->assertNotFalse( get_option( 'gfpdf_current_version' ) );
 		$this->assertNotFalse( get_option( 'gfpdf_settings' ) );
+		$this->assertNotFalse( get_option( 'gpdf_sl_abc_123' ) );
+		$this->assertNotFalse( get_option( 'gpdf_sl_failed_123' ) );
 
 		$this->model->remove_plugin_options();
+
+		/* flush the options cache so fresh values can be checked from the database */
+		wp_cache_delete( 'alloptions', 'options' );
 
 		$this->assertFalse( get_option( 'gfpdf_is_installed' ) );
 		$this->assertFalse( get_option( 'gfpdf_current_version' ) );
 		$this->assertFalse( get_option( 'gfpdf_settings' ) );
+		$this->assertFalse( get_option( 'gpdf_sl_abc_123' ) );
+		$this->assertFalse( get_option( 'gpdf_sl_failed_123' ) );
 
 		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * The network-shared license package cache lives in sitemeta, so it needs its own cleanup on uninstall
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_remove_plugin_network_options() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Network options only exist on Multisite' );
+		}
+
+		update_site_option( 'gpdf_sl_net_abc123', [ 'timeout' => time(), 'value' => '{}' ] );
+		$this->assertNotFalse( get_site_option( 'gpdf_sl_net_abc123' ) );
+
+		$this->model->remove_plugin_network_options();
+
+		/* The direct SQL delete bypasses the object cache */
+		wp_cache_flush();
+
+		$this->assertFalse( get_site_option( 'gpdf_sl_net_abc123' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Backports the **Licensing and Update API** work to the 6.16.0 hot-patch line so Gravity PDF works fully against the new `api.gravitypdf.com` server. The API URL was already switched, but update checks and license activation still used the legacy `edd_action` flow the new server no longer matches. This branch migrates the updater and license handling, adds `GPDF_LICENSE_KEY` support, makes the API traffic Multisite-safe, and redacts secrets from the debug log.

Squashed into a single commit on top of `hot-patch-6.16.0`.

## What's included

**Plugin updater**
- Replace `EDD_SL_Plugin_Updater` with the rewritten, self-contained updater (`get_version` API, `standardize_api_response`, `gpdf_sl_*` cache keys, Multisite changelog / update-notice support)
- Bootstrap: explicit `init()`, `wp_override` on force-check, expose the updater via `Helper_Data`, log the decoded JSON API response
- 6.16.0 upgrade routine purges the legacy `edd_sl_*` update cache and the 6.15.0 failed-request backoff option

**License settings + `GPDF_LICENSE_KEY` constant**
- Move activation / deactivation / delete into the add-on framework (`Helper_Abstract_Addon`) + bulk license verification
- Define a license via the `GPDF_LICENSE_KEY` PHP constant (auto-activation; settings field locked read-only when set)
- Reworked License settings page + AJAX deactivation (`Model_Settings`, `Controller_Settings`, `licence-info` view, `setupLicenseDeactivation.js`)
- Access Pass keys shared across sibling add-ons on activation and deactivation
- Clear cached licensing data on uninstall (incl. the network-shared `gpdf_sl_net_*` cache)

**Multisite: restrict API checks to the primary site**
- On a network-activated Multisite, WP-Cron runs per-site, so every subsite was independently scheduling its own weekly bulk license check and plugin update check — one API call per subsite (worst case: a network-wide `GPDF_LICENSE_KEY` makes every subsite hit the API with the same key)
- `Helper_Misc::is_secondary_network_site()` reads the `active_sitewide_plugins` network option, so it's safe in cron / front-end where `is_plugin_active_for_network()` isn't loaded
- Gate the bulk license check and the update version check to the primary site; subsites read the network-wide `update_plugins` transient the primary site populates

**Log redaction**
- `Redact_Processor` (Monolog) masks license keys, signed update / package URLs, tokens, cookies and nonces in the debug log — key-based (recursing into context arrays / objects) plus pattern-scrubbing of message bodies and string leaves, with CRLF / control-char neutralisation to prevent log injection

**Post-review hardening** (from an expert review of the initial implementation)
- Prevent a Multisite network-update-check request storm, with a schedule floor to avoid a tight reschedule loop
- Guard the updater against non-object / scalar / corrupted-cache API payloads (PHP 8 fatal-safety on `plugins_api` and cached data)
- Redact string leaves and raw response bodies in log context; add `set-cookie` to the deny set
- Sync the cleared license into the in-memory copy when the key is emptied (status / message no longer go stale within the request)
- Correct expired-license date handling, add-on public-action guards, and docblock / version drift

## Scope notes
- `@since` markers and the upgrade-routine version gate are set to **6.16.0**.
- Deliberately excluded (separate epics, not needed here): the broader uninstaller-interface refactor, log rotation, and PSR-Log v1/2/3 groundwork.
- `setupLicenseDeactivation.js` is a source change — the built asset needs regenerating at release (`yarn build`).
- Version constant / changelog reshuffle for 6.16.0 is not part of this PR.

## Testing

**Automated (PHPUnit, wp-env)**
- Single-site: **1132 tests, 3567 assertions — 0 failures / 0 errors** (29 intentional skips)
- Multisite: **1132 tests, 3639 assertions — 0 failures / 0 errors** (2 intentional skips)
- PHPCS: clean on all changed files

**Live / manual** — run against production `api.gravitypdf.com` on a subdirectory Multisite (5 sites, GF 2.10.5), with GF logging on to verify redaction:
- License activation via the settings field — activates live; status `valid` ✓
- Access Pass sibling sharing — activating one add-on auto-activates its pass sibling; an unrelated add-on is left untouched ✓
- Update check — all four plugins resolve to their correct current versions (no false update, no missing entries, no fatal) ✓
- Invalid key — clear error surfaced; other add-ons unaffected ✓
- Empty-key clear — wipes key / status / message in both the DB and the in-memory copy ✓
- Deactivation — one deactivate clears both Access Pass siblings; DB cleared ✓
- Log redaction — license key, checksum and nonce all `[redacted]`; the raw key never appears in plaintext across the full activate → deactivate lifecycle ✓
- `GPDF_LICENSE_KEY` constant — auto-activates covered add-ons, fields read-only, correct "not valid for this product" on an uncovered add-on ✓
- Multisite gating — secondary subsite front-end returns HTTP 200 (no `is_plugin_active_for_network` fatal) and cron runs clean; `is_secondary_network_site` skips secondaries / runs on the primary; License tab hidden on secondary sites ✓
- Uninstaller — removes all options across every site, the network `gpdf_sl_net_*` cache and the PDF folder structure; deactivation clears all scheduled `gfpdf_*` cron events ✓

## Checklist
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code has proper inline documentation / docblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
