### PR TITLE
fix: unschedule deprecated per-add-on license check cron on upgrade to 6.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * 🧹 Housekeeping: When not network activated on Multisite, share the update cache across the network for an active license key
 * 🧹 Housekeeping: When the primary site is not activated on Multisite, display upgrade notices in the network admin on a best-effort basis
 * 🧹 Housekeeping: Turn autoloading off for the update cache data
-* 🧹 Housekeeping: Run an upgrade routine to remove the old update cache
+* 🧹 Housekeeping: Run an upgrade routine to remove the old update cache and cron
 * 🧹 Housekeeping: Delete all licensing data when running the uninstaller
 * 🧹 Housekeeping: Update PHP and JavaScript dependencies
 * 🐞 Bug: Show an error message when the license deactivation request fails with a server or authentication error, instead of leaving the spinner running

--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -184,6 +184,7 @@ class Controller_Upgrade_Routines {
 	 * @since 6.16.0
 	 */
 	protected function remove_legacy_license_check_cron() {
+		/* No public API lists all scheduled hooks, so read the cron array via the core internal (guarded below). */
 		$cron = _get_cron_array();
 		if ( ! is_array( $cron ) ) {
 			return;

--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -61,6 +61,7 @@ class Controller_Upgrade_Routines {
 
 		if ( version_compare( $current_version, '6.16.0', '>=' ) && version_compare( $old_version, '6.16.0', '<' ) ) {
 			$this->remove_legacy_update_cache();
+			$this->remove_legacy_license_check_cron();
 		}
 	}
 
@@ -173,5 +174,28 @@ class Controller_Upgrade_Routines {
 		   ever hit an API failure would otherwise carry a stale autoloaded option forever. */
 		delete_option( 'edd_sl_failed_http_' . md5( 'https://gravitypdf.com?api=1' ) );
 		delete_option( 'edd_sl_failed_http_' . md5( GPDF_API_URL ) );
+	}
+
+	/**
+	 * Unschedule the deprecated per-add-on `gfpdf_<slug>_license_check` cron events, superseded by the bulk check
+	 *
+	 * Sweep by pattern rather than by known slug so events left by add-ons that are no longer active are also removed.
+	 *
+	 * @since 6.16.0
+	 */
+	protected function remove_legacy_license_check_cron() {
+		$cron = _get_cron_array();
+		if ( ! is_array( $cron ) ) {
+			return;
+		}
+
+		foreach ( $cron as $events ) {
+			foreach ( array_keys( $events ) as $hook ) {
+				/* Match the old per-add-on events but keep the 6.16.0 bulk check that replaced them */
+				if ( $hook !== 'gfpdf_bulk_license_check' && preg_match( '/^gfpdf_.+_license_check$/', $hook ) ) {
+					wp_unschedule_hook( $hook );
+				}
+			}
+		}
 	}
 }

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
@@ -63,4 +63,26 @@ class Test_Controller_Upgrade_Routines extends WP_UnitTestCase {
 
 		delete_option( 'edd_sl_version_info_456' );
 	}
+
+	public function test_6_16_0_removes_legacy_license_check_cron() {
+		$future = time() + HOUR_IN_SECONDS;
+
+		/* Deprecated per-add-on events left behind by pre-6.16.0 installs */
+		wp_schedule_single_event( $future, 'gfpdf_core_booster_license_check' );
+		wp_schedule_single_event( $future, 'gfpdf_business_plus_license_check' );
+
+		/* The bulk check that replaced them, and an unrelated hook, must both survive */
+		wp_schedule_single_event( $future, 'gfpdf_bulk_license_check' );
+		wp_schedule_single_event( $future, 'gfpdf_cleanup_tmp_dir' );
+
+		do_action( 'gfpdf_version_changed', '6.15.0', '6.16.0' );
+
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_core_booster_license_check' ) );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_business_plus_license_check' ) );
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_cleanup_tmp_dir' ) );
+
+		wp_clear_scheduled_hook( 'gfpdf_bulk_license_check' );
+		wp_clear_scheduled_hook( 'gfpdf_cleanup_tmp_dir' );
+	}
 }


### PR DESCRIPTION
## Summary

In 6.16.0 the individual `gfpdf_<slug>_license_check` cron events were superseded by a single `gfpdf_bulk_license_check`. New code no longer schedules the per-add-on events, but there was no upgrade routine to remove the ones already scheduled on existing sites — so upgraded installs carried orphaned cron entries that only expired on their own after firing once.

This adds a 6.16.0 upgrade routine that unschedules those deprecated events.

## Changes

- **`src/Controller/Controller_Upgrade_Routines.php`** — new `remove_legacy_license_check_cron()`, wired into the existing `>= 6.16.0` upgrade branch alongside `remove_legacy_update_cache()`. It sweeps the cron array via `_get_cron_array()` and calls `wp_unschedule_hook()` on every hook matching `^gfpdf_.+_license_check$`, explicitly excluding the live `gfpdf_bulk_license_check`.
- **`tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php`** — new test verifying the deprecated per-add-on events are removed while the bulk check and an unrelated `gfpdf_*` hook survive.
- **`CHANGELOG.md`** — Housekeeping entry under 6.16.0.

## Design notes

- **Sweep by pattern, not by registered add-on.** Iterating `$this->data->addon` would only see currently-active add-ons; a pattern sweep also clears events left behind by add-ons that are no longer active — which is exactly the orphaned case this routine targets.
- **`wp_unschedule_hook()` over `wp_clear_scheduled_hook()`.** The former clears *all* events for a hook regardless of args, which is the correct primitive for a catch-all sweep.
- **Bulk-hook exclusion.** The regex `^gfpdf_.+_license_check$` also matches `gfpdf_bulk_license_check`, so the routine explicitly skips it to avoid unscheduling the replacement event.

## Testing

- `php -l` clean on the changed files.
- `--group upgrade` suite passes on live wp-env (3 tests, 9 assertions).

## Note on multisite

This runs per-site on version change (via `gfpdf_version_changed`), so each site clears its own cron when its stored version rolls over — the intended behaviour. A network-wide immediate sweep would require iterating sites explicitly; happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)