### PR TITLE
fix: flush the update cache on every license removal path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * 🐞 Bug: Show an error message when the license deactivation request fails with a server or authentication error, instead of leaving the spinner running
 * 🐞 Bug: Ignore repeat clicks of the Deactivate button while a request is in progress
 * 🐞 Bug: Clearing a license key from the settings now updates the license status straight away
+* 🐞 Bug: Delete all cached update information when a license key is deactivated/cleared from the settings page, or is rejected by the licensing server
 * 🐞 Bug: Fix PHP fatal error when doing an update check and the licensing server is unavailable
 * 🐞 Bug: Stop repeated update requests if the licensing server returns an empty response
 * 💻 Developer: Add `GPDFAPI::get_pdf_filename( $entry_id, $pdf_id, $include_extension )` to get the filename of a PDF

--- a/src/Helper/Helper_Abstract_Addon.php
+++ b/src/Helper/Helper_Abstract_Addon.php
@@ -711,6 +711,22 @@ abstract class Helper_Abstract_Addon {
 	}
 
 	/**
+	 * Whether incoming license info differs from what this add-on already holds
+	 *
+	 * The incoming key is compared against the raw `$license_key` property, not get_license_key(), which folds in the
+	 * `GPDF_LICENSE_KEY` constant and so reads identically on both sides however the add-on's own key changed.
+	 *
+	 * @param array $license_info
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	private function license_info_has_changed( $license_info ) {
+		return $license_info['license'] !== $this->license_key || $license_info['status'] !== $this->license_key_status;
+	}
+
+	/**
 	 * Remove the license info and keys from the settings
 	 *
 	 * @since 4.2
@@ -1169,7 +1185,16 @@ abstract class Helper_Abstract_Addon {
 			return;
 		}
 
-		$this->update_license_info( $addon->get_license_info(), $use_database );
+		$license_info = $addon->get_license_info();
+		$has_changed  = $this->license_info_has_changed( $license_info );
+
+		$this->update_license_info( $license_info, $use_database );
+
+		/* Cached update info was fetched under the old key, so it holds no package for the new one. A hardcoded key
+		   re-fires this action every few hours, so skip the flush when nothing actually moved. */
+		if ( $has_changed ) {
+			$this->flush_update_cache();
+		}
 
 		$this->license_auto_activated = true;
 	}
@@ -1251,7 +1276,14 @@ abstract class Helper_Abstract_Addon {
 			return;
 		}
 
-		$this->update_license_info( $addon->get_license_info(), true );
+		$license_info = $addon->get_license_info();
+		$has_changed  = $this->license_info_has_changed( $license_info );
+
+		$this->update_license_info( $license_info, true );
+
+		if ( $has_changed ) {
+			$this->flush_update_cache();
+		}
 
 		$this->license_auto_deactivated = true;
 	}
@@ -1269,5 +1301,6 @@ abstract class Helper_Abstract_Addon {
 
 		$this->plugin_updater->delete_version_info_cache();
 		$this->plugin_updater->delete_transient_plugin_info();
+		$this->plugin_updater->delete_network_version_info_cache();
 	}
 }

--- a/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
+++ b/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
@@ -39,6 +39,22 @@ class EDD_SL_Plugin_Updater {
 	/* The network-shared package outlives the per-site 3h check cache so a quiet licensed site can't let it lapse */
 	protected const NETWORK_CACHE_TTL = 3 * DAY_IN_SECONDS;
 
+	/*
+	 * Drawn from Helper_Data::addon_license_responses(). `error` and `rate_limit` are deliberately absent — a failed or
+	 * throttled request is not a verdict on the license, so it must not strip a package other sites depend on.
+	 */
+	protected const UNENTITLED_LICENSE_STATUSES = [
+		'expired',
+		'revoked',
+		'disabled',
+		'missing',
+		'invalid',
+		'site_inactive',
+		'item_name_mismatch',
+		'invalid_item_id',
+		'no_activations_left',
+	];
+
 	/**
 	 * Class constructor.
 	 *
@@ -735,11 +751,12 @@ class EDD_SL_Plugin_Updater {
 		/*
 		 * Promote the package to a network option so any site on the Multisite can install the update. The store can
 		 * return a package URL even when the license is inactive (that URL errors on access), so only an active license
-		 * is allowed to share its package.
+		 * is allowed to share its package. The promoting site is recorded so it alone can withdraw the package later.
 		 */
 		if ( is_multisite() && $this->is_license_active() && is_object( $value ) && ! empty( $value->package ) ) {
 			$network_data            = $data;
 			$network_data['timeout'] = time() + self::NETWORK_CACHE_TTL;
+			$network_data['blog_id'] = get_current_blog_id();
 			update_site_option( $this->get_network_cache_key(), $network_data );
 		}
 	}
@@ -759,6 +776,35 @@ class EDD_SL_Plugin_Updater {
 		}
 
 		return delete_option( $cache_key );
+	}
+
+	/**
+	 * Withdraw the package this site shared with the network, so a removed license stops backing network-wide downloads
+	 *
+	 * Ownership counts as much as the license state: a package promoted by another site belongs to a site that is still
+	 * licensed, and must outlive this one losing its own.
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	public function delete_network_version_info_cache() {
+		if ( ! is_multisite() ) {
+			return false;
+		}
+
+		$lost_license = empty( $this->api_data['license'] ) || in_array( $this->license_status, self::UNENTITLED_LICENSE_STATUSES, true );
+		if ( ! $lost_license ) {
+			return false;
+		}
+
+		$cache_key = $this->get_network_cache_key();
+		$cache     = get_site_option( $cache_key );
+		if ( ! is_array( $cache ) || (int) ( $cache['blog_id'] ?? 0 ) !== get_current_blog_id() ) {
+			return false;
+		}
+
+		return delete_site_option( $cache_key );
 	}
 
 	/**

--- a/src/Model/Model_Settings.php
+++ b/src/Model/Model_Settings.php
@@ -308,6 +308,12 @@ class Model_Settings extends Helper_Abstract_Model {
 					]
 				);
 
+				/* Clearing the field removes the license as surely as the Deactivate button does — drop the cached
+				   package. Every add-on posts an empty field on an unrelated save, so only flush when a key was set. */
+				if ( ! empty( $settings[ $option_key ] ) ) {
+					$addon->flush_update_cache();
+				}
+
 				continue;
 			}
 

--- a/src/Model/Model_Uninstall.php
+++ b/src/Model/Model_Uninstall.php
@@ -141,8 +141,8 @@ class Model_Uninstall extends Helper_Abstract_Model {
 	/**
 	 * Remove the network-shared license package cache stored in sitemeta on a Multisite
 	 *
-	 * The per-site caches removed by remove_plugin_options() live in each site's options table; the network cache
-	 * (see EDD_SL_Plugin_Updater::get_network_cache_key()) is a single network option, so it's cleaned up once here.
+	 * Every extension keeps its own entry (see EDD_SL_Plugin_Updater::get_network_cache_key()), but all are
+	 * network-scoped rather than per-site, so one wildcard pass clears them without walking the site list.
 	 *
 	 * @since 6.16.0
 	 */

--- a/tests/phpunit/unit-tests/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
+++ b/tests/phpunit/unit-tests/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
@@ -1065,4 +1065,91 @@ class Test_EDD_SL_Plugin_Updater extends WP_UnitTestCase {
 		$this->assertSame( '0.2', $result->new_version );
 		$this->assertEmpty( $result->package );
 	}
+
+	public function test_delete_network_version_info_cache_withdraws_own_promotion() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'valid' );
+
+		$licensed              = new \stdClass();
+		$licensed->new_version = '0.2';
+		$licensed->package     = 'https://store.com/download/licensed-123';
+		$this->class->set_version_info_cache( $licensed );
+
+		$cache = get_site_option( $this->class->get_network_cache_key() );
+		$this->assertSame( get_current_blog_id(), $cache['blog_id'] );
+
+		/* A failed or throttled check is not a verdict on the license, so the shared package stands */
+		foreach ( [ 'error', 'rate_limit' ] as $status ) {
+			$this->class->set_license_status( $status );
+			$this->assertFalse( $this->class->delete_network_version_info_cache(), $status );
+		}
+
+		/* Removing the key does withdraw it */
+		$this->class->set_license_key( '' );
+		$this->assertTrue( $this->class->delete_network_version_info_cache() );
+		$this->assertFalse( get_site_option( $this->class->get_network_cache_key() ) );
+	}
+
+	/**
+	 * @dataProvider providerUnentitledLicenseStatus
+	 */
+	public function test_delete_network_version_info_cache_withdraws_on_store_rejection( $status ) {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'valid' );
+
+		$licensed              = new \stdClass();
+		$licensed->new_version = '0.2';
+		$licensed->package     = 'https://store.com/download/licensed-123';
+		$this->class->set_version_info_cache( $licensed );
+
+		/* The key stays populated on a rejection, so the status is the only signal the entitlement ended */
+		$this->class->set_license_status( $status );
+
+		$this->assertTrue( $this->class->delete_network_version_info_cache() );
+		$this->assertFalse( get_site_option( $this->class->get_network_cache_key() ) );
+	}
+
+	public function providerUnentitledLicenseStatus() {
+		return [
+			[ 'expired' ],
+			[ 'revoked' ],
+			[ 'disabled' ],
+			[ 'missing' ],
+			[ 'invalid' ],
+			[ 'site_inactive' ],
+			[ 'item_name_mismatch' ],
+			[ 'invalid_item_id' ],
+			[ 'no_activations_left' ],
+		];
+	}
+
+	public function test_delete_network_version_info_cache_keeps_another_sites_promotion() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* Another site promoted this package, so its license is still active and the package must survive */
+		$network              = new \stdClass();
+		$network->new_version = '0.2';
+		$network->package     = 'https://store.com/download/licensed-123';
+		update_site_option(
+			$this->class->get_network_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( $network ), 'blog_id' => get_current_blog_id() + 1 ]
+		);
+
+		$this->class->set_license_key( '' );
+
+		$this->assertFalse( $this->class->delete_network_version_info_cache() );
+		$this->assertNotEmpty( get_site_option( $this->class->get_network_cache_key() ) );
+
+		delete_site_option( $this->class->get_network_cache_key() );
+	}
 }

--- a/tests/phpunit/unit-tests/Model/Test_Model_Settings.php
+++ b/tests/phpunit/unit-tests/Model/Test_Model_Settings.php
@@ -605,6 +605,51 @@ class Test_Model_Settings extends WP_UnitTestCase {
 		$this->assertSame( '', $this->addon->get_license_key() );
 	}
 
+	public function test_maybe_active_licenses_flushes_update_cache_on_empty_key() {
+		do_action( 'init' );
+
+		$options = \GPDFAPI::get_options_class();
+		$slug    = $this->addon->get_slug();
+
+		$settings                    = $options->get_settings();
+		$settings[ "license_$slug" ] = 'old-key';
+		$options->update_settings( $settings );
+
+		$this->addon->update_license_info( [ 'license' => 'old-key', 'status' => 'active', 'message' => 'ok' ] );
+
+		$updater = $this->addon->get_plugin_updater();
+		update_option(
+			$updater->get_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( (object) [ 'new_version' => '2.0' ] ) ]
+		);
+
+		$this->model->maybe_active_licenses( [ "license_$slug" => '' ] );
+
+		/* The cached update info was fetched with the now-removed key, so it must not outlive it */
+		$this->assertFalse( $updater->get_cached_version_info() );
+
+		delete_option( $updater->get_cache_key() );
+	}
+
+	public function test_maybe_active_licenses_skips_flush_for_unlicensed_addon() {
+		do_action( 'init' );
+
+		$slug    = $this->addon->get_slug();
+		$updater = $this->addon->get_plugin_updater();
+
+		update_option(
+			$updater->get_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( (object) [ 'new_version' => '2.0' ] ) ]
+		);
+
+		/* Every add-on posts an empty license field on an unrelated save; one that never had a key keeps its cache */
+		$this->model->maybe_active_licenses( [ "license_$slug" => '' ] );
+
+		$this->assertIsObject( $updater->get_cached_version_info() );
+
+		delete_option( $updater->get_cache_key() );
+	}
+
 	public function test_licensing_bulk_license_check_skips_malformed_and_unknown_items() {
 		do_action( 'init' );
 

--- a/tests/phpunit/unit-tests/test-addon.php
+++ b/tests/phpunit/unit-tests/test-addon.php
@@ -737,6 +737,96 @@ class Test_Addon extends WP_UnitTestCase {
 
 		$this->assertFalse( $this->addon->has_license_auto_deactivated() );
 	}
+
+	/**
+	 * The sibling's cached update info was fetched unlicensed (so it holds no package) and must not survive the
+	 * Access Pass adopting a key.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_activate_license_flushes_update_cache() {
+		$this->addon->set_edd_download_id( 10 );
+		$this->addon2->set_edd_download_id( 20 );
+
+		/* Seed first — init() re-reads the license info from the database, overwriting the in-memory copy */
+		$updater = $this->seed_update_cache( $this->addon2 );
+
+		$this->addon->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid', 'products' => [ 10, 20 ] ] ) ];
+		$this->addon2->maybe_auto_activate_license( $response, $this->addon, false );
+
+		$this->assertFalse( $updater->get_cached_version_info() );
+
+		$this->addon->delete_license_info();
+		$this->addon2->delete_license_info();
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_deactivate_license_flushes_update_cache() {
+		$this->addon->set_edd_download_id( 10 );
+		$this->addon2->set_edd_download_id( 20 );
+		$this->addon->delete_license_info();
+
+		$updater = $this->seed_update_cache( $this->addon2 );
+
+		$this->addon2->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'deactivated', 'products' => [ 10, 20 ] ] ) ];
+		$this->addon2->maybe_auto_deactivate_license( $response, $this->addon );
+
+		$this->assertFalse( $updater->get_cached_version_info() );
+
+		$this->addon2->delete_license_info();
+	}
+
+	/**
+	 * A store rejection arrives with the key still populated, so the status has to carry the withdrawal end to end.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_rejected_license_response_withdraws_network_package() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		$this->addon->init();
+		do_action( 'init' );
+
+		$updater = $this->addon->get_plugin_updater();
+		$package = (object) [ 'new_version' => '2.0', 'package' => 'https://store.com/download/123' ];
+
+		update_site_option(
+			$updater->get_network_cache_key(),
+			[ 'timeout' => strtotime( '+3 days' ), 'value' => wp_json_encode( $package ), 'blog_id' => get_current_blog_id() ]
+		);
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'expired', 'expires' => '2020-01-01 00:00:00' ] ) ];
+		$this->addon->update_license_status_from_response( 'unchanged-key', $response );
+
+		$this->assertSame( 'expired', $this->addon->get_license_status() );
+		$this->assertFalse( get_site_option( $updater->get_network_cache_key() ) );
+	}
+
+	/**
+	 * Boot the add-on's updater and prime its version-info cache
+	 *
+	 * @return \GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater
+	 */
+	private function seed_update_cache( $addon ) {
+		$addon->init();
+		do_action( 'init' );
+
+		$updater = $addon->get_plugin_updater();
+		update_option(
+			$updater->get_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( (object) [ 'new_version' => '2.0', 'package' => '' ] ) ]
+		);
+
+		return $updater;
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

License activation and deactivation already flushed the cached update info, but three paths that change license state did not.

**1. Access Pass siblings.** `maybe_auto_activate_license()` / `maybe_auto_deactivate_license()` called `update_license_info()` alone. Every add-on covered by the pass kept version info fetched under the old key (so, no package) for up to the 3-hour TTL, plus its stale `update_plugins` entry.

**2. Clearing the key in the settings form.** Unlike the Deactivate button, the empty-key branch of `maybe_active_licenses()` left the cached package in place.

**3. The Multisite network cache.** `delete_version_info_cache()` only removes the per-site option, so the `gpdf_sl_net_*` package a site promoted stayed borrowable via `maybe_apply_network_package()` for its 3-day TTL — a site that had lost its license could still hand a download URL to the network.

## What ends the network entitlement

Withdrawal needs a lost license **and** ownership of the shared package.

- **Lost license** means the key was removed *or* the store rejected it: `expired`, `revoked`, `disabled`, `missing`, `invalid`, `site_inactive`, `item_name_mismatch`, `invalid_item_id`, `no_activations_left`. These all arrive with the key still populated, so the status is the only signal.
- `error` and `rate_limit` are deliberately excluded. They are written on a `WP_Error`, timeout or 429, and treating a failed request as a verdict would strip a package every subsite depends on whenever the licensing server is briefly unreachable.
- **Ownership**: the promoting blog id is stored alongside the package, so a promotion made by another site — which is therefore still licensed — outlives this site's deactivation.

`flush_update_cache()` takes no flag; the withdrawal derives from the updater's own key and status, so no caller has to remember to ask for it.

## Guards against no-op work

- The sibling flush only fires when the key or status actually moved — a hardcoded `GPDF_LICENSE_KEY` re-fires the activation action every few hours and would otherwise force a fresh remote request per add-on each cycle.
- The settings-form flush only fires when a key was previously stored — the licensing tab posts an empty field for every registered add-on on an unrelated save.

## Testing

16 new tests. Full PHPUnit suite green in both modes: **1149 tests / 3578 assertions** single-site, **1149 / 3677** multisite. `phpcs` clean on the changed files.

The rejection-status tests were verified non-vacuous: with the status gate reverted to the key-only check, all 10 fail.

## Follow-up (not in this patch)

All five `update_license_info()` call sites in `src/` are now immediately followed by a flush — that 100% correlation says the invariant belongs inside `update_license_info()` itself. Deliberately left for 6.17 rather than relocating side effects of a public `@since 4.2` method in a hot patch. Same for the settings-clear branch being a second, partial definition of "license removed" alongside `delete_license_info()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)