### PR TITLE
fix: invalidate the object cache when bulk-deleting plugin options

### DIFF
--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -155,7 +155,18 @@ class Controller_Upgrade_Routines {
 	protected function remove_legacy_update_cache() {
 		global $wpdb;
 
-		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'edd_sl_%' AND option_value LIKE '%gravity-pdf%'" );
+		/* Delete via the API: a stale autoloaded row left in the cache is the cost this routine exists to remove */
+		$keys = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s AND option_value LIKE %s",
+				$wpdb->esc_like( 'edd_sl_' ) . '%',
+				'%' . $wpdb->esc_like( 'gravity-pdf' ) . '%'
+			)
+		);
+
+		foreach ( $keys as $key ) {
+			delete_option( $key );
+		}
 
 		/* The failure-backoff option stores a bare timestamp, so the value filter above can't match it — target both
 		   the historical (≤6.14.x) and the 6.15.0 API hosts by exact name. 6.15.0's key was autoloaded, so a site that

--- a/src/Model/Model_Uninstall.php
+++ b/src/Model/Model_Uninstall.php
@@ -133,9 +133,16 @@ class Model_Uninstall extends Helper_Abstract_Model {
 		delete_option( 'gfpdf_current_version' );
 		delete_option( 'gfpdf_settings' );
 
-		/* Remove license API data */
+		/* Remove license API data. Deleting one by one, not with a raw DELETE, lets WordPress drop its cached copies */
 		global $wpdb;
-		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'gpdf_sl_%'" );
+
+		$keys = $wpdb->get_col(
+			$wpdb->prepare( "SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s", $wpdb->esc_like( 'gpdf_sl_' ) . '%' )
+		);
+
+		foreach ( $keys as $key ) {
+			delete_option( $key );
+		}
 	}
 
 	/**
@@ -148,7 +155,16 @@ class Model_Uninstall extends Helper_Abstract_Model {
 	 */
 	public function remove_plugin_network_options() {
 		global $wpdb;
-		$wpdb->query( "DELETE FROM $wpdb->sitemeta WHERE meta_key LIKE 'gpdf_sl_net_%'" );
+
+		/* delete_network_option() rather than delete_site_option(), which would narrow the sweep to the current
+		   network and strand rows belonging to the others sharing this sitemeta table */
+		$rows = $wpdb->get_results(
+			$wpdb->prepare( "SELECT site_id, meta_key FROM $wpdb->sitemeta WHERE meta_key LIKE %s", $wpdb->esc_like( 'gpdf_sl_net_' ) . '%' )
+		);
+
+		foreach ( $rows as $row ) {
+			delete_network_option( $row->site_id, $row->meta_key );
+		}
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
@@ -47,4 +47,20 @@ class Test_Controller_Upgrade_Routines extends WP_UnitTestCase {
 		$this->assertSame( 'No', $this->options->get_option( 'background_processing' ) );
 	}
 
+	public function test_6_16_0_removes_legacy_update_cache() {
+		update_option( 'edd_sl_version_info_123', 'a payload naming gravity-pdf' );
+		update_option( 'edd_sl_failed_http_' . md5( GPDF_API_URL ), time() );
+
+		/* An unrelated add-on's cache shares the prefix but not the value, and must survive */
+		update_option( 'edd_sl_version_info_456', 'a payload naming another-plugin' );
+
+		do_action( 'gfpdf_version_changed', '6.15.0', '6.16.0' );
+
+		/* No cache flush here on purpose — the routine must invalidate what it deletes */
+		$this->assertFalse( get_option( 'edd_sl_version_info_123' ) );
+		$this->assertFalse( get_option( 'edd_sl_failed_http_' . md5( GPDF_API_URL ) ) );
+		$this->assertNotFalse( get_option( 'edd_sl_version_info_456' ) );
+
+		delete_option( 'edd_sl_version_info_456' );
+	}
 }

--- a/tests/phpunit/unit-tests/test-uninstaller.php
+++ b/tests/phpunit/unit-tests/test-uninstaller.php
@@ -142,9 +142,7 @@ class Test_Uninstaller extends WP_UnitTestCase {
 
 		$this->model->remove_plugin_options();
 
-		/* flush the options cache so fresh values can be checked from the database */
-		wp_cache_delete( 'alloptions', 'options' );
-
+		/* No cache flush here on purpose — the uninstall must invalidate what it deletes */
 		$this->assertFalse( get_option( 'gfpdf_is_installed' ) );
 		$this->assertFalse( get_option( 'gfpdf_current_version' ) );
 		$this->assertFalse( get_option( 'gfpdf_settings' ) );
@@ -169,9 +167,7 @@ class Test_Uninstaller extends WP_UnitTestCase {
 
 		$this->model->remove_plugin_network_options();
 
-		/* The direct SQL delete bypasses the object cache */
-		wp_cache_flush();
-
+		/* No cache flush here on purpose — the uninstall must invalidate what it deletes */
 		$this->assertFalse( get_site_option( 'gpdf_sl_net_abc123' ) );
 	}
 


### PR DESCRIPTION
Follow-up to #1684.

## The problem

Three cleanup routines removed options with a raw `DELETE ... LIKE` query. That takes the rows out of the database but leaves whatever WordPress cached behind — the individually cached entry in the `options` / `site-options` group, and for an autoloaded row a copy inside the `alloptions` blob that keeps being loaded on every request.

| | pattern |
|---|---|
| `Model_Uninstall::remove_plugin_options()` | `gpdf_sl_%` |
| `Model_Uninstall::remove_plugin_network_options()` | `gpdf_sl_net_%` |
| `Controller_Upgrade_Routines::remove_legacy_update_cache()` | `edd_sl_%` |

This is observable without a persistent object cache — `get_option()` / `get_site_option()` read through the per-request cache too.

## Why the upgrade routine is the one that bites

The uninstaller calls `deactivate_plugins()` immediately afterwards, so little gets a chance to read the stale values. The upgrade routine doesn't — the plugin keeps running, and leaving a legacy autoloaded option in the cache is the exact cost the routine exists to remove.

It was masked by the two `delete_option()` calls that follow it: core's `delete_option()` runs `wp_load_alloptions( true )`, forcing a rebuild from the database that drops the swept rows along the way. But it bails at `if ( is_null( $row ) ) return false;` before touching the cache when the option doesn't exist — and on a site that never hit an API failure, neither of those two options exists. So the mitigation was real but accidental and conditional.

## The fix

Each query now selects the names and deletes through the API.

Two details worth review attention:

- The network sweep uses `delete_network_option()` with the row's own `site_id`, **not** `delete_site_option()`. `sitemeta` is shared across networks and the original query had no `site_id` filter, so it swept all of them; `delete_site_option()` would silently narrow the cleanup to the current network and strand the rest.
- Wildcards are now escaped with `esc_like()`. `'gpdf_sl_%'` previously meant "gpdf, any char, sl, any char, anything" — harmless in practice, but wrong.

## Testing

Both uninstaller tests previously flushed the cache by hand before asserting, which papered over the bug:

```php
/* The direct SQL delete bypasses the object cache */
wp_cache_flush();
```

Those flushes are gone, so the assertions now cover the real behaviour. The upgrade routine had no coverage at all and gains a test, including an unrelated `edd_sl_*` option that must survive the value filter.

All three tests fail without their corresponding fix (verified by stashing the `src/` changes). Full suite green both modes: **1150 tests / 3581 assertions** single-site, **1150 / 3680** multisite. `phpcs` clean.

No changelog entry, by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)