### PR TITLE
Remove the license from the site even when deactivation fails

### DIFF
--- a/src/Helper/Helper_Data.php
+++ b/src/Helper/Helper_Data.php
@@ -242,7 +242,7 @@ class Helper_Data {
 				'disable'                              => esc_html__( 'Disable', 'gravity-pdf' ),
 				'updateSuccess'                        => esc_html__( 'Successfully Updated', 'gravity-pdf' ),
 				'deleteSuccess'                        => esc_html__( 'Successfully Deleted', 'gravity-pdf' ),
-				'licenseDeactivationError'             => esc_html__( 'An error occurred and your license key may not have been deactivated. Reload the page and try again.', 'gravity-pdf' ),
+				'licenseDeactivationError'             => esc_html__( 'An error occurred and your license key may not have been correctly deactivated. Login to your GravityPDF.com account and check if your site has been unlinked from the key.', 'gravity-pdf' ),
 				'no'                                   => esc_html__( 'No', 'gravity-pdf' ),
 				'yes'                                  => esc_html__( 'Yes', 'gravity-pdf' ),
 				'standard'                             => esc_html__( 'Standard', 'gravity-pdf' ),

--- a/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
+++ b/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
@@ -41,21 +41,17 @@ export function setupLicenseDeactivation () {
 
       /* Our endpoint always returns a `success` or `error` string. A transport/auth failure (eg. a 500, or the 401
          from handle_ajax_authentication) instead hits jQuery's error handler with the raw jqXHR, so neither is set. */
-      const successMessage = typeof response?.success === 'string' ? response.success : null
-      if (successMessage === null) {
-        /* Deactivation didn't complete — re-enable the button and surface the error so the user can retry */
-        $button.prop('disabled', false)
-        const error = typeof response?.error === 'string' ? response.error : GFPDF.licenseDeactivationError
-        showLicenseMessage($container, error, false)
-        return
-      }
+      const success = typeof response?.success === 'string'
+      const message = success
+        ? response.success
+        : (typeof response?.error === 'string' ? response.error : GFPDF.licenseDeactivationError)
 
-      /* update UI to reflect deactivation */
-      postLicenseDeactivation(slug, $container, successMessage)
+      /* deactivate_license() drops the key from this site even when the API rejects it, so always clear the UI */
+      postLicenseDeactivation(slug, $container, message, success)
 
       /* handle any shared licenses that were also deactivated */
-      if (Array.isArray(response.extra)) {
-        response.extra.forEach(item => postLicenseDeactivation(item, $('#gfpdf-settings-field-wrapper-license_' + item), successMessage))
+      if (success && Array.isArray(response.extra)) {
+        response.extra.forEach(item => postLicenseDeactivation(item, $('#gfpdf-settings-field-wrapper-license_' + item), message, true))
       }
     })
 
@@ -63,17 +59,13 @@ export function setupLicenseDeactivation () {
   })
 }
 
-function postLicenseDeactivation (slug, $container, message) {
+function postLicenseDeactivation (slug, $container, message, success) {
   /* cleanup inputs */
   $('#gfpdf_settings\\[license_' + slug + '\\]').val('')
   $('#gfpdf_settings\\[license_' + slug + '_message\\]').val('')
   $('#gfpdf_settings\\[license_' + slug + '_status\\]').val('')
   $container.find('button').remove()
 
-  showLicenseMessage($container, message, true)
-}
-
-function showLicenseMessage ($container, message, success) {
   $container
     .find('#message')
     .toggleClass('success', success)

--- a/tests/js-unit/admin/settings/common/setupLicenseDeactivation.test.js
+++ b/tests/js-unit/admin/settings/common/setupLicenseDeactivation.test.js
@@ -74,12 +74,11 @@ describe('setupLicenseDeactivation', () => {
   })
 
   describe('on an application error (HTTP 200 { error })', () => {
-    it('keeps the field and button so the user can retry, and shows the error', () => {
+    it('still removes the key from the site, but shows the error', () => {
       deactivate({ error: 'An API error occurred.' })
 
-      expect(fieldValue('sample')).toBe('a-real-license-key')
-      expect($('.gfpdf-deactivate-license').length).toBe(1)
-      expect($('.gfpdf-deactivate-license').prop('disabled')).toBe(false)
+      expect(fieldValue('sample')).toBe('')
+      expect($('.gfpdf-deactivate-license').length).toBe(0)
 
       const $message = $('#gfpdf-settings-field-wrapper-license_sample #message')
       expect($message.hasClass('error')).toBe(true)
@@ -89,13 +88,12 @@ describe('setupLicenseDeactivation', () => {
   })
 
   describe('on a transport/auth failure (jqXHR, not our JSON)', () => {
-    it('does not clear the field or remove the button, and shows the generic fallback message', () => {
+    it('still removes the key from the site, and shows the generic fallback message', () => {
       /* jQuery's error handler passes the raw jqXHR — neither success nor error is a string */
       deactivate({ readyState: 4, status: 401, statusText: 'Unauthorized' })
 
-      expect(fieldValue('sample')).toBe('a-real-license-key')
-      expect($('.gfpdf-deactivate-license').length).toBe(1)
-      expect($('.gfpdf-deactivate-license').prop('disabled')).toBe(false)
+      expect(fieldValue('sample')).toBe('')
+      expect($('.gfpdf-deactivate-license').length).toBe(0)
 
       const $message = $('#gfpdf-settings-field-wrapper-license_sample #message')
       expect($message.hasClass('error')).toBe(true)

--- a/tests/js-unit/setupTests.js
+++ b/tests/js-unit/setupTests.js
@@ -17,7 +17,7 @@ window.GFPDF = {
   noResultText: 'It doesn\'t look like there are any topics related to your issue.',
   coreFontGithubError: 'Could not download Core Font list. Try again.',
   getSearchResultError: 'An error occurred. Please try again',
-  licenseDeactivationError: 'An error occurred and your license key may not have been deactivated. Reload the page and try again.',
+  licenseDeactivationError: 'An error occurred and your license key may not have been correctly deactivated. Login to your GravityPDF.com account and check if your site has been unlinked from the key.',
   userCapabilities: { administrator: true },
   // Font manager component
   fontListInstalledFonts: 'Installed Fonts',


### PR DESCRIPTION
Reverts the "keep the license key on screen and allow another attempt" behaviour from #1682. A failed deactivation now still removes the key from the site.

## Why

`Helper_Abstract_Addon::deactivate_license()` deletes the local license info *before* it inspects the API response:

```php
/* Remove license data from database, no matter if the API request fails */
$this->delete_license_info();
$this->flush_update_cache();
```

So the key is gone from this site whether or not GravityPDF.com accepted the deactivation. The UI didn't match: on an `{error}` response or a transport failure it kept the key in the field and left the Deactivate button in place, implying the license was still installed and retryable — but a reload showed an empty field, because the DB row had already been deleted.

## What changed

All three outcomes now clear the key/message/status inputs and drop the Deactivate button. Only the message differs:

| Response | Fields cleared | Button removed | Message |
|---|---|---|---|
| `{success}` | ✅ | ✅ | green, from server |
| `{error}` (API rejected) | ✅ | ✅ | red, from server |
| jqXHR (500 / 401) | ✅ | ✅ | red, `GFPDF.licenseDeactivationError` |

The `extra` teardown for All Access Pass siblings still runs on success only — `process_license_deactivation()` only populates that list once the API confirms deactivation.

`licenseDeactivationError` is reworded to match the two equivalent PHP messages in `process_license_deactivation()`: the user is pointed at their GravityPDF.com account to confirm the site was unlinked, rather than told to reload and retry.

Kept from #1682: the red-vs-green styling fix (genuine `{error}` responses were previously given the `success` class) and the repeat-click guard.

## Note

On a 401/nonce failure the server never reaches `deactivate_license()`, so the key *is* still in the DB and reappears on reload — the UI clears optimistically there. That's the trade-off for "remove it regardless"; the error message points the user at their account to confirm.

## Testing

`npx jest` — 58 suites / 468 tests passing. The three deactivation-path tests were updated to assert the new behaviour; eslint clean.

No changelog entry (per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)