### PR TITLE
Merge 6.16.0 license/update/log-redact refinements from hot-patch-6.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Gravity PDF
 
+### 6.16.0
+* 🎉 Feature: Gravity Forms 3.0 compatibility
+* 🎉 Feature: Auto-activate/deactivate license key for installed Gravity PDF extensions when saving an Access Pass
+* 🎉 Feature: Support for setting a license key in code using the PHP constant `GPDF_LICENSE_KEY`
+* 🔒 Security: Redact sensitive information from log files
+* 🔒 Security: Harden update and license checks
+* 🧹 Housekeeping: Bulk license + update check for all Gravity PDF products
+* 🧹 Housekeeping: When network activated on Multisite, license checks are now completed by the primary site
+* 🧹 Housekeeping: When network activated on Multisite, the license admin page is hidden when not the primary site
+* 🧹 Housekeeping: When not network activated on Multisite, share the update cache across the network for an active license key
+* 🧹 Housekeeping: When the primary site is not activated on Multisite, display upgrade notices in the network admin on a best-effort basis
+* 🧹 Housekeeping: Turn autoloading off for the update cache data
+* 🧹 Housekeeping: Run an upgrade routine to remove the old update cache and cron
+* 🧹 Housekeeping: Delete all licensing data when running the uninstaller
+* 🧹 Housekeeping: Update PHP and JavaScript dependencies
+* 🐞 Bug: Show an error message when the license deactivation request fails with a server or authentication error, instead of leaving the spinner running
+* 🐞 Bug: Ignore repeat clicks of the Deactivate button while a request is in progress
+* 🐞 Bug: Clearing a license key from the settings now updates the license status straight away
+* 🐞 Bug: Delete all cached update information when a license key is deactivated/cleared from the settings page, or is rejected by the licensing server
+* 🐞 Bug: Fix PHP fatal error when doing an update check and the licensing server is unavailable
+* 🐞 Bug: Stop repeated update requests if the licensing server returns an empty response
+* 💻 Developer: Add `GPDFAPI::get_pdf_filename( $entry_id, $pdf_id, $include_extension )` to get the filename of a PDF
+* 💻 Developer: Add `gfpdf_addon_hardcoded_license_key` filter to override the `GPDF_LICENSE_KEY` constant
+* 💻 Developer: Add `gfpdf_logging_redact_keys` filter to redact additional keys from the Gravity PDF logs
+* 💻 Developer: Replace `edd_sl_*` hooks with `gpdf_sl_*` hooks
+* 💻 Developer: Add `gfpdf_addon_post_license_activation` and `gfpdf_addon_post_license_deactivation` actions
+* 💻 Developer: Deprecate `Helper_Abstract_Addon::plugin_updater()`, `Helper_Abstract_Addon::schedule_license_check()`, and `Model_Settings::deactivate_license_key()`
+
 ### 6.15.0
 * 🎉 Feature: Switch the update/license API server to api.gravitypdf.com
 * 🧹 Housekeeping: Remove MBString Regex as a software dependency

--- a/gravity-pdf-updater.php
+++ b/gravity-pdf-updater.php
@@ -58,8 +58,8 @@ add_action(
 add_action(
 	'http_api_debug',
 	function ( $response, $context, $class_object, $parsed_args, $url ) {
-		/* Log only Gravity PDF requests */
-		if ( $url !== GPDF_API_URL ) {
+		/* Log only Gravity PDF requests. The self-update check posts to a trailingslashit()'d URL, so normalise both sides. */
+		if ( untrailingslashit( $url ) !== untrailingslashit( GPDF_API_URL ) ) {
 			return;
 		}
 

--- a/pdf.php
+++ b/pdf.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Gravity PDF
-Version: 6.15.0
+Version: 6.16.0
 Description: Automatically generate highly customizable PDF documents using Gravity Forms and WordPress (canonical)
 Author: Blue Liquid Designs
 Author URI: https://blueliquiddesigns.com.au
@@ -36,7 +36,7 @@ if ( defined( 'PDF_PLUGIN_BASENAME' ) ) {
 /*
  * Set base constants we'll use throughout the plugin
  */
-define( 'PDF_EXTENDED_VERSION', '6.15.0' ); /* the current plugin version */
+define( 'PDF_EXTENDED_VERSION', '6.16.0' ); /* the current plugin version */
 define( 'PDF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); /* plugin directory path */
 define( 'PDF_PLUGIN_URL', plugin_dir_url( __FILE__ ) ); /* plugin directory url */
 define( 'PDF_PLUGIN_BASENAME', plugin_basename( __FILE__ ) ); /* the plugin basename */

--- a/src/Controller/Controller_Settings.php
+++ b/src/Controller/Controller_Settings.php
@@ -179,6 +179,10 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 					return;
 				}
 
+				if ( $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+					return;
+				}
+
 				add_action( 'gfpdf_bulk_license_check', [ $this->model, 'licensing_bulk_license_check' ] );
 				if ( ! wp_next_scheduled( 'gfpdf_bulk_license_check' ) ) {
 					wp_schedule_single_event( strtotime( '+1 week' ), 'gfpdf_bulk_license_check' );
@@ -310,28 +314,25 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 	 *
 	 * @return void
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	protected function maybe_schedule_network_update_check() {
-		if ( ! is_multisite() || get_current_blog_id() === 1 || is_plugin_active_for_network( PDF_PLUGIN_BASENAME ) ) {
+		if ( ! is_multisite() || is_main_site() ) {
+			return;
+		}
+
+		/* Network-activated installs already receive update checks through the normal flow */
+		if ( $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
 			return;
 		}
 
 		add_action( 'gfpdf_network_update_check', [ $this->model, 'run_network_update_check' ] );
 
-		/* skip if event already scheduled */
+		/* skip if event already scheduled; run_network_update_check() re-arms it each cycle */
 		if ( wp_next_scheduled( 'gfpdf_network_update_check' ) ) {
 			return;
 		}
 
-		/* grab the next run-time for a plugin update check on the primary site */
-		switch_to_blog( 1 );
-		$timestamp = wp_next_scheduled( 'wp_update_plugins' );
-		restore_current_blog();
-
-		if ( $timestamp !== false ) {
-			/* Run action 1 minute after the primary site schedules a plugin update check */
-			wp_schedule_event( $timestamp + 60, 'twicedaily', 'gfpdf_network_update_check' );
-		}
+		$this->model->schedule_network_update_check();
 	}
 }

--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -64,8 +64,9 @@ class Controller_Upgrade_Routines {
 			$this->fix_tmp_folder_permissions();
 		}
 
-		if ( version_compare( $current_version, '6.15.0', '>=' ) && version_compare( $old_version, '6.14.0', '<' ) ) {
+		if ( version_compare( $current_version, '6.16.0', '>=' ) && version_compare( $old_version, '6.16.0', '<' ) ) {
 			$this->remove_legacy_update_cache();
+			$this->remove_legacy_license_check_cron();
 		}
 	}
 
@@ -153,13 +154,54 @@ class Controller_Upgrade_Routines {
 	}
 
 	/**
-	 * Remove Gravity PDF's edd_sl_* options
+	 * Remove Gravity PDF's legacy edd_sl_* update cache options left behind by the previous plugin updater
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	protected function remove_legacy_update_cache() {
 		global $wpdb;
 
-		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'edd_sl_%' AND option_value LIKE '%gravity-pdf%'" );
+		/* Delete via the API: a stale autoloaded row left in the cache is the cost this routine exists to remove */
+		$keys = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s AND option_value LIKE %s",
+				$wpdb->esc_like( 'edd_sl_' ) . '%',
+				'%' . $wpdb->esc_like( 'gravity-pdf' ) . '%'
+			)
+		);
+
+		foreach ( $keys as $key ) {
+			delete_option( $key );
+		}
+
+		/* The failure-backoff option stores a bare timestamp, so the value filter above can't match it — target both
+		   the historical (≤6.14.x) and the 6.15.0 API hosts by exact name. 6.15.0's key was autoloaded, so a site that
+		   ever hit an API failure would otherwise carry a stale autoloaded option forever. */
+		delete_option( 'edd_sl_failed_http_' . md5( 'https://gravitypdf.com?api=1' ) );
+		delete_option( 'edd_sl_failed_http_' . md5( GPDF_API_URL ) );
+	}
+
+	/**
+	 * Unschedule the deprecated per-add-on `gfpdf_<slug>_license_check` cron events, superseded by the bulk check
+	 *
+	 * Sweep by pattern rather than by known slug so events left by add-ons that are no longer active are also removed.
+	 *
+	 * @since 6.16.0
+	 */
+	protected function remove_legacy_license_check_cron() {
+		/* No public API lists all scheduled hooks, so read the cron array via the core internal (guarded below). */
+		$cron = _get_cron_array();
+		if ( ! is_array( $cron ) ) {
+			return;
+		}
+
+		foreach ( $cron as $events ) {
+			foreach ( array_keys( $events ) as $hook ) {
+				/* Match the old per-add-on events but keep the 6.16.0 bulk check that replaced them */
+				if ( $hook !== 'gfpdf_bulk_license_check' && preg_match( '/^gfpdf_.+_license_check$/', $hook ) ) {
+					wp_unschedule_hook( $hook );
+				}
+			}
+		}
 	}
 }

--- a/src/Helper/Helper_Abstract_Addon.php
+++ b/src/Helper/Helper_Abstract_Addon.php
@@ -127,37 +127,37 @@ abstract class Helper_Abstract_Addon {
 
 	/**
 	 * @var EDD_SL_Plugin_Updater
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	protected $plugin_updater;
 
 	/**
 	 * @var string The current license key for this addon
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	protected $license_key = '';
 
 	/**
 	 * @var string The current license key status (retrieved from the API) for this addon
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	protected $license_key_status = '';
 
 	/**
 	 * @var string The current license key message for this addon (based on the status)
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	protected $license_key_message = '';
 
 	/**
 	 * @var bool Whether the addon activated the license based on another addon activation
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	protected $license_auto_activated = false;
 
 	/**
 	 * @var bool Whether the addon deactivated the license based on another addon deactivation
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	protected $license_auto_deactivated = false;
 
@@ -291,12 +291,12 @@ abstract class Helper_Abstract_Addon {
 
 	/**
 	 * @return EDD_SL_Plugin_Updater|null
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function get_plugin_updater() {
 		$updater = $this->plugin_updater;
 		if ( ! $updater ) {
-			_doing_it_wrong( __METHOD__, 'This method should not be called before the "init" hook (priority 1)', '6.15.0' );
+			_doing_it_wrong( __METHOD__, 'This method should not be called before the "init" hook (priority 1)', '6.16.0' );
 		}
 
 		return $updater;
@@ -325,15 +325,7 @@ abstract class Helper_Abstract_Addon {
 
 		/* Maybe auto-activate hardcoded license */
 		$maybe_activate_hardcoded_license = function () {
-			$hardcoded_license = $this->get_license_key_from_constant();
-			if (
-				$hardcoded_license && /* is constant defined */
-				$hardcoded_license !== $this->license_key && /* is hardcoded license different to DB version */
-				! $this->license_auto_activated && /* if addon hasn't already be auto-activated when another addon was activated */
-				is_admin() /* is the admin area */
-			) {
-				$this->activate_license( $hardcoded_license, true );
-			}
+			$this->maybe_activate_hardcoded_license();
 		};
 
 		add_action( 'init', $maybe_activate_hardcoded_license, 2 );
@@ -418,13 +410,13 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @return void
 	 * @since 4.2
-	 * @depecated 6.15.0 Use self::central_plugin_updater()
+	 * @deprecated 6.16.0 Use self::central_plugin_updater()
 	 */
 	public function plugin_updater() {}
 
 	/**
 	 * @return array
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function get_default_api_params() {
 		return [
@@ -441,7 +433,7 @@ abstract class Helper_Abstract_Addon {
 	 * The central add-on update initializer
 	 *
 	 * @return void
-	 * @since 6.14
+	 * @since 6.16.0
 	 */
 	protected function central_plugin_updater() {
 		$this->plugin_updater = new EDD_SL_Plugin_Updater(
@@ -450,7 +442,49 @@ abstract class Helper_Abstract_Addon {
 			$this->get_default_api_params()
 		);
 
+		$this->plugin_updater->set_license_status( $this->get_license_status() );
 		$this->plugin_updater->init();
+	}
+
+	/**
+	 * Activate a hardcoded license key (set via the GPDF_LICENSE_KEY constant) on an admin request.
+	 *
+	 * Retries while the stored status isn't active/valid so a transient API failure on the first attempt self-heals,
+	 * and re-activates when the constant key is rotated. A short backoff keeps a rejected or unreachable key from
+	 * hitting the licensing API on every admin request.
+	 *
+	 * @return void
+	 * @since 6.16.0
+	 */
+	protected function maybe_activate_hardcoded_license() {
+		$hardcoded_license = $this->get_license_key_from_constant();
+		if ( ! $hardcoded_license || $this->license_auto_activated || ! is_admin() ) {
+			return;
+		}
+
+		/* On a network-activated Multisite, only the primary site activates the hardcoded license */
+		if ( \GPDFAPI::get_misc_class()->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return;
+		}
+
+		$key_changed = $hardcoded_license !== $this->license_key;
+		$is_active   = in_array( $this->get_license_status(), [ 'active', 'valid' ], true );
+
+		if ( ! $key_changed && $is_active ) {
+			return;
+		}
+
+		/* Back off retries for an unchanged, still-inactive key so a bad or unreachable key doesn't POST every request */
+		$backoff = 'gfpdf_license_activation_' . $this->get_slug();
+		if ( ! $key_changed && get_transient( $backoff ) ) {
+			return;
+		}
+
+		$this->activate_license( $hardcoded_license, true );
+
+		if ( ! in_array( $this->get_license_status(), [ 'active', 'valid' ], true ) ) {
+			set_transient( $backoff, 1, 3 * HOUR_IN_SECONDS );
+		}
 	}
 
 	/**
@@ -617,7 +651,7 @@ abstract class Helper_Abstract_Addon {
 	 * @param bool $use_database Fetch license info from the database
 	 *
 	 * @since    4.2
-	 * @since 6.15.0 Get license info stored in the object
+	 * @since 6.16.0 Get license info stored in the object
 	 */
 	public function get_license_info( $use_database = false ) {
 		if ( $use_database ) {
@@ -635,6 +669,8 @@ abstract class Helper_Abstract_Addon {
 			'message' => $this->get_license_message(),
 		];
 
+		$this->log->notice( 'Get plugin license details', $license_details );
+
 		return $license_details;
 	}
 
@@ -645,7 +681,7 @@ abstract class Helper_Abstract_Addon {
 	 * @param bool $use_database Whether to update the database or not. A DB update will auto-call Model_Settings::maybe_active_licenses(), which may not be ideal
 	 *
 	 * @since    4.2
-	 * @since 6.15.0 Added
+	 * @since 6.16.0 Added
 	 */
 	public function update_license_info( $license_info, $use_database = false ) {
 		$this->license_key         = $license_info['license'] ?? '';
@@ -655,6 +691,7 @@ abstract class Helper_Abstract_Addon {
 		/* Check the update has been initialized before setting the license key */
 		if ( isset( $this->plugin_updater ) ) {
 			$this->plugin_updater->set_license_key( $this->license_key );
+			$this->plugin_updater->set_license_status( $this->license_key_status );
 		}
 
 		if ( ! $use_database ) {
@@ -671,6 +708,22 @@ abstract class Helper_Abstract_Addon {
 		$this->log->notice( 'Update plugin license details', $license_info );
 
 		$this->options->update_settings( $settings );
+	}
+
+	/**
+	 * Whether incoming license info differs from what this add-on already holds
+	 *
+	 * The incoming key is compared against the raw `$license_key` property, not get_license_key(), which folds in the
+	 * `GPDF_LICENSE_KEY` constant and so reads identically on both sides however the add-on's own key changed.
+	 *
+	 * @param array $license_info
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	private function license_info_has_changed( $license_info ) {
+		return $license_info['license'] !== $this->license_key || $license_info['status'] !== $this->license_key_status;
 	}
 
 	/**
@@ -718,7 +771,7 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @return false|string
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	final public function get_license_key_from_constant() {
 		$slug = $this->get_slug();
@@ -770,17 +823,28 @@ abstract class Helper_Abstract_Addon {
 	 * Whether the addon activated the license based on another addon activation
 	 *
 	 * @return bool
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	final public function has_license_auto_activated() {
 		return $this->license_auto_activated;
 	}
 
 	/**
+	 * Whether the license key is controlled by the site rather than the settings form — a `GPDF_LICENSE_KEY`
+	 * constant or an auto-activated Access Pass. Such a key is authoritative: a submitted value must be ignored.
+	 *
+	 * @return bool
+	 * @since 6.16.0
+	 */
+	final public function is_license_admin_managed() {
+		return (bool) $this->get_license_key_from_constant() || $this->has_license_auto_activated();
+	}
+
+	/**
 	 * Whether the addon deactivated the license based on another addon deactivation.
 	 *
 	 * @return bool
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	final public function has_license_auto_deactivated() {
 		return $this->license_auto_deactivated;
@@ -794,7 +858,7 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @since    4.2
 	 *
-	 * @depreacted 6.15.0 Handled in bulk via Model_Settings::licensing_bulk_license_check()
+	 * @deprecated 6.16.0 Handled in bulk via Model_Settings::licensing_bulk_license_check()
 	 */
 	final public function maybe_schedule_license_check() {
 		if ( ! wp_next_scheduled( 'gfpdf_' . $this->get_slug() . '_license_check' ) ) {
@@ -808,6 +872,11 @@ abstract class Helper_Abstract_Addon {
 	 * @since    4.2
 	 */
 	public function schedule_license_check() {
+		/* On a network-activated Multisite, only the primary site runs the license check */
+		if ( \GPDFAPI::get_misc_class()->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return false;
+		}
+
 		/* If there's no license key disable the check */
 		if ( empty( $this->get_license_key() ) ) {
 			return false;
@@ -874,7 +943,7 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @return bool
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function update_license_status_from_response( $license_key, $response, $use_database = false ) {
 		$response_code = wp_remote_retrieve_response_code( $response );
@@ -889,7 +958,6 @@ abstract class Helper_Abstract_Addon {
 			$license_data = json_decode( wp_remote_retrieve_body( $response ) );
 		}
 
-		$license_info       = $this->get_license_info();
 		$possible_responses = $this->data->addon_license_responses( $this->get_name() );
 
 		$status = 'error';
@@ -899,18 +967,30 @@ abstract class Helper_Abstract_Addon {
 			$status = $license_data->license;
 		}
 
-		$license_info['license'] = $license_key;
-		$license_info['status']  = $status;
-		$license_info['message'] = $possible_responses[ $license_info['status'] ] ?? $possible_responses['generic'];
+		/* Build the info fresh — all three fields are set here, so a get_license_info() read (and its per-call
+		   "Get plugin license details" notice) would be redundant */
+		$license_info = [
+			'license' => $license_key,
+			'status'  => $status,
+			'message' => $possible_responses[ $status ] ?? $possible_responses['generic'],
+		];
 
 		switch ( $license_info['status'] ) {
 			case 'expired':
 				$date_format = get_option( 'date_format' );
-				try {
-					$dt   = new \DateTimeImmutable( $license_data->expires, wp_timezone() );
-					$date = $dt->format( $date_format );
-				} catch ( \Exception $e ) {
-					$date = gmdate( $date_format, false );
+				$expires     = $license_data->expires ?? '';
+
+				if ( empty( $expires ) ) {
+					/* DateTimeImmutable('') silently resolves to "now", implying the key expired today; surface unknown */
+					$date = __( 'an unknown date', 'gravity-pdf' );
+				} else {
+					try {
+						$dt   = new \DateTimeImmutable( $expires, wp_timezone() );
+						$date = $dt->format( $date_format );
+					} catch ( \Exception $e ) {
+						/* gmdate() without a timestamp uses the current time, avoiding the 1 Jan 1970 gmdate(fmt, false) gives */
+						$date = gmdate( $date_format );
+					}
 				}
 
 				$url = add_query_arg(
@@ -930,7 +1010,7 @@ abstract class Helper_Abstract_Addon {
 					[
 						'edd_action'            => 'add_to_cart',
 						'download_id'           => $this->get_edd_download_id(),
-						'edd_options[price_id]' => $license_data->price_id,
+						'edd_options[price_id]' => $license_data->price_id ?? '',
 					],
 					'https://gravitypdf.com/checkout/'
 				);
@@ -943,8 +1023,8 @@ abstract class Helper_Abstract_Addon {
 					[
 						'view'       => 'upgrades',
 						'action'     => 'manage_licenses',
-						'license_id' => $license_data->license_id,
-						'payment_id' => $license_data->payment_id,
+						'license_id' => $license_data->license_id ?? '',
+						'payment_id' => $license_data->payment_id ?? '',
 					],
 					'https://gravitypdf.com/account/'
 				);
@@ -967,6 +1047,12 @@ abstract class Helper_Abstract_Addon {
 	 * @since 4.3
 	 */
 	public function license_registration() {
+
+		/* On a network-activated Multisite, the primary site manages licensing */
+		if ( \GPDFAPI::get_misc_class()->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return;
+		}
+
 		$edd_id = $this->get_edd_download_id();
 		if ( in_array( $this->get_license_status(), [ 'active', 'valid' ], true ) || empty( $edd_id ) ) {
 			return;
@@ -1034,7 +1120,7 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @return array The API response and license status
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function activate_license( $license_key = '', $use_database = false ) {
 
@@ -1071,9 +1157,15 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @return void
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
-	public function maybe_auto_activate_license( $response, $addon, $use_database ) {
+	public function maybe_auto_activate_license( $response, $addon, $use_database = false ) {
+		/* The gfpdf_addon_post_license_activation action is public: a third-party do_action() may fire it with fewer
+		   args (default $use_database) or a non-addon second arg — bail before dereferencing it */
+		if ( ! $addon instanceof self ) {
+			return;
+		}
+
 		/* skip if current addon doing licence activation */
 		if ( $this->get_edd_download_id() === $addon->get_edd_download_id() ) {
 			return;
@@ -1094,7 +1186,16 @@ abstract class Helper_Abstract_Addon {
 			return;
 		}
 
-		$this->update_license_info( $addon->get_license_info(), $use_database );
+		$license_info = $addon->get_license_info();
+		$has_changed  = $this->license_info_has_changed( $license_info );
+
+		$this->update_license_info( $license_info, $use_database );
+
+		/* Cached update info was fetched under the old key, so it holds no package for the new one. A hardcoded key
+		   re-fires this action every few hours, so skip the flush when nothing actually moved. */
+		if ( $has_changed ) {
+			$this->flush_update_cache();
+		}
 
 		$this->license_auto_activated = true;
 	}
@@ -1104,7 +1205,7 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @return bool
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function deactivate_license() {
 		$response = wp_remote_post(
@@ -1148,9 +1249,14 @@ abstract class Helper_Abstract_Addon {
 	 *
 	 * @return void
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function maybe_auto_deactivate_license( $response, $addon ) {
+		/* Public action (see maybe_auto_activate_license): guard against a non-addon second arg from a third-party do_action() */
+		if ( ! $addon instanceof self ) {
+			return;
+		}
+
 		/* skip if current addon doing licence activation */
 		if ( $this->get_edd_download_id() === $addon->get_edd_download_id() ) {
 			return;
@@ -1171,7 +1277,14 @@ abstract class Helper_Abstract_Addon {
 			return;
 		}
 
-		$this->update_license_info( $addon->get_license_info(), true );
+		$license_info = $addon->get_license_info();
+		$has_changed  = $this->license_info_has_changed( $license_info );
+
+		$this->update_license_info( $license_info, true );
+
+		if ( $has_changed ) {
+			$this->flush_update_cache();
+		}
 
 		$this->license_auto_deactivated = true;
 	}
@@ -1179,7 +1292,7 @@ abstract class Helper_Abstract_Addon {
 	/**
 	 * Delete the add-on update information
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 * @return void
 	 */
 	public function flush_update_cache() {
@@ -1189,5 +1302,6 @@ abstract class Helper_Abstract_Addon {
 
 		$this->plugin_updater->delete_version_info_cache();
 		$this->plugin_updater->delete_transient_plugin_info();
+		$this->plugin_updater->delete_network_version_info_cache();
 	}
 }

--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -1715,9 +1715,9 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		/* get selected value (if any) */
 		$value = $this->get_form_value( $args );
 
-		/** @var Helper_Abstract_Addon $addon */
-		$addon             = $args['data'];
-		$hardcoded_license = $addon->get_license_key_from_constant();
+		/** @var Helper_Abstract_Addon|null $addon */
+		$addon             = $args['data'] ?? null;
+		$hardcoded_license = $addon instanceof Helper_Abstract_Addon ? $addon->get_license_key_from_constant() : '';
 		if ( $hardcoded_license ) {
 			$value['key']   = $hardcoded_license;
 			$args['desc2']  = __( 'License key set by the site administrator.', 'gravity-pdf' );

--- a/src/Helper/Helper_Data.php
+++ b/src/Helper/Helper_Data.php
@@ -247,6 +247,7 @@ class Helper_Data {
 				'disable'                              => esc_html__( 'Disable', 'gravity-pdf' ),
 				'updateSuccess'                        => esc_html__( 'Successfully Updated', 'gravity-pdf' ),
 				'deleteSuccess'                        => esc_html__( 'Successfully Deleted', 'gravity-pdf' ),
+				'licenseDeactivationError'             => esc_html__( 'An error occurred and your license key may not have been correctly deactivated. Login to your GravityPDF.com account and check if your site has been unlinked from the key.', 'gravity-pdf' ),
 				'no'                                   => esc_html__( 'No', 'gravity-pdf' ),
 				'yes'                                  => esc_html__( 'Yes', 'gravity-pdf' ),
 				'standard'                             => esc_html__( 'Standard', 'gravity-pdf' ),

--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -399,12 +399,9 @@ class Helper_Misc {
 		/* Check if $dir to delete falls inside one of the Gravity PDF directories */
 		$allowed_to_delete = false;
 		foreach ( $folders as $folder ) {
-			$real_folder_path = realpath( $folder );
-			if ( ! $real_folder_path ) {
-				continue;
-			}
+			$folder_path = realpath( $folder );
 
-			if ( strpos( $path_to_test, $real_folder_path ) === 0 ) {
+			if ( $folder_path !== false && strpos( $path_to_test, $folder_path ) === 0 ) {
 				$allowed_to_delete = true;
 				break;
 			}
@@ -1108,5 +1105,26 @@ class Helper_Misc {
 			/* Unauthorized response */
 			wp_die( '401', 401 );
 		}
+	}
+
+	/**
+	 * Whether the current site is a secondary site on a Multisite network where the plugin is network activated
+	 *
+	 * Used to restrict license/update API checks to the primary site.
+	 *
+	 * @param string $plugin_basename The plugin to test for network activation (eg. PDF_PLUGIN_BASENAME)
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	public function is_secondary_network_site( $plugin_basename ) {
+		if ( ! is_multisite() || is_main_site() ) {
+			return false;
+		}
+
+		$network_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+
+		return isset( $network_plugins[ $plugin_basename ] );
 	}
 }

--- a/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
+++ b/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @author  Easy Digital Downloads
  * @version 1.9.4
- * @since   6.15.0 Modified to make this class more useful for our plugin suite
+ * @since   6.16.0 Modified to make this class more useful for our plugin suite
  */
 class EDD_SL_Plugin_Updater {
 
@@ -32,6 +32,28 @@ class EDD_SL_Plugin_Updater {
 	protected $wp_override = false;
 	protected $beta        = false;
 	protected $failed_request_cache_key;
+
+	/* Local gate for sharing a package across a Multisite; kept off api_data so it never rides an outbound API request */
+	protected $license_status = '';
+
+	/* The network-shared package outlives the per-site 3h check cache so a quiet licensed site can't let it lapse */
+	protected const NETWORK_CACHE_TTL = 3 * DAY_IN_SECONDS;
+
+	/*
+	 * Drawn from Helper_Data::addon_license_responses(). `error` and `rate_limit` are deliberately absent — a failed or
+	 * throttled request is not a verdict on the license, so it must not strip a package other sites depend on.
+	 */
+	protected const UNENTITLED_LICENSE_STATUSES = [
+		'expired',
+		'revoked',
+		'disabled',
+		'missing',
+		'invalid',
+		'site_inactive',
+		'item_name_mismatch',
+		'invalid_item_id',
+		'no_activations_left',
+	];
 
 	/**
 	 * Class constructor.
@@ -121,11 +143,44 @@ class EDD_SL_Plugin_Updater {
 	 */
 	public function get_repo_api_data() {
 		$version_info = $this->get_cached_version_info();
-		if ( $version_info !== false ) {
+		if ( false === $version_info ) {
+			$version_info = $this->get_version_info();
+		}
+
+		return $this->maybe_apply_network_package( $version_info );
+	}
+
+	/**
+	 * Borrow a licensed download package cached by another site on the network
+	 *
+	 * On a Multisite where the plugin is activated per-site (not network-wide) each site checks for updates using its
+	 * own license. A site without a valid license still receives version info but an empty `package`, which would
+	 * otherwise overwrite the shared update_plugins transient and strip the download URL for every site. When any site
+	 * does hold a valid license it promotes its package to a network option (see set_version_info_cache()); here we fall
+	 * back to that package so the whole network can install the update.
+	 *
+	 * @param \stdClass|false $version_info
+	 *
+	 * @return \stdClass|false
+	 *
+	 * @since 6.16.0
+	 */
+	protected function maybe_apply_network_package( $version_info ) {
+		if ( ! is_multisite() || ! is_object( $version_info ) || ! empty( $version_info->package ) ) {
 			return $version_info;
 		}
 
-		return $this->get_version_info();
+		$network = $this->get_network_cached_version_info();
+		if (
+			is_object( $network )
+			&& ! empty( $network->package )
+			&& ! empty( $version_info->new_version )
+			&& version_compare( $network->new_version ?? '', $version_info->new_version, '>=' )
+		) {
+			$version_info->package = $network->package;
+		}
+
+		return $version_info;
 	}
 
 	/**
@@ -358,12 +413,9 @@ class EDD_SL_Plugin_Updater {
 		// Get the transient where we store the api request for this plugin for 24 hours
 		$edd_api_request_transient = $this->get_cached_version_info();
 
-		//If we have no transient-saved value, run the API, set a fresh transient with the API value, and return that value too right now.
+		//If we have no transient-saved value, run the API (which caches a successful response internally) and return it too right now.
 		if ( empty( $edd_api_request_transient ) ) {
 			$api_response = $this->get_version_info();
-
-			// Expires in 3 hours
-			$this->set_version_info_cache( $api_response );
 
 			if ( false !== $api_response ) {
 				$_data = $api_response;
@@ -372,12 +424,15 @@ class EDD_SL_Plugin_Updater {
 			$_data = $edd_api_request_transient;
 		}
 
-		if ( ! isset( $_data->plugin ) ) {
-			$_data->plugin = $this->name;
-		}
+		// $_data stays false when get_version_info() bails (API down, backoff, secondary site) — assigning to a bool fatals on PHP 8.
+		if ( is_object( $_data ) ) {
+			if ( ! isset( $_data->plugin ) ) {
+				$_data->plugin = $this->name;
+			}
 
-		if ( ! isset( $_data->version ) && ! empty( $_data->new_version ) ) {
-			$_data->version = $_data->new_version;
+			if ( ! isset( $_data->version ) && ! empty( $_data->new_version ) ) {
+				$_data->version = $_data->new_version;
+			}
 		}
 
 		return $_data;
@@ -408,6 +463,37 @@ class EDD_SL_Plugin_Updater {
 	}
 
 	/**
+	 * Normalize a sections/banners/icons value into an associative array.
+	 *
+	 * The store may hand these back as a JSON-encoded string, a legacy PHP-serialized array (a:N:{...}), or an
+	 * already-decoded object (some EDD endpoints). JSON is attempted first since it can't trigger object injection; a
+	 * serialized value is only unserialized when it is an array and with `allowed_classes => false`, so any nested
+	 * object is neutralized and a bare serialized-object payload (O:...) — the object-injection vector the earlier
+	 * hardening guarded against — is refused and collapses to an empty array.
+	 *
+	 * @param string|array|\stdClass $data
+	 *
+	 * @return array
+	 *
+	 * @since 6.16.0
+	 */
+	public function normalize_api_collection( $data ) {
+		if ( is_string( $data ) ) {
+			$json = json_decode( $data );
+
+			if ( json_last_error() === JSON_ERROR_NONE && ( is_array( $json ) || is_object( $json ) ) ) {
+				$data = $json;
+			} elseif ( preg_match( '/^a:\d+:\{/', $data ) ) {
+				$data = unserialize( $data, [ 'allowed_classes' => false ] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- object injection is guarded by allowed_classes => false
+			}
+		}
+
+		// A string we couldn't decode (or a failed unserialize) falls through here; convert_object_to_array() maps any
+		// non-array/object to [], so an unrecognized payload safely collapses to an empty collection.
+		return $this->convert_object_to_array( $data );
+	}
+
+	/**
 	 * Calls the API and, if successful, returns the object delivered by the API.
 	 *
 	 * @return \stdClass|false
@@ -415,6 +501,11 @@ class EDD_SL_Plugin_Updater {
 	public function get_version_info() {
 		/* Don't allow a plugin to ping itself */
 		if ( trailingslashit( home_url() ) === $this->api_url ) {
+			return false;
+		}
+
+		/* The primary site checks for updates on behalf of network-activated installs */
+		if ( \GPDFAPI::get_misc_class()->is_secondary_network_site( $this->name ) ) {
 			return false;
 		}
 
@@ -515,7 +606,7 @@ class EDD_SL_Plugin_Updater {
 	 *
 	 * @return array
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function get_version_api_params() {
 		return [
@@ -524,7 +615,7 @@ class EDD_SL_Plugin_Updater {
 			'item_id'     => $this->api_data['item_id'] ?? false,
 			'version'     => $this->api_data['version'] ?? false,
 			'slug'        => $this->slug,
-			'author'      => $this->api_data['author'],
+			'author'      => $this->api_data['author'] ?? '',
 			'url'         => home_url(),
 			'beta'        => $this->beta,
 			'php_version' => phpversion(),
@@ -571,6 +662,13 @@ class EDD_SL_Plugin_Updater {
 		$response = apply_filters( 'gpdf_sl_plugin_updater_api_response', $response, $this->api_data, $this->plugin_file );
 		$response = $this->standardize_api_response( $response );
 
+		// A 200 with an empty/unparseable body yields false — back off like any other failure so we don't re-POST every call.
+		if ( false === $response ) {
+			$this->log_failed_request();
+
+			return false;
+		}
+
 		$this->set_version_info_cache( $response );
 
 		return $response;
@@ -584,21 +682,44 @@ class EDD_SL_Plugin_Updater {
 	 * @return object|false
 	 */
 	public function get_cached_version_info( $cache_key = '' ) {
-
 		if ( empty( $cache_key ) ) {
 			$cache_key = $this->get_cache_key();
 		}
 
-		$cache = get_option( $cache_key );
+		return $this->read_timed_cache( get_option( $cache_key ) );
+	}
 
-		/* Cache is expired */
+	/**
+	 * Get the licensed version info promoted to the network cache by any site on a Multisite, if it exists
+	 *
+	 * @return \stdClass|false
+	 *
+	 * @since 6.16.0
+	 */
+	public function get_network_cached_version_info() {
+		return $this->read_timed_cache( get_site_option( $this->get_network_cache_key() ) );
+	}
+
+	/**
+	 * Decode a timed version-info cache payload, shared by the per-site and network cache readers
+	 *
+	 * @param mixed $cache The stored [ 'timeout' => int, 'value' => string ] payload
+	 *
+	 * @return \stdClass|false
+	 *
+	 * @since 6.16.0
+	 */
+	protected function read_timed_cache( $cache ) {
+		/* Guard against a corrupted scalar-string option: array access on a string throws a TypeError on PHP 8 */
+		if ( ! is_array( $cache ) ) {
+			return false;
+		}
+
 		if ( empty( $cache['timeout'] ) || time() > $cache['timeout'] ) {
 			return false;
 		}
 
-		$value = json_decode( $cache['value'] );
-
-		return $this->standardize_api_response( $value );
+		return $this->standardize_api_response( json_decode( $cache['value'] ) );
 	}
 
 	/**
@@ -626,6 +747,18 @@ class EDD_SL_Plugin_Updater {
 		];
 
 		update_option( $cache_key, $data, false );
+
+		/*
+		 * Promote the package to a network option so any site on the Multisite can install the update. The store can
+		 * return a package URL even when the license is inactive (that URL errors on access), so only an active license
+		 * is allowed to share its package. The promoting site is recorded so it alone can withdraw the package later.
+		 */
+		if ( is_multisite() && $this->is_license_active() && is_object( $value ) && ! empty( $value->package ) ) {
+			$network_data            = $data;
+			$network_data['timeout'] = time() + self::NETWORK_CACHE_TTL;
+			$network_data['blog_id'] = get_current_blog_id();
+			update_site_option( $this->get_network_cache_key(), $network_data );
+		}
 	}
 
 	/**
@@ -635,7 +768,7 @@ class EDD_SL_Plugin_Updater {
 	 *
 	 * @return bool
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function delete_version_info_cache( $cache_key = '' ) {
 		if ( empty( $cache_key ) ) {
@@ -646,11 +779,40 @@ class EDD_SL_Plugin_Updater {
 	}
 
 	/**
+	 * Withdraw the package this site shared with the network, so a removed license stops backing network-wide downloads
+	 *
+	 * Ownership counts as much as the license state: a package promoted by another site belongs to a site that is still
+	 * licensed, and must outlive this one losing its own.
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	public function delete_network_version_info_cache() {
+		if ( ! is_multisite() ) {
+			return false;
+		}
+
+		$lost_license = empty( $this->api_data['license'] ) || in_array( $this->license_status, self::UNENTITLED_LICENSE_STATUSES, true );
+		if ( ! $lost_license ) {
+			return false;
+		}
+
+		$cache_key = $this->get_network_cache_key();
+		$cache     = get_site_option( $cache_key );
+		if ( ! is_array( $cache ) || (int) ( $cache['blog_id'] ?? 0 ) !== get_current_blog_id() ) {
+			return false;
+		}
+
+		return delete_site_option( $cache_key );
+	}
+
+	/**
 	 * Delete the cached update info without removing the entire update plugin data
 	 *
 	 * @return bool
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function delete_transient_plugin_info() {
 		$plugin_update = get_site_transient( 'update_plugins' );
@@ -698,16 +860,51 @@ class EDD_SL_Plugin_Updater {
 	}
 
 	/**
+	 * The network option name used to share a licensed package across a Multisite
+	 *
+	 * @return string
+	 *
+	 * @since 6.16.0
+	 */
+	public function get_network_cache_key() {
+		return 'gpdf_sl_net_' . md5( $this->slug );
+	}
+
+	/**
 	 * Allow the license key to be set mid-flight
 	 *
 	 * @param string $license_key
 	 *
 	 * @return void
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function set_license_key( $license_key ) {
 		$this->api_data['license'] = $license_key;
+	}
+
+	/**
+	 * Allow the license status to be set mid-flight
+	 *
+	 * @param string $license_status
+	 *
+	 * @return void
+	 *
+	 * @since 6.16.0
+	 */
+	public function set_license_status( $license_status ) {
+		$this->license_status = $license_status;
+	}
+
+	/**
+	 * Whether the current site holds an active/valid license for this add-on
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.0
+	 */
+	protected function is_license_active() {
+		return in_array( $this->license_status, [ 'active', 'valid' ], true );
 	}
 
 	/**
@@ -716,20 +913,23 @@ class EDD_SL_Plugin_Updater {
 	 * @return false|\StdClass
 	 */
 	public function standardize_api_response( $response ) {
-		if ( empty( $response ) ) {
+		/* A non-object (false/null/scalar/array — from a filter or a malformed 200 body) would fatal on the property writes below (PHP 8) */
+		if ( ! is_object( $response ) ) {
 			return false;
 		}
 
+		// sections/banners/icons may arrive as a JSON string, a legacy serialized array, or an already-decoded object;
+		// normalize_api_collection() turns each into an array (see it for the object-injection guard on strings).
 		if ( isset( $response->sections ) ) {
-			$response->sections = $this->convert_object_to_array( maybe_unserialize( $response->sections ) );
+			$response->sections = $this->normalize_api_collection( $response->sections );
 		}
 
 		if ( isset( $response->banners ) ) {
-			$response->banners = $this->convert_object_to_array( maybe_unserialize( $response->banners ) );
+			$response->banners = $this->normalize_api_collection( $response->banners );
 		}
 
 		if ( isset( $response->icons ) ) {
-			$response->icons = $this->convert_object_to_array( maybe_unserialize( $response->icons ) );
+			$response->icons = $this->normalize_api_collection( $response->icons );
 		}
 
 		if ( ! empty( $response->sections ) ) {
@@ -757,10 +957,21 @@ class EDD_SL_Plugin_Updater {
 	/**
 	 * @return string
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function get_plugin_file() {
 		return $this->plugin_file;
+	}
+
+	/**
+	 * The plugin-folder basename sent as `slug` in the version API request and echoed back in the response.
+	 *
+	 * @return string
+	 *
+	 * @since 6.16.0
+	 */
+	public function get_slug() {
+		return $this->slug;
 	}
 
 	/**
@@ -773,14 +984,18 @@ class EDD_SL_Plugin_Updater {
 	 *
 	 * @return bool
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	protected function is_non_active_multisite() {
 		if ( ! is_multisite() ) {
 			return false;
 		}
 
-		if ( is_plugin_active( $this->name ) ) {
+		// is_plugin_active() is in wp-admin/includes/plugin.php, unloaded on the frontend and during WP-Cron.
+		$active_plugins  = (array) get_option( 'active_plugins', [] );
+		$network_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+
+		if ( in_array( $this->name, $active_plugins, true ) || isset( $network_plugins[ $this->name ] ) ) {
 			return false;
 		}
 

--- a/src/Helper/Log/Logger.php
+++ b/src/Helper/Log/Logger.php
@@ -208,23 +208,8 @@ class Logger {
 		/* Add our log file stream */
 		$this->log->pushHandler( $stream );
 
-		/* Add a redact handler to mask sensitive details */
-		$redact = new Redact_Processor(
-			[
-				/* only mask values that look like a license key */
-				'license'         => '/[A-Fa-f0-9]{28}/',
-				'edd_license_key' => '/[A-Fa-f0-9]{28}/',
-
-				/* direct update links */
-				'package'         => 23,
-				'download_link'   => 23,
-			],
-			'*',
-			'%s',
-			32
-		);
-
-		$this->log->pushProcessor( $redact );
+		/* Add a redact processor to mask secrets (license keys, signed update URLs, tokens) from the log */
+		$this->log->pushProcessor( new Redact_Processor( $this->slug ) );
 	}
 
 	/**

--- a/src/Helper/Log/Redact_Processor.php
+++ b/src/Helper/Log/Redact_Processor.php
@@ -1,181 +1,184 @@
 <?php
 
+declare( strict_types=1 );
+
 namespace GFPDF\Helper\Log;
 
 use GFPDF_Vendor\Monolog\Processor\ProcessorInterface;
 
 /**
- * Redact sensitive information from MonoLog context
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Monolog processor that strips secrets and neutralises log-injection before a record is formatted.
  *
- * @package   RedactSensitive
- * @license   MIT License
- * @copyright Copyright (c) 2021 Leo Cavalcante
- * @link      https://github.com/leocavalcante/redact-sensitive/
+ * Gravity PDF logs licensing keys and signed EDD package/download URLs, so redaction is a real requirement.
+ * Two rules a purely keyed model can't satisfy:
+ *
+ *  - Pattern-based message redaction. The message is a free-form sprintf-baked string with no key to match on, so a
+ *    secret interpolated into it ("License $key rejected", a signed URL in an error, a Bearer token echoed from an
+ *    HTTP failure) is invisible to key redaction. So the message body is regex-scrubbed: license/hex shapes,
+ *    bearer/OAuth/secret-key tokens, and URL query strings (which carry signed-link secrets) are masked.
+ *  - Keyed, recursive context redaction. A default deny-key set covers what the plugin actually emits, recursing into
+ *    nested arrays and objects so ['response']['headers']['authorization'] is caught. String leaves under non-deny
+ *    keys are additionally scrub()'d (URL-query blanking + secret patterns), so a raw non-JSON API body or
+ *    string-encoded request body stored under a benign key ('response'/'body') can't leak a signed URL or echoed key.
+ *    The gfpdf_logging_redact_keys filter (passed the logger slug) may only add keys (merged over the defaults so a
+ *    host can't weaken them).
+ *
+ * Log-injection and CRLF forging: a newline in user-controlled message data would forge a second well-formed log line,
+ * so message() collapses \r\n|\r|\n to a space and strips non-printable control chars before redacting (the GF
+ * LineFormatter runs with allowInlineLineBreaks=false). Context is JSON-encoded to one line by the formatter, so it's
+ * safe.
+ *
+ * @since 6.16.0
  */
 class Redact_Processor implements ProcessorInterface {
 
-	/**
-	 * @var string The default replacement character.
-	 */
-	public const DEFAULT_REPLACEMENT = '*';
+	private const REPLACEMENT = '[redacted]';
+
+	/* Bound recursion so a circular or pathologically-deep context graph can't exhaust the stack (DoS). */
+	private const MAX_DEPTH = 10;
 
 	/**
-	 * @var array
+	 * Default deny-keys (lower-case) for keyed context redaction: what the plugin actually emits, not just licensing.
 	 */
-	protected $sensitiveKeys;
+	private const DEFAULT_KEYS = [
+		'license',
+		'edd_license_key',
+		'package',
+		'download_link',
+		'access_token',
+		'refresh_token',
+		'authorization',
+		'password',
+		'secret',
+		'token',
+		'cookie',
+		'set-cookie',
+		'nonce',
+	];
 
 	/**
-	 * @var string
-	 */
-	protected $replacement;
-
-	/**
-	 * @var string
-	 */
-	protected $template;
-
-	/**
-	 * @var int|null
-	 */
-	protected $lengthLimit;
-
-	/**
-	 * Creates a new RedactSensitiveProcessor instance.
+	 * Message-body patterns masked wherever they appear.
 	 *
-	 * @param array    $sensitiveKeys Keys that should trigger the redaction.
-	 * @param string   $replacement   The replacement character.
-	 * @param string   $template      Template for replacement characters.
-	 * @param int|null $lengthLimit   Max length after redaction.
+	 * @var list<string>
 	 */
-	public function __construct( $sensitiveKeys, $replacement = self::DEFAULT_REPLACEMENT, $template = '%s', $lengthLimit = null ) {
-		$this->sensitiveKeys = $sensitiveKeys;
-		$this->replacement   = $replacement;
-		$this->template      = $template;
-		$this->lengthLimit   = $lengthLimit;
+	private const PATTERNS = [
+		'/\b[0-9a-f]{28,40}\b/i', // 28/32/40-hex license / signature shapes
+		'/Bearer\s+\S+/i',        // bearer tokens
+		'/ya29\.[\w\-]+/',        // Google OAuth access tokens
+		'/sk_[A-Za-z0-9]+/',      // Stripe-style secret keys
+	];
+
+	/**
+	 * The effective deny-keys as a lower-cased lookup map (defaults plus any added via the filter), for O(1) matching.
+	 *
+	 * @var array<string, true>
+	 */
+	private $keys;
+
+	/**
+	 * @param string $slug The logger slug, used to scope the redact-keys filter.
+	 *
+	 * @since 6.16.0
+	 */
+	public function __construct( string $slug ) {
+		$added = array_filter( (array) apply_filters( 'gfpdf_logging_redact_keys', self::DEFAULT_KEYS, $slug ), 'is_string' );
+
+		$keys = array_merge( self::DEFAULT_KEYS, array_map( 'strtolower', $added ) );
+
+		/* Flip to a lookup map so context() matches keys in O(1) on the per-record path; keys dedupe for free */
+		$this->keys = array_fill_keys( $keys, true );
 	}
 
 	/**
 	 * @param array $record
 	 *
 	 * @return array
+	 *
+	 * @since 6.16.0
 	 */
 	public function __invoke( array $record ) {
-		$record['context'] = $this->traverseArr( $record['context'], $this->sensitiveKeys );
+		$record['message'] = $this->message( $record['message'] );
+		$record['context'] = $this->context( $record['context'] );
 
 		return $record;
 	}
 
 	/**
-	 * @param string $value
-	 * @param int|string $length
+	 * Normalise (anti log-forging) then pattern-redact the free-form message body.
+	 *
+	 * @param string $message
 	 *
 	 * @return string
+	 *
+	 * @since 6.16.0
 	 */
-	protected function redact( $value, $length ) {
-		$valueLength = strlen( $value );
+	public function message( string $message ): string {
+		/* Collapse line breaks and strip control chars before redacting (Monolog allowInlineLineBreaks=false). */
+		$message = (string) preg_replace( '/\r\n|\r|\n/', ' ', $message );
+		$message = (string) preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $message );
 
-		if ( $valueLength === 0 ) {
-			return $value;
-		}
-
-		/* If $length not an integer, treat it as a pattern that needs to match to redact */
-		if ( is_string( $length ) ) {
-			/* ignore if regex not found */
-			$has_match = preg_match( $length, $value, $match );
-			if ( ! $has_match ) {
-				return $value;
-			}
-
-			$hiddenLength = strlen( $match[0] );
-			$hidden       = str_repeat( $this->replacement, $hiddenLength );
-			$placeholder  = sprintf( $this->template, $hidden );
-			$result       = str_replace( $match[0], $placeholder, $value );
-		} else {
-			$hiddenLength = $valueLength - abs( $length );
-			$hidden       = str_repeat( $this->replacement, $hiddenLength );
-			$placeholder  = sprintf( $this->template, $hidden );
-
-			$result = substr_replace( $value, $placeholder, max( 0, $length ), $hiddenLength );
-		}
-
-		/* If no length limit return the string as-is */
-		if ( ! is_integer( $this->lengthLimit ) ) {
-			return $result;
-		}
-
-		return $length > 0
-			? substr( $result, 0, $this->lengthLimit )
-			: substr( $result, -$this->lengthLimit );
+		return $this->scrub( $message );
 	}
 
 	/**
-	 * @param int|string   $key
-	 * @param array|object $value
-	 * @param array|int    $keys
+	 * Mask secrets in a string: blank URL query strings (signed update/storage links carry secrets there — keep the
+	 * path, drop ?…) then apply the token/hex patterns.
 	 *
-	 * @return array|object
+	 * @param string $value
+	 *
+	 * @return string
+	 *
+	 * @since 6.16.0
 	 */
-	protected function traverse( $key, $value, $keys ) {
-		if ( is_array( $value ) ) {
-			return $this->traverseArr( $value, $keys );
-		}
+	private function scrub( string $value ): string {
+		$value = (string) preg_replace( '#(https?://[^\s?]+)\?\S*#i', '$1?', $value );
 
-		if ( is_object( $value ) ) {
-			return $this->traverseObj( $value, $keys );
-		}
-
-		/* unknown type, skip */
-		return $value;
+		return (string) preg_replace( self::PATTERNS, self::REPLACEMENT, $value );
 	}
 
 	/**
-	 * @param array $arr
-	 * @param array $keys
+	 * Keyed-redact a context array, recursing into nested arrays and objects up to a bounded depth.
 	 *
-	 * @return array
+	 * @param array<array-key, mixed> $context
+	 * @param int                     $depth   Current recursion depth (internal).
+	 *
+	 * @return array<array-key, mixed>
+	 *
+	 * @since 6.16.0
 	 */
-	protected function traverseArr( $arr, $keys ) {
-		foreach ( $arr as $key => $value ) {
-			if ( is_scalar( $value ) ) {
-				if ( array_key_exists( $key, $keys ) ) {
-					$arr[ $key ] = $this->redact( (string) $value, $keys[ $key ] );
-				}
+	public function context( array $context, int $depth = 0 ): array {
+		$out = [];
+
+		foreach ( $context as $key => $value ) {
+			if ( is_string( $key ) && isset( $this->keys[ strtolower( $key ) ] ) ) {
+				$out[ $key ] = self::REPLACEMENT;
 				continue;
 			}
 
-			if ( array_key_exists( $key, $keys ) && is_array( $keys[ $key ] ) ) {
-				$arr[ $key ] = $this->traverse( $key, $value, $keys[ $key ] );
-			} elseif ( null !== $value ) {
-				$arr[ $key ] = $this->traverse( $key, $value, $keys );
+			if ( is_array( $value ) || is_object( $value ) ) {
+				$out[ $key ] = $depth < self::MAX_DEPTH
+					? $this->context( (array) $value, $depth + 1 )
+					: self::REPLACEMENT;
+			} elseif ( is_string( $value ) ) {
+				/* Scrub string leaves too (a raw API body under a benign key like 'response' can carry a signed URL/key
+				   keyed redaction misses); scrub() not message() — the formatter one-lines context, so normalization is moot */
+				$out[ $key ] = $this->scrub( $value );
+			} else {
+				$out[ $key ] = $value;
 			}
 		}
 
-		return $arr;
-	}
-
-	/**
-	 * @param object $obj
-	 * @param array  $keys
-	 *
-	 * @return object
-	 */
-	protected function traverseObj( $obj, $keys ) {
-		foreach ( get_object_vars( $obj ) as $key => $value ) {
-			if ( is_scalar( $value ) ) {
-				if ( array_key_exists( $key, $keys ) ) {
-					$obj->{$key} = $this->redact( (string) $value, $keys[ $key ] );
-				}
-
-				continue;
-			}
-
-			if ( array_key_exists( $key, $keys ) && is_array( $keys[ $key ] ) ) {
-				$obj->{$key} = $this->traverse( $key, $value, $keys[ $key ] );
-			} elseif ( null !== $value ) {
-				$obj->{$key} = $this->traverse( $key, $value, $keys );
-			}
-		}
-
-		return $obj;
+		return $out;
 	}
 }

--- a/src/Model/Model_Settings.php
+++ b/src/Model/Model_Settings.php
@@ -289,8 +289,8 @@ class Model_Settings extends Helper_Abstract_Model {
 				continue;
 			}
 
-			/* Skip if addon has been auto-activated */
-			if ( $addon->has_license_auto_activated() ) {
+			/* An admin-managed key is authoritative — ignore the submitted value and don't burn an activation */
+			if ( $addon->is_license_admin_managed() ) {
 				continue;
 			}
 
@@ -298,6 +298,21 @@ class Model_Settings extends Helper_Abstract_Model {
 			if ( trim( $input[ $option_key ] ) === '' ) {
 				$input[ $option_key . '_message' ] = '';
 				$input[ $option_key . '_status' ]  = '';
+
+				/* Sync the in-memory copy too, else get_license_status() returns the stale prior value this request */
+				$addon->update_license_info(
+					[
+						'license' => '',
+						'status'  => '',
+						'message' => '',
+					]
+				);
+
+				/* Clearing the field removes the license as surely as the Deactivate button does — drop the cached
+				   package. Every add-on posts an empty field on an unrelated save, so only flush when a key was set. */
+				if ( ! empty( $settings[ $option_key ] ) ) {
+					$addon->flush_update_cache();
+				}
 
 				continue;
 			}
@@ -309,7 +324,7 @@ class Model_Settings extends Helper_Abstract_Model {
 
 			/* Run license activation if a new key was submitted, or the existing key isn't valid */
 			if (
-				! in_array( $input[ $option_key . '_status' ], [ 'active', 'valid' ], true ) ||
+				! in_array( $input[ $option_key . '_status' ] ?? '', [ 'active', 'valid' ], true ) ||
 				( isset( $settings[ $option_key ] ) && $settings[ $option_key ] !== $input[ $option_key ] )
 			) {
 				$results = $addon->activate_license( $input[ $option_key ] );
@@ -319,9 +334,9 @@ class Model_Settings extends Helper_Abstract_Model {
 			}
 		}
 
-		/* Save auto-activated license key info */
+		/* Persist the authoritative key/status for admin-managed addons */
 		foreach ( $this->data->addon as $addon ) {
-			if ( ! $addon->has_license_auto_activated() ) {
+			if ( ! $addon->is_license_admin_managed() ) {
 				continue;
 			}
 
@@ -424,17 +439,11 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @return array
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function licensing_bulk_get_version_api_params( $api_params ) {
-		/* Skip if the core updater isn't initialized or there are no addons */
-		if ( empty( $this->data->updater ) && empty( $this->data->addon ) ) {
-			return $api_params;
-		}
-
-		/* Build new parameters */
-		$products = array_merge(
-			[ 'gravity-pdf' => $this->data->updater ],
+		/* Collect each add-on updater, dropping any that haven't been initialized (a third-party subclass may return null) */
+		$products = array_filter(
 			array_map(
 				function ( $addon ) {
 					return $addon->get_plugin_updater();
@@ -443,19 +452,18 @@ class Model_Settings extends Helper_Abstract_Model {
 			)
 		);
 
-		/*
-		 * Keep $bulk_api_params numerically indexed. The API keys its response array by the same
-		 * keys it receives, so numeric indices make it return a JSON array (which the response
-		 * handlers below decode via is_array()). Switching to slug keys would return a JSON object
-		 * and silently break bulk handling.
-		 */
+		/* Include the core plugin only when its updater exists (absent on the non-canonical wordpress.org build) */
+		if ( ! empty( $this->data->updater ) ) {
+			$products = array_merge( [ 'gravity-pdf' => $this->data->updater ], $products );
+		}
+
+		/* Nothing to bundle — leave the individual request untouched */
+		if ( empty( $products ) ) {
+			return $api_params;
+		}
+
 		$bulk_api_params = [];
 		foreach ( $products as $product ) {
-			/* skip improperly-registered plugins */
-			if ( ! $product ) {
-				continue;
-			}
-
 			$bulk_api_params[] = $product->get_version_api_params();
 		}
 
@@ -466,27 +474,44 @@ class Model_Settings extends Helper_Abstract_Model {
 	}
 
 	/**
-	 * @param mixed $response
+	 * Handle the bulk get_version API response: cache each bundled product against its own updater and hand back the
+	 * product that initiated the request for its normal caching path.
 	 *
-	 * @return \StdClass
+	 * @param mixed  $response    The decoded API response — an array of product objects, or a non-array passed straight through
+	 * @param array  $api_data    The initiating updater's API data (part of the filter signature; unused here)
+	 * @param string $plugin_file The initiating plugin file, used to single out which product to hand back
+	 *
+	 * @return \stdClass|mixed|null The initiating product object, null when it isn't in the response, or $response unchanged when not an array
+	 *
+	 * @since 6.16.0
 	 */
 	public function licensing_bulk_get_version_api_response( $response, $api_data, $plugin_file ) {
 		if ( ! is_array( $response ) ) {
 			return $response;
 		}
 
+		/* Map each bundled updater by the slug it sent (the plugin-folder basename the API echoes back), so a response
+		   links to the right product even when an add-on's registered slug differs from its folder — e.g. a renamed folder. */
+		$updaters = [];
+		foreach ( $this->data->addon as $addon ) {
+			$updater = $addon->get_plugin_updater();
+			if ( $updater ) {
+				$updaters[ $updater->get_slug() ] = $updater;
+			}
+		}
+
+		if ( ! empty( $this->data->updater ) ) {
+			$updaters[ $this->data->updater->get_slug() ] = $this->data->updater;
+		}
+
 		$initial_request_data = null;
 
 		foreach ( $response as $product ) {
-			if ( ! isset( $product->slug ) ) {
-				continue;
-			} elseif ( isset( $this->data->addon[ $product->slug ] ) ) {
-				$updater = $this->data->addon[ $product->slug ]->get_plugin_updater();
-			} elseif ( $product->slug === 'gravity-pdf' ) {
-				$updater = $this->data->updater;
-			} else {
+			if ( ! isset( $product->slug, $updaters[ $product->slug ] ) ) {
 				continue; // couldn't link response to a product, skip.
 			}
+
+			$updater = $updaters[ $product->slug ];
 
 			/* skip the product that initialized the request, as it'll be handled in the return method */
 			if ( $updater->get_plugin_file() !== $plugin_file ) {
@@ -504,9 +529,13 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @return bool
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function licensing_bulk_license_check() {
+		if ( $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
+			return false;
+		}
+
 		$addons = $this->data->addon;
 		if ( empty( $addons ) ) {
 			return false;
@@ -560,9 +589,14 @@ class Model_Settings extends Helper_Abstract_Model {
 		}
 
 		/* Check for a malformed response */
-		$license_check = json_decode( wp_remote_retrieve_body( $response ) );
+		$body          = wp_remote_retrieve_body( $response );
+		$license_check = json_decode( $body );
 		if ( ! is_array( $license_check ) ) {
-			$this->log->error( 'Invalid response returned from bulk license status check.', [ 'response' => wp_remote_retrieve_body( $response ) ] );
+			/* Log the decoded body so the redactor can traverse nested keys; cap the raw fallback to bound any leak */
+			$this->log->error(
+				'Invalid response returned from bulk license status check.',
+				[ 'response' => $license_check ?? substr( $body, 0, 500 ) ]
+			);
 
 			wp_schedule_single_event( strtotime( '+3 hour' ), 'gfpdf_bulk_license_check' );
 
@@ -609,29 +643,57 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @return void
 	 *
-	 * @since 6.15.0
+	 * @since 6.16.0
 	 */
 	public function run_network_update_check() {
-		if ( ! is_multisite() ) {
+		if ( ! is_multisite() || is_main_site() ) {
 			return;
 		}
 
-		if ( get_current_blog_id() === 1 ) {
+		/* Network-activated installs receive update checks through the normal flow, so don't re-arm the event there */
+		if ( $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
 			return;
 		}
 
 		/*
-		 * Skip a full wp_plugin_update() check and instead force the
-		 * `pre_set_site_transient_update_plugins` filter do its job,
-		 * which many addons (including Gravity PDF) use to inject update info
+		 * Skip a full wp_plugin_update() check and instead force the `pre_set_site_transient_update_plugins` filter to
+		 * do its job, which many addons (including Gravity PDF) use to inject update info. Run in the current (subsite)
+		 * context, not the main site: update_plugins is network-global, so re-injecting here fires check_update() where
+		 * the per-site add-on is active and its cached network package is found — no per-updater API request.
 		 */
-		switch_to_blog( 1 );
 		$update_info = get_site_transient( 'update_plugins' );
 		if ( $update_info !== false ) {
 			set_site_transient( 'update_plugins', $update_info );
 		}
 
+		/* Re-arm the one-off event so the next run re-syncs to the primary site's plugin update schedule */
+		$this->schedule_network_update_check();
+	}
+
+	/**
+	 * Schedule the next one-off network update check, one minute after the primary site's plugin update check
+	 *
+	 * A self-rescheduling single event (rather than a fixed recurring one) recomputes the offset every cycle, so it
+	 * re-syncs whenever WordPress reschedules its own plugin update check.
+	 *
+	 * @return void
+	 *
+	 * @since 6.16.0
+	 */
+	public function schedule_network_update_check() {
+		switch_to_blog( get_main_site_id() );
+		$timestamp = wp_next_scheduled( 'wp_update_plugins' );
 		restore_current_blog();
+
+		if ( $timestamp === false ) {
+			$timestamp = time() + 12 * HOUR_IN_SECONDS;
+		}
+
+		/* wp_next_scheduled() returns a past time when the primary site's cron is quiet; floor to the future so the
+		   self-rescheduling event isn't perpetually due (which would re-fire on every cron spawn). */
+		$timestamp = max( $timestamp, time() + HOUR_IN_SECONDS );
+
+		wp_schedule_single_event( $timestamp + 60, 'gfpdf_network_update_check' );
 	}
 
 	/**
@@ -643,7 +705,7 @@ class Model_Settings extends Helper_Abstract_Model {
 	 * @return bool
 	 *
 	 * @since 4.2
-	 * @deprecated 6.15.0 Moved to Addon framework
+	 * @deprecated 6.16.0 Moved to Addon framework
 	 */
 	public function deactivate_license_key( Helper_Abstract_Addon $addon, $license_key = '' ) {
 		return $addon->deactivate_license();

--- a/src/Model/Model_Uninstall.php
+++ b/src/Model/Model_Uninstall.php
@@ -108,6 +108,8 @@ class Model_Uninstall extends Helper_Abstract_Model {
 			}
 
 			switch_to_blog( $current_site_id );
+
+			$this->remove_plugin_network_options();
 		} else {
 			$this->remove_plugin_transients();
 			$this->remove_plugin_options();
@@ -162,9 +164,38 @@ class Model_Uninstall extends Helper_Abstract_Model {
 		delete_option( 'gfpdf_current_version' );
 		delete_option( 'gfpdf_settings' );
 
-		/* Remove license API data */
+		/* Remove license API data. Deleting one by one, not with a raw DELETE, lets WordPress drop its cached copies */
 		global $wpdb;
-		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'gpdf_sl_%'" );
+
+		$keys = $wpdb->get_col(
+			$wpdb->prepare( "SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s", $wpdb->esc_like( 'gpdf_sl_' ) . '%' )
+		);
+
+		foreach ( $keys as $key ) {
+			delete_option( $key );
+		}
+	}
+
+	/**
+	 * Remove the network-shared license package cache stored in sitemeta on a Multisite
+	 *
+	 * Every extension keeps its own entry (see EDD_SL_Plugin_Updater::get_network_cache_key()), but all are
+	 * network-scoped rather than per-site, so one wildcard pass clears them without walking the site list.
+	 *
+	 * @since 6.16.0
+	 */
+	public function remove_plugin_network_options() {
+		global $wpdb;
+
+		/* delete_network_option() rather than delete_site_option(), which would narrow the sweep to the current
+		   network and strand rows belonging to the others sharing this sitemeta table */
+		$rows = $wpdb->get_results(
+			$wpdb->prepare( "SELECT site_id, meta_key FROM $wpdb->sitemeta WHERE meta_key LIKE %s", $wpdb->esc_like( 'gpdf_sl_net_' ) . '%' )
+		);
+
+		foreach ( $rows as $row ) {
+			delete_network_option( $row->site_id, $row->meta_key );
+		}
 	}
 
 	/**

--- a/src/View/View_Settings.php
+++ b/src/View/View_Settings.php
@@ -186,8 +186,8 @@ class View_Settings extends Helper_Abstract_View {
 			],
 		];
 
-		/* Add License tab if necessary */
-		if ( count( $this->data->addon ) > 0 ) {
+		/* Add License tab if necessary (skip on secondary network sites — the primary site manages licensing) */
+		if ( count( $this->data->addon ) > 0 && ! $this->misc->is_secondary_network_site( PDF_PLUGIN_BASENAME ) ) {
 			$navigation[10] = [
 				'name' => esc_html__( 'License', 'gravity-pdf' ),
 				'id'   => 'license',

--- a/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
+++ b/src/assets/js/admin/settings/common/setupLicenseDeactivation.js
@@ -8,22 +8,30 @@ import { spinner } from '../../helper/spinner';
  */
 export function setupLicenseDeactivation() {
 	$('.gfpdf-deactivate-license').on('click', function () {
+		const $button = $(this);
+
+		/* Ignore repeat clicks while a deactivation request is already in flight */
+		if ($button.prop('disabled')) {
+			return false;
+		}
+		$button.prop('disabled', true);
+
 		/* Do AJAX call so user can deactivate license */
-		const $container = $(this).parent();
+		const $container = $button.parent();
 
 		/* Add spinner */
 		const $spinner = spinner('gfpdf-spinner');
 
 		/* Add our spinner */
-		$(this).append($spinner);
+		$button.append($spinner);
 
 		/* Set up ajax data */
-		const slug = $(this).data('addon-name');
+		const slug = $button.data('addon-name');
 
 		const data = {
 			action: 'gfpdf_deactivate_license',
 			addon_name: slug,
-			nonce: $(this).data('nonce'),
+			nonce: $button.data('nonce'),
 		};
 
 		/* Do ajax call */
@@ -31,20 +39,27 @@ export function setupLicenseDeactivation() {
 			/* Remove our loading spinner */
 			$spinner.remove();
 
-			/* update UI to reflect deactivation */
-			postLicenseDeactivation(
-				response.success ?? response.error,
-				slug,
-				$container
-			);
+			/* Our endpoint always returns a `success` or `error` string. A transport/auth failure (eg. a 500, or the 401
+			   from handle_ajax_authentication) instead hits jQuery's error handler with the raw jqXHR, so neither is set. */
+			const success = typeof response?.success === 'string';
+			let message = GFPDF.licenseDeactivationError;
+			if (success) {
+				message = response.success;
+			} else if (typeof response?.error === 'string') {
+				message = response.error;
+			}
+
+			/* deactivate_license() drops the key from this site even when the API rejects it, so always clear the UI */
+			postLicenseDeactivation(slug, $container, message, success);
 
 			/* handle any shared licenses that were also deactivated */
-			if (response.success && Array.isArray(response?.extra)) {
+			if (success && Array.isArray(response.extra)) {
 				response.extra.forEach((item) =>
 					postLicenseDeactivation(
-						response.success,
 						item,
-						$('#gfpdf-settings-field-wrapper-license_' + item)
+						$('#gfpdf-settings-field-wrapper-license_' + item),
+						message,
+						true
 					)
 				);
 			}
@@ -54,25 +69,16 @@ export function setupLicenseDeactivation() {
 	});
 }
 
-function postLicenseDeactivation(status, slug, $container) {
+function postLicenseDeactivation(slug, $container, message, success) {
 	/* cleanup inputs */
 	$('#gfpdf_settings\\[license_' + slug + '\\]').val('');
 	$('#gfpdf_settings\\[license_' + slug + '_message\\]').val('');
 	$('#gfpdf_settings\\[license_' + slug + '_status\\]').val('');
 	$container.find('button').remove();
 
-	if (status) {
-		$container
-			.find('#message')
-			.removeClass('error')
-			.addClass('success')
-			.html(status);
-	} else {
-		/* Show error message */
-		$container
-			.find('#message')
-			.removeClass('success')
-			.addClass('error')
-			.html(status);
-	}
+	$container
+		.find('#message')
+		.toggleClass('success', success)
+		.toggleClass('error', !success)
+		.html(message);
 }

--- a/tests/js-unit/admin/settings/common/setupLicenseDeactivation.test.js
+++ b/tests/js-unit/admin/settings/common/setupLicenseDeactivation.test.js
@@ -1,0 +1,129 @@
+import $ from 'jquery';
+import { setupLicenseDeactivation } from '../../../../../src/assets/js/admin/settings/common/setupLicenseDeactivation';
+import { ajaxCall } from '../../../../../src/assets/js/admin/helper/ajaxCall';
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       6.16.0
+ */
+
+jest.mock('../../../../../src/assets/js/admin/helper/ajaxCall');
+jest.mock('../../../../../src/assets/js/admin/helper/spinner', () => ({
+	/* jquery is required lazily: a jest.mock factory can't close over the module-scope `$` import */
+	spinner: () => require('jquery')('<span class="gfpdf-spinner" />'),
+}));
+
+/* Build the license field wrapper the way license_callback() renders it: message div, key/message/status inputs, and
+   the Deactivate button, all inside the #gfpdf-settings-field-wrapper-license_<slug> container. */
+function renderLicenseField(slug) {
+	return $(
+		`<div id="gfpdf-settings-field-wrapper-license_${slug}">
+      <div id="message" class="success">existing message</div>
+      <input id="gfpdf_settings[license_${slug}]" value="a-real-license-key" />
+      <input id="gfpdf_settings[license_${slug}_message]" value="stored message" />
+      <input id="gfpdf_settings[license_${slug}_status]" value="active" />
+      <button class="gfpdf-deactivate-license" data-addon-name="${slug}" data-nonce="nonce-123">Deactivate License</button>
+    </div>`
+	);
+}
+
+/* Trigger the click, then hand the wired callback whatever the endpoint (or jQuery's error handler) would return. */
+function deactivate(respondWith) {
+	$('.gfpdf-deactivate-license').first().trigger('click');
+	const callback = ajaxCall.mock.calls[0][1];
+	callback(respondWith);
+}
+
+const fieldValue = (slug, suffix = '') =>
+	$(`#gfpdf_settings\\[license_${slug}${suffix}\\]`).val();
+
+describe('setupLicenseDeactivation', () => {
+	beforeEach(() => {
+		$('body').append(renderLicenseField('sample'));
+		setupLicenseDeactivation();
+	});
+
+	afterEach(() => {
+		$('body').empty();
+	});
+
+	describe('on success', () => {
+		it('clears the stored key/message/status, removes the button, and shows the success message', () => {
+			deactivate({ success: 'License key deactivated.', extra: [] });
+
+			expect(fieldValue('sample')).toBe('');
+			expect(fieldValue('sample', '_message')).toBe('');
+			expect(fieldValue('sample', '_status')).toBe('');
+			expect($('.gfpdf-deactivate-license').length).toBe(0);
+
+			const $message = $(
+				'#gfpdf-settings-field-wrapper-license_sample #message'
+			);
+			expect($message.hasClass('success')).toBe(true);
+			expect($message.hasClass('error')).toBe(false);
+			expect($message.html()).toBe('License key deactivated.');
+		});
+
+		it('also tears down any All Access Pass siblings returned in extra', () => {
+			$('body').append(renderLicenseField('sibling'));
+
+			deactivate({
+				success: 'Access Pass license key deactivated.',
+				extra: ['sibling'],
+			});
+
+			expect(fieldValue('sibling')).toBe('');
+			expect(
+				$('#gfpdf-settings-field-wrapper-license_sibling button').length
+			).toBe(0);
+		});
+	});
+
+	describe('on an application error (HTTP 200 { error })', () => {
+		it('still removes the key from the site, but shows the error', () => {
+			deactivate({ error: 'An API error occurred.' });
+
+			expect(fieldValue('sample')).toBe('');
+			expect($('.gfpdf-deactivate-license').length).toBe(0);
+
+			const $message = $(
+				'#gfpdf-settings-field-wrapper-license_sample #message'
+			);
+			expect($message.hasClass('error')).toBe(true);
+			expect($message.hasClass('success')).toBe(false);
+			expect($message.html()).toBe('An API error occurred.');
+		});
+	});
+
+	describe('on a transport/auth failure (jqXHR, not our JSON)', () => {
+		it('still removes the key from the site, and shows the generic fallback message', () => {
+			/* jQuery's error handler passes the raw jqXHR — neither success nor error is a string */
+			deactivate({
+				readyState: 4,
+				status: 401,
+				statusText: 'Unauthorized',
+			});
+
+			expect(fieldValue('sample')).toBe('');
+			expect($('.gfpdf-deactivate-license').length).toBe(0);
+
+			const $message = $(
+				'#gfpdf-settings-field-wrapper-license_sample #message'
+			);
+			expect($message.hasClass('error')).toBe(true);
+			expect($message.hasClass('success')).toBe(false);
+			expect($message.html()).toBe(GFPDF.licenseDeactivationError);
+		});
+	});
+
+	describe('on a repeat click while a request is in flight', () => {
+		it('ignores the second click so only one deactivation request is sent', () => {
+			$('.gfpdf-deactivate-license').first().trigger('click');
+			$('.gfpdf-deactivate-license').first().trigger('click');
+
+			expect(ajaxCall).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/tests/js-unit/setupTests.js
+++ b/tests/js-unit/setupTests.js
@@ -23,6 +23,8 @@ window.GFPDF = {
 		"It doesn't look like there are any topics related to your issue.",
 	coreFontGithubError: 'Could not download Core Font list. Try again.',
 	getSearchResultError: 'An error occurred. Please try again',
+	licenseDeactivationError:
+		'An error occurred and your license key may not have been correctly deactivated. Login to your GravityPDF.com account and check if your site has been unlinked from the key.',
 	userCapabilities: { administrator: true },
 	// Font manager component
 	fontListInstalledFonts: 'Installed Fonts',

--- a/tests/phpunit/integration/Controller/Test_Controller_Settings.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_Settings.php
@@ -44,6 +44,18 @@ class Test_Controller_Settings extends TestCase {
 		$this->controller = new Controller_Settings( $model, $view, $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->data, $gfpdf->misc );
 	}
 
+	public function tear_down(): void {
+		$data        = \GPDFAPI::get_data_class();
+		$data->addon = [];
+
+		/* Creating a subsite dirties process globals WP_UnitTestCase won't roll back; reset so later tests aren't polluted */
+		global $wp_settings_errors, $wp_rewrite;
+		$wp_settings_errors = [];
+		$wp_rewrite->init();
+
+		parent::tear_down();
+	}
+
 	public function test_bulk_license_check_schedule_with_no_addons() {
 		$this->controller->add_filters();
 		do_action( 'init' );
@@ -69,6 +81,76 @@ class Test_Controller_Settings extends TestCase {
 		do_action( 'init' );
 
 		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+	}
+
+	public function test_bulk_license_check_not_scheduled_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		$addon = new ControllerSettingsAddon(
+			'my-custom-plugin',
+			'My Custom Plugin',
+			'Gravity PDF',
+			'1.0',
+			'/path/to/plugin/file.php',
+			\GPDFAPI::get_data_class(),
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'my-custom-plugin', 'My Custom Plugin' ),
+			new Helper_Notices()
+		);
+		$addon->init();
+
+		/* Pose as a secondary site with Gravity PDF network-activated; scheduling reads the per-blog cron, so use a real blog */
+		$network_plugins = static function () {
+			return [ PDF_PLUGIN_BASENAME => time() ];
+		};
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( $this->factory()->blog->create() );
+
+		$this->controller->add_actions();
+		do_action( 'init' );
+
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+	}
+
+	/*
+	 * maybe_schedule_network_update_check() runs on every request via after_setup_theme, including the frontend and
+	 * WP-Cron, where wp-admin/includes/plugin.php (which defines is_plugin_active_for_network()) isn't loaded. That
+	 * fatal can't be reproduced here because the PHPUnit bootstrap always loads the file, so guard the contract by
+	 * scanning the source. php_strip_whitespace() drops comments so only real code is matched.
+	 */
+	public function test_network_update_check_avoids_admin_only_plugin_functions() {
+		$source = php_strip_whitespace( ( new \ReflectionClass( Controller_Settings::class ) )->getFileName() );
+		$this->assertStringNotContainsString( 'is_plugin_active_for_network(', $source );
+	}
+
+	/*
+	 * The updater fires gpdf_sl_plugin_updater_api_response with ($response, $api_data, $plugin_file). If the filter
+	 * isn't registered with accepted_args of 3, $plugin_file arrives null, licensing_bulk_get_version_api_response()
+	 * can't identify the initiating product, and that plugin's own update is silently lost while every response-shape
+	 * test still passes. Pin the arg-count.
+	 */
+	public function test_bulk_get_version_response_filter_registered_with_plugin_file_arg() {
+		$this->controller->add_filters();
+
+		$hook = $GLOBALS['wp_filter']['gpdf_sl_plugin_updater_api_response'] ?? null;
+		$this->assertNotNull( $hook );
+
+		$registered = null;
+		foreach ( $hook->callbacks[10] as $callback ) {
+			if ( is_array( $callback['function'] ) && $callback['function'][1] === 'licensing_bulk_get_version_api_response' ) {
+				$registered = $callback;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $registered, 'The bulk get_version response filter was not registered' );
+		$this->assertSame( 3, $registered['accepted_args'] );
 	}
 }
 

--- a/tests/phpunit/integration/Controller/Test_Controller_Upgrade_Routines.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_Upgrade_Routines.php
@@ -97,19 +97,43 @@ class Test_Controller_Upgrade_Routines extends TestCase {
 		}
 	}
 
-	public function test_6_15_0_removes_legacy_edd_sl_options_only_for_gravity_pdf(): void {
-		add_option( 'edd_sl_gravity_pdf_active', 'license-data for gravity-pdf', '', 'no' );
-		add_option( 'edd_sl_other_plugin_active', 'license-data for some-other-plugin', '', 'no' );
-		add_option( 'gpdf_unrelated_option', 'should-survive', '', 'no' );
+	public function test_6_16_0_removes_legacy_update_cache() {
+		update_option( 'edd_sl_version_info_123', 'a payload naming gravity-pdf' );
+		update_option( 'edd_sl_failed_http_' . md5( GPDF_API_URL ), time() );
 
-		do_action( 'gfpdf_version_changed', '6.13.2', '6.15.0' );
+		/* An unrelated add-on's cache shares the prefix but not the value, and must survive */
+		update_option( 'edd_sl_version_info_456', 'a payload naming another-plugin' );
 
-		/* The upgrade routine deletes via a raw wpdb query; bust the per-option cache so get_option re-reads the DB. */
-		wp_cache_delete( 'edd_sl_gravity_pdf_active', 'options' );
+		do_action( 'gfpdf_version_changed', '6.15.0', '6.16.0' );
 
-		$this->assertFalse( get_option( 'edd_sl_gravity_pdf_active', false ) );
-		$this->assertSame( 'license-data for some-other-plugin', get_option( 'edd_sl_other_plugin_active' ) );
-		$this->assertSame( 'should-survive', get_option( 'gpdf_unrelated_option' ) );
+		/* No cache flush here on purpose — the routine must invalidate what it deletes */
+		$this->assertFalse( get_option( 'edd_sl_version_info_123' ) );
+		$this->assertFalse( get_option( 'edd_sl_failed_http_' . md5( GPDF_API_URL ) ) );
+		$this->assertNotFalse( get_option( 'edd_sl_version_info_456' ) );
+
+		delete_option( 'edd_sl_version_info_456' );
+	}
+
+	public function test_6_16_0_removes_legacy_license_check_cron() {
+		$future = time() + HOUR_IN_SECONDS;
+
+		/* Deprecated per-add-on events left behind by pre-6.16.0 installs */
+		wp_schedule_single_event( $future, 'gfpdf_core_booster_license_check' );
+		wp_schedule_single_event( $future, 'gfpdf_business_plus_license_check' );
+
+		/* The bulk check that replaced them, and an unrelated hook, must both survive */
+		wp_schedule_single_event( $future, 'gfpdf_bulk_license_check' );
+		wp_schedule_single_event( $future, 'gfpdf_cleanup_tmp_dir' );
+
+		do_action( 'gfpdf_version_changed', '6.15.0', '6.16.0' );
+
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_core_booster_license_check' ) );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_business_plus_license_check' ) );
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_cleanup_tmp_dir' ) );
+
+		wp_clear_scheduled_hook( 'gfpdf_bulk_license_check' );
+		wp_clear_scheduled_hook( 'gfpdf_cleanup_tmp_dir' );
 	}
 
 }

--- a/tests/phpunit/integration/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
+++ b/tests/phpunit/integration/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
@@ -238,6 +238,96 @@ class Test_EDD_SL_Plugin_Updater extends TestCase {
 		$this->assertFalse( $this->class->request_recently_failed() );
 	}
 
+	public function test_get_version_from_remote_backs_off_on_malformed_200() {
+		$this->class->init();
+
+		/* 200 status but an empty body standardizes to false; without a recorded failure it would re-POST every call */
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => '',
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->assertFalse( $this->class->request_recently_failed() );
+		$this->assertFalse( $this->class->get_version_from_remote() );
+		$this->assertTrue( $this->class->request_recently_failed() );
+	}
+
+	public function test_standardize_api_response_does_not_unserialize_sections() {
+		/* A serialized-object string in a JSON field is an object-injection payload; it must not be unserialized */
+		$response           = new \stdClass();
+		$response->sections = 'O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}';
+
+		$result = $this->class->standardize_api_response( $response );
+
+		$this->assertSame( [], $result->sections );
+	}
+
+	public function test_standardize_api_response_unserializes_serialized_array_sections() {
+		/* Regression: serialized-array sections were dropped by the object-injection hardening, blanking the changelog modal */
+		$response           = new \stdClass();
+		$response->sections = serialize( [ 'description' => 'Excerpt here', 'changelog' => 'Changelog here' ] );
+		$response->banners  = serialize( [ 'high' => 'https://store.com/banner-large.png' ] );
+		$response->icons    = serialize( [ '1x' => 'https://store.com/icon-1.png' ] );
+
+		$result = $this->class->standardize_api_response( $response );
+
+		$this->assertSame( 'Excerpt here', $result->sections['description'] );
+		$this->assertSame( 'Changelog here', $result->sections['changelog'] );
+		$this->assertSame( 'https://store.com/banner-large.png', $result->banners['high'] );
+		$this->assertSame( 'https://store.com/icon-1.png', $result->icons['1x'] );
+		$this->assertSame( 'Excerpt here', $result->description[0] );
+		$this->assertSame( 'Changelog here', $result->changelog[0] );
+	}
+
+	public function test_standardize_api_response_serialized_array_neutralizes_nested_objects() {
+		/* A serialized array that nests an object must still not instantiate the class — objects stay disallowed */
+		$response           = new \stdClass();
+		$response->sections = 'a:1:{s:9:"changelog";O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}}';
+
+		$result = $this->class->standardize_api_response( $response );
+
+		$this->assertArrayHasKey( 'changelog', $result->sections );
+		$this->assertNotInstanceOf( \stdClass::class, $result->sections['changelog'] );
+		$this->assertIsArray( $result->sections['changelog'] );
+	}
+
+	public function test_standardize_api_response_decodes_json_string_sections() {
+		/* The store may JSON-encode sections/banners/icons instead of serializing them; both must resolve to arrays */
+		$response           = new \stdClass();
+		$response->sections = wp_json_encode( [ 'description' => 'Excerpt here', 'changelog' => 'Changelog here' ] );
+		$response->banners  = wp_json_encode( [ 'high' => 'https://store.com/banner-large.png' ] );
+		$response->icons    = wp_json_encode( [ '1x' => 'https://store.com/icon-1.png' ] );
+
+		$result = $this->class->standardize_api_response( $response );
+
+		$this->assertSame( 'Excerpt here', $result->sections['description'] );
+		$this->assertSame( 'Changelog here', $result->sections['changelog'] );
+		$this->assertSame( 'https://store.com/banner-large.png', $result->banners['high'] );
+		$this->assertSame( 'https://store.com/icon-1.png', $result->icons['1x'] );
+		$this->assertSame( 'Changelog here', $result->changelog[0] );
+	}
+
+	public function test_standardize_api_response_returns_false_for_non_object_payload() {
+		/* A non-empty, non-object payload passes empty() but the property writes below fatal on PHP 8; each must bail
+		   to false. Reachable via a third-party gpdf_sl_plugin_updater_api_response filter or a malformed 200 body. */
+		$this->assertFalse( $this->class->standardize_api_response( json_decode( '"a bare string"' ) ) );
+		$this->assertFalse( $this->class->standardize_api_response( json_decode( '[1,2,3]' ) ) );
+		$this->assertFalse( $this->class->standardize_api_response( 42 ) );
+		$this->assertFalse( $this->class->standardize_api_response( true ) );
+	}
+
+	public function test_get_cached_version_info_returns_false_for_corrupted_scalar_option() {
+		/* A corrupted scalar-string option (e.g. a network option edited by a super-admin) would throw a TypeError on
+		   the array access inside read_timed_cache() without the is_array() guard */
+		update_option( $this->class->get_cache_key(), 'corrupted-not-an-array' );
+
+		$this->assertFalse( $this->class->get_cached_version_info() );
+	}
+
 	public function test_check_update_already_exists() {
 		$updates           = new \stdClass();
 		$updates->response = [
@@ -311,6 +401,31 @@ class Test_EDD_SL_Plugin_Updater extends TestCase {
 		$updater = new EDD_SL_Plugin_Updater( home_url(), 'test-plugin/test-plugin.php' );
 
 		$this->assertFalse( $updater->get_version_info() );
+	}
+
+	public function test_get_version_info_skipped_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP in tests' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		/* Pose as a secondary site with the add-on network-activated; only a network option is read, so no real blog is needed */
+		$network_plugins = static function () { return [ 'test-plugin/test-plugin.php' => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		$this->assertFalse( $this->class->get_version_info() );
+		$this->assertFalse( $http_called );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		remove_filter( 'pre_http_request', $spy );
 	}
 
 	public function test_get_tested_version() {
@@ -424,6 +539,27 @@ class Test_EDD_SL_Plugin_Updater extends TestCase {
 		$results = apply_filters( 'plugins_api', new \stdClass(), 'plugin_information', $args );
 
 		$this->assertCount( 1, (array) $results ); // "plugin" key
+	}
+
+	public function test_plugins_api_filter_returns_false_when_api_unreachable() {
+		$this->class->init();
+
+		$args       = new \stdClass();
+		$args->slug = 'test-plugin';
+
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 500 ],
+				'body'     => '',
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		/* WP core passes $_data = false by default; a failed API leaves it false — assigning $_data->plugin on that bool fatals on PHP 8 */
+		$results = apply_filters( 'plugins_api', false, 'plugin_information', $args );
+
+		$this->assertFalse( $results );
 	}
 
 	public function test_plugins_api_filter_with_cache() {
@@ -773,320 +909,249 @@ class Test_EDD_SL_Plugin_Updater extends TestCase {
 		$this->assertStringNotContainsString( 'Update now.', $output );
 	}
 
-	public function test_check_update_short_circuits_when_response_already_set_and_no_override() {
-		$transient           = new \stdClass();
-		$transient->response = [
-			'test-plugin/test-plugin.php' => 'preset',
-		];
-
-		$result = $this->class->check_update( $transient );
-
-		$this->assertSame( 'preset', $result->response['test-plugin/test-plugin.php'] );
-		$this->assertEmpty( get_option( $this->class->get_cache_key() ) );
-	}
-
-	public function test_get_tested_version_returns_null_when_tested_is_empty() {
-		$version_info         = new \stdClass();
-		$version_info->tested = '';
-
-		$this->assertNull( $this->class->get_tested_version( $version_info ) );
-
-		$bare = new \stdClass();
-		$this->assertNull( $this->class->get_tested_version( $bare ) );
-	}
-
-	public function test_show_update_notification_skipped_in_network_admin() {
+	public function test_is_non_active_multisite() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Not running multisite tests' );
 		}
 
-		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		grant_super_admin( $user_id );
-		wp_set_current_user( $user_id );
+		$plugin          = 'test-plugin/test-plugin.php';
+		$active_plugins  = [];
+		$network_plugins = [];
 
-		set_current_screen( 'plugins-network' );
-
-		$this->class->init();
-
-		ob_start();
-		do_action( 'after_plugin_row', 'test-plugin/test-plugin.php', [ 'Name' => 'Test Plugin' ] );
-		$this->assertEmpty( ob_get_clean() );
-	}
-
-	public function test_show_update_notification_skipped_for_mismatched_file() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Not running multisite tests' );
-		}
-
-		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		grant_super_admin( $user_id );
-		wp_set_current_user( $user_id );
-
-		$this->class->init();
-
-		ob_start();
-		do_action( 'after_plugin_row', 'some-other/some-other.php', [ 'Name' => 'Other Plugin' ] );
-		$this->assertEmpty( ob_get_clean() );
-	}
-
-	public function test_show_update_notification_with_update_no_package_no_changelog() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Not running multisite tests' );
-		}
-
-		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		grant_super_admin( $user_id );
-		wp_set_current_user( $user_id );
-
-		$this->class->init();
-
-		$api_response = function () {
-			return [
-				'response' => [ 'code' => 200 ],
-				'body'     => json_encode( [
-					'new_version'    => '0.2',
-					'stable_version' => '0.2',
-					'name'           => 'Test Plugin',
-					'slug'           => 'test-plugin',
-					'sections'       => [
-						'description' => 'Excerpt here',
-					],
-					'banners'        => [],
-					'icons'          => [],
-					'requires'       => '6.4',
-					'requires_php'   => '7.3',
-					'tested'         => '10.1',
-				] ),
-			];
+		/* Fake the per-site and network plugin lists without touching the shared options */
+		$site_filter = static function () use ( &$active_plugins ) {
+			return $active_plugins;
 		};
+		$network_filter = static function () use ( &$network_plugins ) {
+			return $network_plugins;
+		};
+		add_filter( 'pre_option_active_plugins', $site_filter );
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_filter );
 
-		add_filter( 'pre_http_request', $api_response );
+		$method = new \ReflectionMethod( $this->class, 'is_non_active_multisite' );
+		$method->setAccessible( true );
 
-		ob_start();
-		do_action( 'after_plugin_row', 'test-plugin/test-plugin.php', [ 'Name' => 'Test Plugin' ] );
+		/* Active on the current site */
+		$active_plugins = [ $plugin ];
+		$this->assertFalse( $method->invoke( $this->class ) );
 
-		$output = ob_get_clean();
-		$this->assertStringContainsString( 'There is a new version of Test Plugin available.', $output );
-		$this->assertStringNotContainsString( 'View version', $output );
-		$this->assertStringNotContainsString( 'update now', $output );
-		$this->assertStringNotContainsString( 'Update now.', $output );
+		/* Network activated */
+		$active_plugins  = [];
+		$network_plugins = [ $plugin => time() ];
+		$this->assertFalse( $method->invoke( $this->class ) );
+
+		/* Not active anywhere -> non-active multisite */
+		$active_plugins  = [];
+		$network_plugins = [];
+		$this->assertTrue( $method->invoke( $this->class ) );
+
+		remove_filter( 'pre_option_active_plugins', $site_filter );
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_filter );
 	}
 
-	public function test_show_changelog_returns_early_when_action_missing() {
-		unset( $_REQUEST['gpdf_sl_action'], $_REQUEST['plugin'] );
-
-		ob_start();
-		$this->class->show_changelog();
-		$this->assertEmpty( ob_get_clean() );
+	/*
+	 * The update check runs under WP-Cron and on the frontend, where wp-admin/includes/plugin.php (which defines
+	 * is_plugin_active()) isn't loaded. That fatal can't be reproduced here because the PHPUnit bootstrap always loads
+	 * the file, so guard the contract by scanning the source. php_strip_whitespace() drops comments so only real code
+	 * is matched.
+	 */
+	public function test_multisite_check_avoids_admin_only_plugin_functions() {
+		$source = php_strip_whitespace( ( new \ReflectionClass( EDD_SL_Plugin_Updater::class ) )->getFileName() );
+		$this->assertStringNotContainsString( 'is_plugin_active(', $source );
 	}
 
-	public function test_show_changelog_returns_early_for_mismatched_plugin() {
-		$_REQUEST['gpdf_sl_action'] = 'view_plugin_changelog';
-		$_REQUEST['plugin']         = 'something-else';
+	public function test_set_version_info_cache_promotes_active_licensed_package_to_network() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
 
-		ob_start();
-		$this->class->show_changelog();
-		$output = ob_get_clean();
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'valid' );
 
-		unset( $_REQUEST['gpdf_sl_action'], $_REQUEST['plugin'] );
+		$licensed              = new \stdClass();
+		$licensed->new_version = '0.2';
+		$licensed->package     = 'https://store.com/download/licensed-123';
+		$this->class->set_version_info_cache( $licensed );
 
-		$this->assertEmpty( $output );
+		$cache = get_site_option( $this->class->get_network_cache_key() );
+		$this->assertNotEmpty( $cache );
+		$this->assertSame( 'https://store.com/download/licensed-123', json_decode( $cache['value'] )->package );
 	}
 
-	public function test_convert_object_to_array_returns_empty_for_scalar_input() {
-		$this->assertSame( [], $this->class->convert_object_to_array( 'a-string' ) );
-		$this->assertSame( [], $this->class->convert_object_to_array( 42 ) );
-		$this->assertSame( [], $this->class->convert_object_to_array( null ) );
-	}
+	public function test_set_version_info_cache_skips_promotion_when_license_inactive() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
 
-	public function test_convert_object_to_array_recurses_into_nested_objects() {
-		$inner        = new \stdClass();
-		$inner->color = 'blue';
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'expired' );
 
-		$outer        = new \stdClass();
-		$outer->inner = $inner;
-		$outer->scalar = 'x';
-
-		$result = $this->class->convert_object_to_array( $outer );
-
-		$this->assertSame( 'x', $result['scalar'] );
-		$this->assertSame( [ 'color' => 'blue' ], $result['inner'] );
-	}
-
-	public function test_verify_ssl_defaults_true_and_respects_filter() {
-		$this->assertTrue( $this->class->verify_ssl() );
-
-		add_filter( 'gpdf_sl_api_request_verify_ssl', '__return_false' );
-		$this->assertFalse( $this->class->verify_ssl() );
-		remove_filter( 'gpdf_sl_api_request_verify_ssl', '__return_false' );
-	}
-
-	public function test_get_active_plugins_merges_single_site_and_network_keys() {
-		update_option( 'active_plugins', [ 'a/a.php', 'b/b.php' ] );
-		update_site_option( 'active_sitewide_plugins', [ 'c/c.php' => 1, 'd/d.php' => 1 ] );
-
-		$merged = $this->class->get_active_plugins();
-
-		$this->assertContains( 'a/a.php', $merged );
-		$this->assertContains( 'b/b.php', $merged );
-		$this->assertContains( 'c/c.php', $merged );
-		$this->assertContains( 'd/d.php', $merged );
-	}
-
-	public function test_standardize_api_response_returns_false_for_empty_input() {
-		$this->assertFalse( $this->class->standardize_api_response( null ) );
-		$this->assertFalse( $this->class->standardize_api_response( '' ) );
-		$this->assertFalse( $this->class->standardize_api_response( false ) );
-	}
-
-	public function test_standardize_api_response_defaults_missing_requires_keys() {
+		/* The store can return a package even for an inactive license; that URL errors, so it must not be shared */
 		$response              = new \stdClass();
 		$response->new_version = '0.2';
+		$response->package     = 'https://store.com/download/inactive-123';
+		$this->class->set_version_info_cache( $response );
 
-		$result = $this->class->standardize_api_response( $response );
-
-		$this->assertSame( '', $result->requires );
-		$this->assertSame( '', $result->requires_php );
-		$this->assertSame( 'test-plugin/test-plugin.php', $result->plugin );
-		$this->assertSame( 'test-plugin/test-plugin.php', $result->id );
+		$this->assertFalse( get_site_option( $this->class->get_network_cache_key() ) );
 	}
 
-	public function test_delete_transient_plugin_info_short_circuits_when_entry_missing() {
-		$transient           = new \stdClass();
-		$transient->response = [
-			'some-other/some-other.php' => 'untouched',
-		];
-		set_site_transient( 'update_plugins', $transient );
-
-		$this->assertTrue( $this->class->delete_transient_plugin_info() );
-
-		$after = get_site_transient( 'update_plugins' );
-		$this->assertSame( 'untouched', $after->response['some-other/some-other.php'] );
-	}
-
-	public function test_set_version_info_cache_skipped_when_plugin_not_active_in_multisite() {
+	public function test_get_repo_api_data_borrows_network_package_when_site_unlicensed() {
 		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Not running multisite tests' );
+			$this->markTestSkipped( 'Multisite tests only' );
 		}
 
-		update_option( 'active_plugins', [] );
+		/* A licensed site elsewhere on the network has shared its package */
+		$network              = new \stdClass();
+		$network->new_version = '0.2';
+		$network->package     = 'https://store.com/download/licensed-123';
+		update_site_option(
+			$this->class->get_network_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( $network ) ]
+		);
 
-		$this->class->set_version_info_cache( [ 'foo' => 'bar' ] );
-
-		$this->assertEmpty( get_option( $this->class->get_cache_key() ) );
-	}
-
-	public function test_show_changelog_wp_dies_without_update_plugins_capability() {
-		$user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
-		wp_set_current_user( $user_id );
-
-		$_REQUEST['gpdf_sl_action'] = 'view_plugin_changelog';
-		$_REQUEST['plugin']         = 'test-plugin';
-		$_REQUEST['gpdf_sl_nonce']  = wp_create_nonce( 'install-plugin_test-plugin' );
-
-		try {
-			$this->class->show_changelog();
-			$this->fail( 'Expected WPDieException' );
-		} catch ( \WPDieException $e ) {
-			$this->assertStringContainsString( 'do not have permission', $e->getMessage() );
-		} finally {
-			unset( $_REQUEST['gpdf_sl_action'], $_REQUEST['plugin'], $_REQUEST['gpdf_sl_nonce'] );
-		}
-	}
-
-	public function test_get_version_from_remote_returns_false_on_wp_error() {
-		add_filter( 'pre_http_request', function () {
-			return new \WP_Error( 'http_error', 'Connection refused' );
-		} );
-
-		$this->assertFalse( $this->class->get_version_from_remote() );
-		$this->assertTrue( $this->class->request_recently_failed() );
-	}
-
-	public function test_request_recently_failed_returns_false_for_non_numeric_value() {
-		update_option( 'gpdf_sl_failed_http_' . md5( 'http://store.com/' ), 'not-a-number' );
-
-		$this->assertFalse( $this->class->request_recently_failed() );
-	}
-
-	public function test_log_failed_request_persists_future_timestamp() {
-		$this->class->log_failed_request();
-
-		$stored = get_option( 'gpdf_sl_failed_http_' . md5( 'http://store.com/' ) );
-
-		$this->assertGreaterThan( time(), (int) $stored );
-	}
-
-	public function test_get_cached_version_info_uses_explicit_cache_key() {
-		$key = 'gpdf_sl_custom_key';
-
-		update_option( $key, [
-			'timeout' => time() + 60,
-			'value'   => json_encode( [ 'new_version' => '5.5' ] ),
-		] );
-
-		$result = $this->class->get_cached_version_info( $key );
-
-		$this->assertSame( '5.5', $result->new_version );
-	}
-
-	public function test_set_version_info_cache_uses_explicit_cache_key_on_single_site() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'Test targets single-site path' );
-		}
-
-		$key = 'gpdf_sl_explicit_key';
-		$this->class->set_version_info_cache( [ 'foo' => 'bar' ], $key );
-
-		$stored = get_option( $key );
-		$this->assertSame( '{"foo":"bar"}', $stored['value'] );
-		$this->assertGreaterThan( time(), $stored['timeout'] );
-	}
-
-	public function test_delete_version_info_cache_uses_explicit_cache_key() {
-		$key = 'gpdf_sl_to_delete';
-		update_option( $key, 'something' );
-
-		$this->assertTrue( $this->class->delete_version_info_cache( $key ) );
-		$this->assertFalse( get_option( $key ) );
-	}
-
-	public function test_get_repo_api_data_returns_cached_when_present() {
-		update_option( $this->class->get_cache_key(), [
-			'timeout' => time() + 60,
-			'value'   => json_encode( [ 'new_version' => '2.0' ] ),
-		] );
+		/* This site sees the update but has no package of its own (missing/invalid license) */
+		$local              = new \stdClass();
+		$local->new_version = '0.2';
+		$local->package     = '';
+		$this->class->set_version_info_cache( $local );
 
 		$result = $this->class->get_repo_api_data();
 
-		$this->assertSame( '2.0', $result->new_version );
+		$this->assertSame( '0.2', $result->new_version );
+		$this->assertSame( 'https://store.com/download/licensed-123', $result->package );
 	}
 
-	public function test_check_update_initialises_stdclass_when_passed_non_object(): void {
-		/* Prevent any real HTTP requests from get_update_transient_data() below. */
-		add_filter(
-			'pre_http_request',
-			static function () {
-				return [
-					'response' => [ 'code' => 200 ],
-					'body'     => json_encode( [
-						'plugins'      => [],
-						'translations' => [],
-						'no_update'    => [],
-					] ),
-				];
-			},
-			10,
-			3
+	public function test_set_version_info_cache_network_ttl_outlives_per_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		delete_option( $this->class->get_cache_key() );
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'valid' );
+
+		$licensed              = new \stdClass();
+		$licensed->new_version = '0.2';
+		$licensed->package     = 'https://store.com/download/licensed-123';
+		$this->class->set_version_info_cache( $licensed );
+
+		$per_site = get_option( $this->class->get_cache_key() );
+		$network  = get_site_option( $this->class->get_network_cache_key() );
+
+		/* The shared package must survive quiet stretches between licensed-site checks, so it outlives the per-site cache */
+		$this->assertGreaterThan( $per_site['timeout'], $network['timeout'] );
+	}
+
+	public function test_get_repo_api_data_does_not_borrow_expired_network_package() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* A licensed site shared a package, but the network cache has since expired */
+		$network              = new \stdClass();
+		$network->new_version = '0.2';
+		$network->package     = 'https://store.com/download/licensed-123';
+		update_site_option(
+			$this->class->get_network_cache_key(),
+			[ 'timeout' => time() - 60, 'value' => wp_json_encode( $network ) ]
 		);
 
-		foreach ( [ null, 'string-value', [ 'array' => 'value' ], 42, false ] as $non_object ) {
-			$result = $this->class->check_update( $non_object );
+		/* This site sees the update but has no package of its own (missing/invalid license) */
+		$local              = new \stdClass();
+		$local->new_version = '0.2';
+		$local->package     = '';
+		$this->class->set_version_info_cache( $local );
 
-			$this->assertInstanceOf( \stdClass::class, $result );
-			$this->assertObjectHasProperty( 'last_checked', $result );
-			$this->assertObjectHasProperty( 'checked', $result );
-			$this->assertArrayHasKey( 'test-plugin/test-plugin.php', $result->checked );
+		$result = $this->class->get_repo_api_data();
+
+		$this->assertSame( '0.2', $result->new_version );
+		$this->assertEmpty( $result->package );
+	}
+
+	public function test_delete_network_version_info_cache_withdraws_own_promotion() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
 		}
+
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'valid' );
+
+		$licensed              = new \stdClass();
+		$licensed->new_version = '0.2';
+		$licensed->package     = 'https://store.com/download/licensed-123';
+		$this->class->set_version_info_cache( $licensed );
+
+		$cache = get_site_option( $this->class->get_network_cache_key() );
+		$this->assertSame( get_current_blog_id(), $cache['blog_id'] );
+
+		/* A failed or throttled check is not a verdict on the license, so the shared package stands */
+		foreach ( [ 'error', 'rate_limit' ] as $status ) {
+			$this->class->set_license_status( $status );
+			$this->assertFalse( $this->class->delete_network_version_info_cache(), $status );
+		}
+
+		/* Removing the key does withdraw it */
+		$this->class->set_license_key( '' );
+		$this->assertTrue( $this->class->delete_network_version_info_cache() );
+		$this->assertFalse( get_site_option( $this->class->get_network_cache_key() ) );
+	}
+
+	/**
+	 * @dataProvider providerUnentitledLicenseStatus
+	 */
+	public function test_delete_network_version_info_cache_withdraws_on_store_rejection( $status ) {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		delete_site_option( $this->class->get_network_cache_key() );
+		$this->class->set_license_status( 'valid' );
+
+		$licensed              = new \stdClass();
+		$licensed->new_version = '0.2';
+		$licensed->package     = 'https://store.com/download/licensed-123';
+		$this->class->set_version_info_cache( $licensed );
+
+		/* The key stays populated on a rejection, so the status is the only signal the entitlement ended */
+		$this->class->set_license_status( $status );
+
+		$this->assertTrue( $this->class->delete_network_version_info_cache() );
+		$this->assertFalse( get_site_option( $this->class->get_network_cache_key() ) );
+	}
+
+	public function providerUnentitledLicenseStatus() {
+		return [
+			[ 'expired' ],
+			[ 'revoked' ],
+			[ 'disabled' ],
+			[ 'missing' ],
+			[ 'invalid' ],
+			[ 'site_inactive' ],
+			[ 'item_name_mismatch' ],
+			[ 'invalid_item_id' ],
+			[ 'no_activations_left' ],
+		];
+	}
+
+	public function test_delete_network_version_info_cache_keeps_another_sites_promotion() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* Another site promoted this package, so its license is still active and the package must survive */
+		$network              = new \stdClass();
+		$network->new_version = '0.2';
+		$network->package     = 'https://store.com/download/licensed-123';
+		update_site_option(
+			$this->class->get_network_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( $network ), 'blog_id' => get_current_blog_id() + 1 ]
+		);
+
+		$this->class->set_license_key( '' );
+
+		$this->assertFalse( $this->class->delete_network_version_info_cache() );
+		$this->assertNotEmpty( get_site_option( $this->class->get_network_cache_key() ) );
+
+		delete_site_option( $this->class->get_network_cache_key() );
 	}
 }

--- a/tests/phpunit/integration/Helper/Log/Test_Redact_Processor.php
+++ b/tests/phpunit/integration/Helper/Log/Test_Redact_Processor.php
@@ -4,254 +4,246 @@ declare( strict_types=1 );
 
 namespace GFPDF\Helper\Log;
 
+use GFPDF\Tests\Integration\TestCase;
 use GFPDF_Vendor\Monolog\DateTimeImmutable;
 use GFPDF_Vendor\Monolog\Handler\TestHandler;
 use GFPDF_Vendor\Monolog\Logger as MonoLogger;
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * @group logger
- * @internal Not testing WordPress, so use Yoast TestCase directly instead of WP_UnitTestCase
  */
 class Test_Redact_Processor extends TestCase {
 
-	public function test_basic_usage() {
-		$handler   = new TestHandler();
-		$processor = new Redact_Processor( [ 'test_key' => 4 ] );
-
-		$logger = new MonoLogger( 'Test', [ $handler ], [ $processor ] );
-		$logger->info( 'Testing', [ 'test_key' => 'test_value' ] );
-
-		$this->assertTrue(
-			$handler->hasRecordThatPasses( function ( $record ): bool {
-				return $record['context']['test_key'] === 'test******';
-			}, MonoLogger::INFO )
-		);
-	}
-
-	public function test_redacts_records_contexts() {
-		$sensitive_keys = [ 'test' => 3 ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => 'foobar' ] );
-
-		$this->assertSame( [ 'test' => 'foo***' ], $processor( $record )['context'] );
-	}
-
-	public function test_redacts_using_template() {
-		$sensitive_keys = [ 'test' => 2 ];
-		$processor      = new Redact_Processor( $sensitive_keys, '*', '%s(redacted)' );
-
-		$record = $this->get_record( [ 'test' => 'foobar' ] );
-
-		$this->assertSame( [ 'test' => 'fo****(redacted)' ], $processor( $record )['context'] );
-	}
-
-	public function test_redacts_discarding_masked() {
-		$sensitive_keys = [ 'test' => 1 ];
-		$processor      = new Redact_Processor( $sensitive_keys, '*', '...' );
-
-		$record = $this->get_record( [ 'test' => 'foobar123' ] );
-
-		$this->assertSame( [ 'test' => 'f...' ], $processor( $record )['context'] );
-	}
-
-	public function test_truncates_masked_characters() {
-		$sensitive_keys = [ 'test' => 3 ];
-		$processor      = new Redact_Processor( $sensitive_keys, '*', '%s', 5 );
-
-		$record = $this->get_record( [ 'test' => 'foobar' ] );
-
-		$this->assertSame( [ 'test' => 'foo**' ], $processor( $record )['context'] );
-	}
-
-	public function test_truncates_visible_characters() {
-		$sensitive_keys = [ 'test' => 3 ];
-		$processor      = new Redact_Processor( $sensitive_keys, '*', '%s', 2 );
-
-		$record = $this->get_record( [ 'test' => 'foobar' ] );
-
-		$this->assertSame( [ 'test' => 'fo' ], $processor( $record )['context'] );
-	}
-
-	public function test_overrides_default_replacement() {
-		$sensitive_keys = [ 'test' => 3 ];
-		$processor      = new Redact_Processor( $sensitive_keys, '_' );
-
-		$record = $this->get_record( [ 'test' => 'foobar' ] );
-
-		$this->assertSame( [ 'test' => 'foo___' ], $processor( $record )['context'] );
-	}
-
-	public function test_redacts_from_right_to_left() {
-		$sensitive_keys = [ 'test' => -3 ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => 'foobar' ] );
-
-		$this->assertSame( [ 'test' => '***bar' ], $processor( $record )['context'] );
-	}
-
-	public function test_truncates_masked_from_right_to_left() {
-		$sensitive_keys = [ 'test' => -3 ];
-		$processor      = new Redact_Processor( $sensitive_keys, '*', '%s', 4 );
-
-		$record = $this->get_record( [ 'test' => 'foobar' ] );
-
-		$this->assertSame( [ 'test' => '*bar' ], $processor( $record )['context'] );
-	}
-
-	public function test_truncates_visible_from_right_to_left() {
-		$sensitive_keys = [ 'test' => -3 ];
-		$processor      = new Redact_Processor( $sensitive_keys, '*', '%s', 2 );
-
-		$record = $this->get_record( [ 'test' => 'foobar' ] );
-
-		$this->assertSame( [ 'test' => 'ar' ], $processor( $record )['context'] );
-	}
-
-	public function test_redacts_nested_arrays() {
-		$sensitive_keys = [ 'test' => [ 'nested' => 3 ] ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => [ 'nested' => 'foobar' ] ] );
-
-		$this->assertSame( [ 'test' => [ 'nested' => 'foo***' ] ], $processor( $record )['context'] );
-	}
-
-	public function test_redacts_inside_nested_arrays() {
-		$sensitive_keys = [ 'nested' => 3 ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => [ 'nested' => 'foobar' ] ] );
-
-		$this->assertSame( [ 'test' => [ 'nested' => 'foo***' ] ], $processor( $record )['context'] );
-	}
-
-	public function test_redacts_nested_objects() {
-		$nested         = new \stdClass();
-		$nested->value  = 'foobar';
-		$nested->nested = [ 'value' => 'bazqux' ];
-
-		$sensitive_keys = [ 'test' => [ 'nested' => [ 'value' => 3, 'nested' => [ 'value' => -3 ] ] ] ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => [ 'nested' => $nested ] ] );
-
-		$this->assertSame( [ 'test' => [ 'nested' => $nested ] ], $processor( $record )['context'] );
-		$this->assertSame( 'foo***', $nested->value );
-		$this->assertSame( '***qux', $nested->nested['value'] );
-	}
-
-	public function test_redacts_inside_nested_objects() {
-		$nested         = new \stdClass();
-		$nested->value  = 'foobar';
-		$nested->nested = [ 'value' => 'bazqux' ];
-
-		$sensitive_keys = [ 'nested' => [ 'value' => -3 ] ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => [ 'nested' => $nested ] ] );
-
-		$this->assertSame( [ 'test' => [ 'nested' => $nested ] ], $processor( $record )['context'] );
-		$this->assertSame( '***bar', $nested->value );
-		$this->assertSame( '***qux', $nested->nested['value'] );
-	}
-
-	public function test_preserves_empty_values() {
-		$sensitive_keys = [ 'test' => 3, 'optionalKey' => 10 ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => 'foobar', 'optionalKey' => '' ] );
-
-		$this->assertSame( [ 'test' => 'foo***', 'optionalKey' => '' ], $processor( $record )['context'] );
-	}
-
-	public function test_ignored_when_finds_an_un_traversable_value() {
-		$sensitive_keys = [ 'test' => 3 ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$context = [ 'test' => fopen( __FILE__, 'rb' ) ];
-		$record  = $this->get_record( $context );
-
-		$this->assertSame( $context, $processor( $record )['context'] );
-	}
-
-	public function test_should_not_throw_when_non_scalar_value_but_keys_are_not_nested() {
-		$sensitive_keys = [ 'test' => -4 ];
-		$obj            = new \stdClass();
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => $obj ] );
-
-		$this->assertSame( [ 'test' => $obj ], $processor( $record )['context'] );
-	}
-
-	public function test_ignore_when_null_value() {
-		$sensitive_keys = [ 'test' => 3 ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => 'foobar', 'optionalKey' => null ] );
-
-		$this->assertSame( [ 'test' => 'foo***', 'optionalKey' => null ], $processor( $record )['context'] );
-	}
-
-	public function test_redacts_nested_values_when_key_is_integer() {
-		$sensitive_keys = [ 'test' => 3 ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 0 => [ 'good' => 'value' ], 1 => [ 'test' => 'foobar' ] ] );
-
-		$this->assertSame( [ 0 => [ 'good' => 'value' ], 1 => [ 'test' => 'foo***' ] ], $processor( $record )['context'] );
-	}
-
-	public function test_redact_with_regex() {
-		$sensitive_keys = [ 'key' => '/[A-Fa-f0-9]{28}/' ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'key' => '098f6bcd4621d373cade4e832627b4f6' ] );
-		$this->assertSame( [ 'key' => '****************************b4f6' ], $processor( $record )['context'] );
-
-		$record = $this->get_record( [ 'key' => '098f6bcd4621d373cade4e832627b4f67asb' ] );
-		$this->assertSame( [ 'key' => '****************************b4f67asb' ], $processor( $record )['context'] );
-
-		$record = $this->get_record( [ 'key' => 'rate_limit' ] );
-		$this->assertSame( [ 'key' => 'rate_limit' ], $processor( $record )['context'] );
-	}
-
-	public function test_redact_with_regex_inside_nested_object() {
-		$nested         = new \stdClass();
-		$nested->value  = 'foobar';
-		$nested->nested = [ 'key' => '098f6bcd4621d373cade4e832627b4f6', 'status' => 'rate_limit' ];
-
-		$sensitive_keys = [ 'key' => '/[A-Fa-f0-9]{28}/', 'status' => '/[A-Fa-f0-9]{28}/' ];
-		$processor      = new Redact_Processor( $sensitive_keys );
-
-		$record = $this->get_record( [ 'test' => [ 'nested' => $nested ] ] );
-
-		$this->assertSame( [ 'test' => [ 'nested' => $nested ] ], $processor( $record )['context'] );
-		$this->assertSame( '****************************b4f6', $nested->nested['key'] );
-		$this->assertSame( 'rate_limit', $nested->nested['status'] );
+	protected function processor( $slug = 'test-plugin' ) {
+		return new Redact_Processor( $slug );
 	}
 
 	/**
-	 * @param        $context
-	 * @param        $level
-	 * @param        $message
-	 * @param string $channel
-	 * @param        $datetime
-	 * @param array  $extra
-	 *
-	 * @return array
+	 * Keyed context redaction replaces the whole value with the placeholder, case-insensitively.
 	 */
-	protected function get_record( $context = [], $level = MonoLogger::WARNING, $message = 'test', string $channel = 'test', $datetime = null, array $extra = [] ) {
+	public function test_redacts_context_by_key() {
+		$context = $this->processor()->context(
+			[
+				'license'       => 'abc123',
+				'Authorization' => 'Bearer xyz',
+				'status'        => 'valid',
+			]
+		);
+
+		$this->assertSame( '[redacted]', $context['license'] );
+		$this->assertSame( '[redacted]', $context['Authorization'] );
+		$this->assertSame( 'valid', $context['status'] );
+	}
+
+	/**
+	 * Recurses into nested arrays so deeply-nested secrets (eg. HTTP response headers) are caught.
+	 */
+	public function test_redacts_nested_arrays() {
+		$context = $this->processor()->context(
+			[
+				'response' => [
+					'headers' => [
+						'authorization' => 'Bearer xyz',
+						'content-type'  => 'application/json',
+					],
+				],
+			]
+		);
+
+		$this->assertSame( '[redacted]', $context['response']['headers']['authorization'] );
+		$this->assertSame( 'application/json', $context['response']['headers']['content-type'] );
+	}
+
+	/**
+	 * Objects are cast to arrays and recursed so an object-valued context can't smuggle secrets past redaction.
+	 */
+	public function test_redacts_nested_objects() {
+		$obj           = new \stdClass();
+		$obj->token    = 'secret-value';
+		$obj->harmless = 'keep-me';
+
+		$context = $this->processor()->context( [ 'data' => $obj ] );
+
+		$this->assertSame( '[redacted]', $context['data']['token'] );
+		$this->assertSame( 'keep-me', $context['data']['harmless'] );
+	}
+
+	/**
+	 * A circular reference must not recurse forever — the depth cap replaces the value instead of exhausting the stack.
+	 */
+	public function test_caps_recursion_on_circular_references() {
+		$node        = new \stdClass();
+		$node->child = $node;
+
+		/* Without the depth cap this overflows the stack before returning; reaching the assertion proves it terminates. */
+		$result = $this->processor()->context( [ 'root' => $node ] );
+
+		/* Follow the self-referential chain; it must bottom out at the marker rather than loop. */
+		$cursor = $result['root'];
+		while ( is_array( $cursor ) ) {
+			$cursor = $cursor['child'];
+		}
+
+		$this->assertSame( '[redacted]', $cursor );
+	}
+
+	/**
+	 * Non-string keys and scalar values that don't match a deny-key pass through untouched.
+	 */
+	public function test_preserves_untargeted_values() {
+		$context = $this->processor()->context(
+			[
+				0         => 'positional',
+				'count'   => 5,
+				'enabled' => true,
+				'nothing' => null,
+			]
+		);
+
+		$this->assertSame( [ 0 => 'positional', 'count' => 5, 'enabled' => true, 'nothing' => null ], $context );
+	}
+
+	/**
+	 * The filter may add deny-keys.
+	 */
+	public function test_filter_adds_keys() {
+		add_filter(
+			'gfpdf_logging_redact_keys',
+			function ( $keys ) {
+				$keys[] = 'my_custom_secret';
+
+				return $keys;
+			}
+		);
+
+		$context = $this->processor()->context( [ 'my_custom_secret' => 'hunter2', 'license' => 'abc' ] );
+
+		$this->assertSame( '[redacted]', $context['my_custom_secret'] );
+		$this->assertSame( '[redacted]', $context['license'] );
+	}
+
+	/**
+	 * The filter may only add keys — returning an empty set can't weaken the defaults.
+	 */
+	public function test_filter_cannot_remove_defaults() {
+		add_filter(
+			'gfpdf_logging_redact_keys',
+			function () {
+				return [];
+			}
+		);
+
+		$context = $this->processor()->context( [ 'license' => 'abc123' ] );
+
+		$this->assertSame( '[redacted]', $context['license'] );
+	}
+
+	/**
+	 * A raw non-JSON API body stored under a benign key (eg. 'response'/'body') isn't caught by keyed redaction, so
+	 * its string value is run through the same message() pattern scrub — masking the signed URLs and echoed keys the
+	 * raw-body fallback path would otherwise leak.
+	 */
+	public function test_pattern_scrubs_context_string_leaves() {
+		$context = $this->processor()->context(
+			[
+				'response' => 'package https://store.com/download/file.zip?signature=deadbeef',
+				'body'     => 'license 098f6bcd4621d373cade4e832627b4f6 rejected',
+			]
+		);
+
+		$this->assertSame( 'package https://store.com/download/file.zip?', $context['response'] );
+		$this->assertSame( 'license [redacted] rejected', $context['body'] );
+	}
+
+	/**
+	 * set-cookie is a deny-key: a Set-Cookie header can carry a session secret.
+	 */
+	public function test_redacts_set_cookie_key() {
+		$context = $this->processor()->context( [ 'set-cookie' => 'session=abc; HttpOnly' ] );
+
+		$this->assertSame( '[redacted]', $context['set-cookie'] );
+	}
+
+	/**
+	 * @dataProvider provider_message_patterns
+	 */
+	public function test_redacts_message_patterns( $message, $expected ) {
+		$this->assertSame( $expected, $this->processor()->message( $message ) );
+	}
+
+	public function provider_message_patterns() {
 		return [
-			'message'  => (string) $message,
-			'context'  => $context,
-			'level'    => MonoLogger::toMonologLevel( $level ),
-			'channel'  => $channel,
-			'datetime' => $datetime ?? new DateTimeImmutable( true ),
-			'extra'    => $extra,
+			'hex license'  => [ 'License 098f6bcd4621d373cade4e832627b4f6 rejected', 'License [redacted] rejected' ],
+			'bearer token' => [ 'Auth failed: Bearer abc.def.ghi', 'Auth failed: [redacted]' ],
+			'google oauth' => [ 'token ya29.a0AfB_xyz-123 expired', 'token [redacted] expired' ],
+			'stripe key'   => [ 'using sk_4eC39HqLyjWDarjtT1zdp7dc', 'using [redacted]' ],
+			'plain text'   => [ 'nothing sensitive here', 'nothing sensitive here' ],
 		];
+	}
+
+	/**
+	 * Signed-link secrets live in the query string, so keep the path and drop everything after the ?.
+	 */
+	public function test_blanks_url_query_strings() {
+		$this->assertSame(
+			'Download failed https://example.com/file.zip?',
+			$this->processor()->message( 'Download failed https://example.com/file.zip?token=secret&exp=123' )
+		);
+	}
+
+	/**
+	 * A newline in message data must not be able to forge a second log line.
+	 */
+	public function test_collapses_line_breaks() {
+		$this->assertSame(
+			'line one line two line three',
+			$this->processor()->message( "line one\r\nline two\nline three" )
+		);
+	}
+
+	/**
+	 * Non-printable control characters are stripped before redaction.
+	 */
+	public function test_strips_control_characters() {
+		$this->assertSame( 'clean', $this->processor()->message( "cl\x00ea\x07n" ) );
+	}
+
+	/**
+	 * __invoke redacts both the message body and the context in a single pass.
+	 */
+	public function test_invoke_redacts_message_and_context() {
+		$record = [
+			'message'  => 'License 098f6bcd4621d373cade4e832627b4f6 rejected',
+			'context'  => [ 'license' => 'abc123', 'status' => 'invalid' ],
+			'level'    => MonoLogger::toMonologLevel( MonoLogger::WARNING ),
+			'channel'  => 'test',
+			'datetime' => new DateTimeImmutable( true ),
+			'extra'    => [],
+		];
+
+		$processed = ( $this->processor() )( $record );
+
+		$this->assertSame( 'License [redacted] rejected', $processed['message'] );
+		$this->assertSame( '[redacted]', $processed['context']['license'] );
+		$this->assertSame( 'invalid', $processed['context']['status'] );
+	}
+
+	/**
+	 * Works as a pushed Monolog processor end-to-end.
+	 */
+	public function test_works_as_monolog_processor() {
+		$handler = new TestHandler();
+		$logger  = new MonoLogger( 'Test', [ $handler ], [ $this->processor() ] );
+
+		$logger->info( 'Key 098f6bcd4621d373cade4e832627b4f6', [ 'token' => 'shhh' ] );
+
+		$this->assertTrue(
+			$handler->hasRecordThatPasses(
+				function ( $record ): bool {
+					return $record['message'] === 'Key [redacted]' && $record['context']['token'] === '[redacted]';
+				},
+				MonoLogger::INFO
+			)
+		);
 	}
 }

--- a/tests/phpunit/integration/Helper/Test_Helper_Misc_Config.php
+++ b/tests/phpunit/integration/Helper/Test_Helper_Misc_Config.php
@@ -102,4 +102,47 @@ class Test_Helper_Misc_Config extends TestCase {
 		$this->assertSame( 'view', $this->misc->backwards_compat_output( 'display' ) );
 		$this->assertSame( 'download', $this->misc->backwards_compat_output( 'download' ) );
 	}
+
+	public function test_is_secondary_network_site_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Not running single site tests' );
+		}
+
+		$this->assertFalse( $this->misc->is_secondary_network_site( 'gravity-pdf/pdf.php' ) );
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_is_secondary_network_site_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not running multisite tests' );
+		}
+
+		$plugin          = 'gravity-pdf/pdf.php';
+		$network_plugins = [ $plugin => time() ];
+
+		/* Fake the network-activated plugin list without touching the shared option */
+		$filter = static function () use ( &$network_plugins ) {
+			return $network_plugins;
+		};
+		add_filter( 'pre_site_option_active_sitewide_plugins', $filter );
+
+		/* The primary site is never treated as secondary, even when the plugin is network activated */
+		$this->assertFalse( $this->misc->is_secondary_network_site( $plugin ) );
+
+		/* Pose as a secondary site — we only read a network option, so no real blog is needed */
+		switch_to_blog( PHP_INT_MAX );
+
+		/* Secondary site, plugin not network activated */
+		$network_plugins = [];
+		$this->assertFalse( $this->misc->is_secondary_network_site( $plugin ) );
+
+		/* Secondary site, plugin network activated */
+		$network_plugins = [ $plugin => time() ];
+		$this->assertTrue( $this->misc->is_secondary_network_site( $plugin ) );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $filter );
+	}
 }

--- a/tests/phpunit/integration/Model/Test_Model_Settings.php
+++ b/tests/phpunit/integration/Model/Test_Model_Settings.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types=1 );
 
 namespace GFPDF\Model;
@@ -46,8 +47,6 @@ class Test_Model_Settings extends TestCase {
 
 		parent::set_up();
 
-		remove_all_actions( 'init' );
-
 		$this->model = new Model_Settings( $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->templates );
 
 		$this->addon = new ModelSettingsAddon(
@@ -80,31 +79,75 @@ class Test_Model_Settings extends TestCase {
 
 		$this->addon1->set_edd_download_id( 10 );
 
-		$data = \GPDFAPI::get_data_class();
-		$data->updater = null;
-		$data->addon = [];
+		$this->addon->init();
+		$this->addon1->init();
 	}
 
 	public function tear_down(): void {
 		parent::tear_down();
-
-		$data = \GPDFAPI::get_data_class();
-		$data->updater = null;
+		$data        = \GPDFAPI::get_data_class();
 		$data->addon = [];
+
+		/* Creating a subsite dirties process globals WP_UnitTestCase won't roll back; reset so later tests aren't polluted */
+		global $wp_settings_errors, $wp_rewrite;
+		$wp_settings_errors = [];
+		$wp_rewrite->init();
 	}
 
 	public function test_license_bulk_get_version_api_params_skipped() {
 		/* Check skipped when not initialized */
+		$data          = \GPDFAPI::get_data_class();
+		$data->updater = null;
+		$data->addon   = [];
 		$this->assertTrue( $this->model->licensing_bulk_get_version_api_params( true ) );
 	}
 
-	public function test_license_bulk_get_version_api_params_core_plugin() {
-		$this->addon->init();
+	public function test_license_bulk_get_version_api_params_missing_updater() {
+		/* Non-canonical build (updater key never registered): bulk the add-ons only, without throwing from Helper_Data::__get() */
+		do_action( 'init' );
+
+		$data = \GPDFAPI::get_data_class();
+		unset( $data->updater );
+
+		$this->assertNotEmpty( $data->addon );
+
+		$params = $this->model->licensing_bulk_get_version_api_params( [] );
+		$this->assertArrayHasKey( 'edd_action', $params );
+		$this->assertCount( count( $data->addon ), $params['products'] );
+	}
+
+	public function test_license_bulk_get_version_api_params_skips_uninitialized_addon() {
+		$this->setExpectedIncorrectUsage( 'GFPDF\Helper\Helper_Abstract_Addon::get_plugin_updater' );
 
 		do_action( 'init' );
 
-		$params = $this->model->licensing_bulk_get_version_api_params( [] );
+		/* Register an add-on whose updater was never initialized — get_plugin_updater() returns null */
+		$data          = \GPDFAPI::get_data_class();
+		$uninitialized = new ModelSettingsAddon(
+			'uninitialized-plugin',
+			'Uninitialized Plugin',
+			'Gravity PDF',
+			'1.0',
+			'/path/to/plugin/file.php',
+			\GPDFAPI::get_data_class(),
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'uninitialized-plugin', 'Uninitialized Plugin' ),
+			new Helper_Notices()
+		);
+		$data->add_addon( $uninitialized );
 
+		/* Core + the two initialized add-ons; the uninitialized one is skipped rather than fataling */
+		$params = $this->model->licensing_bulk_get_version_api_params( [] );
+		$this->assertCount( 3, $params['products'] );
+	}
+
+	public function test_license_bulk_get_version_api_params_core_plugin() {
+		$data        = \GPDFAPI::get_data_class();
+		$data->addon = [];
+		do_action( 'init' );
+
+		$params = $this->model->licensing_bulk_get_version_api_params( [] );
 		$this->assertArrayHasKey( 'edd_action', $params );
 		$this->assertArrayHasKey( 'products', $params );
 		$this->assertCount( 1, $params['products'] );
@@ -114,27 +157,89 @@ class Test_Model_Settings extends TestCase {
 	}
 
 	public function test_licensing_bulk_get_version_api_response() {
-		$this->addon->init();
-		$this->addon1->init();
-
 		do_action( 'init' );
 
 		$params = $this->model->licensing_bulk_get_version_api_params( [] );
 		$this->assertArrayHasKey( 'edd_action', $params );
 		$this->assertArrayHasKey( 'products', $params );
-		$this->assertCount( 2, $params['products'] );
+		$this->assertCount( 3, $params['products'] );
 		$this->assertArrayHasKey( 'license', $params['products'][0] );
 		$this->assertArrayHasKey( 'item_id', $params['products'][0] );
 		$this->assertArrayHasKey( 'url', $params['products'][0] );
 		$this->assertArrayHasKey( 'license', $params['products'][1] );
 		$this->assertArrayHasKey( 'item_id', $params['products'][1] );
 		$this->assertArrayHasKey( 'url', $params['products'][1] );
+		$this->assertArrayHasKey( 'license', $params['products'][2] );
+		$this->assertArrayHasKey( 'item_id', $params['products'][2] );
+		$this->assertArrayHasKey( 'url', $params['products'][2] );
+	}
+
+	public function test_licensing_bulk_get_version_api_response_maps_by_folder_slug() {
+		$data          = \GPDFAPI::get_data_class();
+		$data->addon   = [];
+		$data->updater = null;
+
+		/*
+		 * Registered slug deliberately differs from the plugin-folder basename (e.g. a user-renamed folder). The API
+		 * echoes back the folder slug the updater sent, not the registered slug — the exact mismatch L8 dropped.
+		 */
+		$initiator = new ModelSettingsAddon(
+			'registered-initiator',
+			'Initiator',
+			'Gravity PDF',
+			'1.0',
+			'/plugins/folder-initiator/main.php',
+			$data,
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'registered-initiator', 'Initiator' ),
+			new Helper_Notices()
+		);
+
+		$sibling = new ModelSettingsAddon(
+			'registered-sibling',
+			'Sibling',
+			'Gravity PDF',
+			'1.0',
+			'/plugins/folder-sibling/main.php',
+			$data,
+			\GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'registered-sibling', 'Sibling' ),
+			new Helper_Notices()
+		);
+
+		$initiator->init();
+		$sibling->init();
+		do_action( 'init' );
+
+		$initiator_updater = $data->addon['registered-initiator']->get_plugin_updater();
+		$sibling_updater   = $data->addon['registered-sibling']->get_plugin_updater();
+
+		/* The sibling add-on is an active plugin in reality; mark it so the multisite cache gate doesn't skip its caching */
+		update_option( 'active_plugins', [ plugin_basename( $sibling_updater->get_plugin_file() ) ] );
+
+		/* The bulk response is a list of product objects identified only by the folder slug echoed back */
+		$response = [
+			(object) [ 'slug' => 'folder-initiator', 'new_version' => '9.9.9', 'stable_version' => '9.9.9' ],
+			(object) [ 'slug' => 'folder-sibling', 'new_version' => '8.8.8', 'stable_version' => '8.8.8' ],
+		];
+
+		/* Fire the response filter as the initiator's own updater would — its plugin file identifies the initiator */
+		$initial = $this->model->licensing_bulk_get_version_api_response( $response, [], $initiator_updater->get_plugin_file() );
+
+		/* The initiator's own product is handed back for its normal caching path */
+		$this->assertIsObject( $initial );
+		$this->assertSame( 'folder-initiator', $initial->slug );
+		$this->assertSame( '9.9.9', $initial->new_version );
+
+		/* The sibling was linked by its folder slug (not its registered slug) and cached — this is what L8 dropped */
+		$cached = $sibling_updater->get_cached_version_info();
+		$this->assertIsObject( $cached );
+		$this->assertSame( '8.8.8', $cached->new_version );
 	}
 
 	public function test_licensing_bulk_license_check_success() {
-		$this->addon->init();
-		$this->addon1->init();
-
 		do_action( 'init' );
 
 		$data = \GPDFAPI::get_data_class();
@@ -170,13 +275,13 @@ class Test_Model_Settings extends TestCase {
 	}
 
 	public function test_licensing_bulk_license_check_no_addons() {
+		$data        = \GPDFAPI::get_data_class();
+		$data->addon = [];
+
 		$this->assertFalse( $this->model->licensing_bulk_license_check() );
 	}
 
 	public function test_licensing_bulk_license_check_bad_status_code() {
-		$this->addon->init();
-		$this->addon1->init();
-
 		do_action( 'init' );
 
 		wp_clear_scheduled_hook( 'gfpdf_bulk_license_check' );
@@ -199,6 +304,377 @@ class Test_Model_Settings extends TestCase {
 
 		$this->assertFalse( $this->model->licensing_bulk_license_check() );
 		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+
+		remove_filter( 'pre_http_request', $api_response );
+	}
+
+	public function test_licensing_bulk_license_check_bad_response() {
+		do_action( 'init' );
+
+		wp_clear_scheduled_hook( 'gfpdf_bulk_license_check' );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+
+		$data = \GPDFAPI::get_data_class();
+		foreach ( $data->addon as $addon ) {
+			$addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+		}
+
+		/* Do a malformed request */
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => '<!DOCTYPE />',
+			];
+		};
+
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->assertFalse( $this->model->licensing_bulk_license_check() );
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
+
+		remove_filter( 'pre_http_request', $api_response );
+	}
+
+	public function test_licensing_bulk_license_check_skipped_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		do_action( 'init' );
+
+		$data = \GPDFAPI::get_data_class();
+		foreach ( $data->addon as $addon ) {
+			/* In-memory keys + updaters so the check would otherwise build params and POST — proving the gate is what stops it */
+			$addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+		}
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP in tests' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		/* Pose as a secondary site with Gravity PDF network-activated; only a network option is read, so no real blog is needed */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		$this->assertFalse( $this->model->licensing_bulk_license_check() );
+		$this->assertFalse( $http_called );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		remove_filter( 'pre_http_request', $spy );
+	}
+
+	public function test_schedule_network_update_check_uses_single_event_synced_to_wp_update_plugins() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'wp_update_plugins' );
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		$wp_check = time() + 3 * HOUR_IN_SECONDS;
+		wp_schedule_event( $wp_check, 'twicedaily', 'wp_update_plugins' );
+
+		$this->model->schedule_network_update_check();
+
+		/* One minute after the primary site's plugin update check */
+		$this->assertSame( $wp_check + 60, wp_next_scheduled( 'gfpdf_network_update_check' ) );
+
+		/* A one-off event (wp_get_schedule() is false for single events) so the offset is recomputed each run */
+		$this->assertFalse( wp_get_schedule( 'gfpdf_network_update_check' ) );
+	}
+
+	public function test_schedule_network_update_check_falls_back_when_wp_update_plugins_unscheduled() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'wp_update_plugins' );
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		$before = time();
+		$this->model->schedule_network_update_check();
+
+		/* Falls back to ~12 hours out so the self-rescheduling chain survives a missing primary-site check */
+		$this->assertGreaterThanOrEqual( $before + 12 * HOUR_IN_SECONDS, wp_next_scheduled( 'gfpdf_network_update_check' ) );
+		$this->assertFalse( wp_get_schedule( 'gfpdf_network_update_check' ) );
+	}
+
+	public function test_schedule_network_update_check_floors_overdue_wp_update_plugins_to_future() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'wp_update_plugins' );
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		/* wp_update_plugins only advances when the primary site runs cron, so it reports a PAST time when that site is
+		   quiet. Left as-is the offset would be in the past and the self-rescheduling event would fire every cron spawn. */
+		wp_schedule_event( time() - HOUR_IN_SECONDS, 'twicedaily', 'wp_update_plugins' );
+
+		$before = time();
+		$this->model->schedule_network_update_check();
+
+		/* Floored to the future rather than immediately due */
+		$this->assertGreaterThan( $before, wp_next_scheduled( 'gfpdf_network_update_check' ) );
+	}
+
+	public function test_run_network_update_check_reinjects_transient_in_subsite_context() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* A per-site-activated subsite (not network-activated) is the path this method targets */
+		$blog_id = $this->factory()->blog->create();
+		switch_to_blog( $blog_id );
+
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		/* Isolate the transient round-trip to our own spy: real listeners (Gravity Forms' check_update on the read
+		   filter, stale add-on updaters) would otherwise run their own version checks and hit the network. We only
+		   care which blog the re-injection fires in. */
+		remove_all_filters( 'site_transient_update_plugins' );
+		remove_all_filters( 'transient_update_plugins' );
+		remove_all_filters( 'pre_set_site_transient_update_plugins' );
+
+		/* Seed a non-false update_plugins transient so the round-trip has something to re-inject */
+		set_site_transient( 'update_plugins', (object) [ 'checked' => [] ] );
+
+		/* Record the blog context in which check_update() (pre_set_site_transient_update_plugins) fires */
+		$fired_on_blog = null;
+		$spy           = function ( $value ) use ( &$fired_on_blog ) {
+			$fired_on_blog = get_current_blog_id();
+			return $value;
+		};
+		add_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		$this->model->run_network_update_check();
+
+		remove_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		/* The re-injection must fire in the subsite context (where the per-site add-on's cache lives), not the main
+		   site — switching to the main site would miss that cache and force an uncached API request per updater (H1) */
+		$this->assertSame( $blog_id, $fired_on_blog );
+		$this->assertNotSame( get_main_site_id(), $fired_on_blog );
+
+		/* And it re-arms the self-rescheduling event into the future (H2) */
+		$this->assertGreaterThan( time(), wp_next_scheduled( 'gfpdf_network_update_check' ) );
+
+		restore_current_blog();
+	}
+
+	public function test_run_network_update_check_skips_on_main_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+		remove_all_filters( 'pre_set_site_transient_update_plugins' );
+		set_site_transient( 'update_plugins', (object) [ 'checked' => [] ] );
+
+		$fired = false;
+		$spy   = function ( $value ) use ( &$fired ) {
+			$fired = true;
+			return $value;
+		};
+		add_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		/* The main site receives update checks through the normal flow, so the forced check is skipped */
+		$this->model->run_network_update_check();
+
+		remove_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		$this->assertFalse( $fired );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_network_update_check' ) );
+	}
+
+	public function test_run_network_update_check_skips_on_network_activated_secondary_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		wp_clear_scheduled_hook( 'gfpdf_network_update_check' );
+
+		/* Network-activated secondary sites are served by the normal flow, so the forced check must not re-arm here */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		remove_all_filters( 'pre_set_site_transient_update_plugins' );
+		set_site_transient( 'update_plugins', (object) [ 'checked' => [] ] );
+
+		$fired = false;
+		$spy   = function ( $value ) use ( &$fired ) {
+			$fired = true;
+			return $value;
+		};
+		add_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		$this->model->run_network_update_check();
+
+		remove_filter( 'pre_set_site_transient_update_plugins', $spy );
+
+		$this->assertFalse( $fired );
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_network_update_check' ) );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+	}
+
+	public function test_maybe_active_licenses_ignores_submitted_value_for_constant_managed_addon() {
+		$slug = $this->addon->get_slug();
+
+		/* A hardcoded constant key makes the add-on admin-managed: the submitted value must be ignored and the
+		   authoritative constant value persisted, without burning an activation against the key */
+		add_filter( 'gfpdf_addon_hardcoded_license_key', static function () { return 'CONSTANT-KEY'; } );
+		$this->addon->update_license_info( [ 'license' => 'CONSTANT-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		$input = $this->model->maybe_active_licenses(
+			[
+				"license_$slug"           => 'forged-attacker-key',
+				"license_{$slug}_status"  => 'active',
+				"license_{$slug}_message" => 'forged',
+			]
+		);
+
+		remove_filter( 'pre_http_request', $spy );
+		remove_all_filters( 'gfpdf_addon_hardcoded_license_key' );
+
+		$this->assertFalse( $http_called );
+		$this->assertSame( 'CONSTANT-KEY', $input[ "license_$slug" ] );
+		$this->assertSame( 'active', $input[ "license_{$slug}_status" ] );
+	}
+
+	public function test_maybe_active_licenses_ignores_submitted_value_for_auto_activated_addon() {
+		$slug = $this->addon->get_slug();
+
+		/* Give the sibling a real Access Pass license, then auto-activate our add-on off it (its EDD id is in the pass) */
+		$this->addon1->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid', 'products' => [ 5 ] ] ) ];
+		$this->addon->maybe_auto_activate_license( $response, $this->addon1, false );
+		$this->assertTrue( $this->addon->is_license_admin_managed() );
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		$input = $this->model->maybe_active_licenses(
+			[
+				"license_$slug"           => 'forged-attacker-key',
+				"license_{$slug}_status"  => 'active',
+				"license_{$slug}_message" => 'forged',
+			]
+		);
+
+		remove_filter( 'pre_http_request', $spy );
+
+		/* The auto-activated (admin-managed) key is authoritative — no activation POST, forged value overwritten */
+		$this->assertFalse( $http_called );
+		$this->assertSame( 'AP-KEY', $input[ "license_$slug" ] );
+		$this->assertSame( 'active', $input[ "license_{$slug}_status" ] );
+	}
+
+	public function test_maybe_active_licenses_clears_in_memory_status_on_empty_key() {
+		$slug = $this->addon->get_slug();
+
+		$this->addon->update_license_info( [ 'license' => 'old-key', 'status' => 'active', 'message' => 'ok' ] );
+
+		$this->model->maybe_active_licenses(
+			[
+				"license_$slug"          => '   ',
+				"license_{$slug}_status" => 'active',
+			]
+		);
+
+		/* Clearing the field must sync the cached model, not just the persisted array (L5) */
+		$this->assertSame( '', $this->addon->get_license_status() );
+		$this->assertSame( '', $this->addon->get_license_key() );
+	}
+
+	public function test_maybe_active_licenses_flushes_update_cache_on_empty_key() {
+		do_action( 'init' );
+
+		$options = \GPDFAPI::get_options_class();
+		$slug    = $this->addon->get_slug();
+
+		$settings                    = $options->get_settings();
+		$settings[ "license_$slug" ] = 'old-key';
+		$options->update_settings( $settings );
+
+		$this->addon->update_license_info( [ 'license' => 'old-key', 'status' => 'active', 'message' => 'ok' ] );
+
+		$updater = $this->addon->get_plugin_updater();
+		update_option(
+			$updater->get_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( (object) [ 'new_version' => '2.0' ] ) ]
+		);
+
+		$this->model->maybe_active_licenses( [ "license_$slug" => '' ] );
+
+		/* The cached update info was fetched with the now-removed key, so it must not outlive it */
+		$this->assertFalse( $updater->get_cached_version_info() );
+
+		delete_option( $updater->get_cache_key() );
+	}
+
+	public function test_maybe_active_licenses_skips_flush_for_unlicensed_addon() {
+		do_action( 'init' );
+
+		$slug    = $this->addon->get_slug();
+		$updater = $this->addon->get_plugin_updater();
+
+		update_option(
+			$updater->get_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( (object) [ 'new_version' => '2.0' ] ) ]
+		);
+
+		/* Every add-on posts an empty license field on an unrelated save; one that never had a key keeps its cache */
+		$this->model->maybe_active_licenses( [ "license_$slug" => '' ] );
+
+		$this->assertIsObject( $updater->get_cached_version_info() );
+
+		delete_option( $updater->get_cache_key() );
+	}
+
+	public function test_licensing_bulk_license_check_skips_malformed_and_unknown_items() {
+		do_action( 'init' );
+
+		$data = \GPDFAPI::get_data_class();
+		foreach ( $data->addon as $addon ) {
+			$addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+		}
+
+		/* item 5 = our add-on (valid → expired); the other two rows are malformed / unknown and must be skipped
+		   without fataling, while the valid row still applies */
+		$api_response = function () {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					[ 'item_id' => 5, 'license' => 'expired' ],
+					[ 'license' => 'valid' ],                       // missing item_id
+					[ 'item_id' => 99999, 'license' => 'valid' ],   // unknown add-on
+				] ),
+			];
+		};
+		add_filter( 'pre_http_request', $api_response );
+
+		$this->assertTrue( $this->model->licensing_bulk_license_check() );
+		$this->assertSame( 'expired', $this->addon->get_license_status() );
 
 		remove_filter( 'pre_http_request', $api_response );
 	}
@@ -252,53 +728,6 @@ class Test_Model_Settings extends TestCase {
 		$this->assertArrayHasKey( 'templateList', $out );
 		$this->assertArrayHasKey( 'activeDefaultTemplate', $out );
 		$this->assertIsArray( $out['templateList'] );
-	}
-
-	public function test_licensing_bulk_get_version_api_response_returns_non_array_unchanged() {
-		$this->assertSame( 'scalar', $this->model->licensing_bulk_get_version_api_response( 'scalar', [], 'plugin.php' ) );
-	}
-
-	public function test_licensing_bulk_get_version_api_response_skips_responses_without_slug() {
-		$response = [ (object) [ 'name' => 'no slug here' ] ];
-
-		$this->assertNull( $this->model->licensing_bulk_get_version_api_response( $response, [], 'plugin.php' ) );
-	}
-
-	public function test_licensing_bulk_license_check_returns_false_when_addons_have_no_license_key() {
-		$this->addon->init();
-		do_action( 'init' );
-
-		$this->assertFalse( $this->model->licensing_bulk_license_check() );
-	}
-
-	public function test_licensing_bulk_license_check_bad_response() {
-		$this->addon->init();
-		$this->addon1->init();
-
-		do_action( 'init' );
-
-		wp_clear_scheduled_hook( 'gfpdf_bulk_license_check' );
-		$this->assertFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
-
-		$data = \GPDFAPI::get_data_class();
-		foreach ( $data->addon as $addon ) {
-			$addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
-		}
-
-		/* Do a malformed request */
-		$api_response = function () {
-			return [
-				'response' => [ 'code' => 200 ],
-				'body'     => '<!DOCTYPE />',
-			];
-		};
-
-		add_filter( 'pre_http_request', $api_response );
-
-		$this->assertFalse( $this->model->licensing_bulk_license_check() );
-		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_bulk_license_check' ) );
-
-		remove_filter( 'pre_http_request', $api_response );
 	}
 
 }

--- a/tests/phpunit/integration/Model/Test_Uninstaller.php
+++ b/tests/phpunit/integration/Model/Test_Uninstaller.php
@@ -191,6 +191,20 @@ class Test_Uninstaller extends TestCase {
 		wp_set_current_user( 0 );
 	}
 
+	public function test_remove_plugin_network_options() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Network options only exist on Multisite' );
+		}
+
+		update_site_option( 'gpdf_sl_net_abc123', [ 'timeout' => time(), 'value' => '{}' ] );
+		$this->assertNotFalse( get_site_option( 'gpdf_sl_net_abc123' ) );
+
+		$this->model->remove_plugin_network_options();
+
+		/* No cache flush here on purpose — the uninstall must invalidate what it deletes */
+		$this->assertFalse( get_site_option( 'gpdf_sl_net_abc123' ) );
+	}
+
 	/**
 	 * Check we are successfully removing our GF PDF Settings
 	 *


### PR DESCRIPTION
## What this does

`development` and `hot-patch-6.16.0` **each independently overhauled** the licensing / updater / log-redaction subsystem from the same pre-overhaul ancestor. This PR combines them **line-by-line**, taking hot-patch's refined 6.16.0 implementation while preserving development's independent work (React font-manager, i18n `translators:` comments, multicurrency re-enable, `GPDF_API_URL` override, the multisite uninstall `switch_to_blog` fix, etc.).

The refinements were isolated via `git diff 4fa01684 hot-patch-6.16.0` and applied over development's parallel implementation with a 3-way merge (base = the branches' merge-base), resolving every conflict toward hot-patch's licensing refinements and preserving development's unrelated changes.

## Production code
- **EDD_SL_Plugin_Updater** — network-shared licensed-package cache across a Multisite, PHP 8 object guards, `normalize_api_collection()` object-injection hardening, back-off on a malformed 200, option-based multisite active checks.
- **Redact_Processor** — full 6.16.0 rewrite (message pattern scrub + recursive keyed context redaction with a depth cap, CRLF/log-injection neutralisation, `gfpdf_logging_redact_keys` filter); `Logger` switched to the new single-arg processor.
- **Helper_Abstract_Addon** — `GPDF_LICENSE_KEY` hardcoded-license activation with backoff, `is_license_admin_managed()`, `flush_update_cache()` on license change, secondary-network-site guards.
- **Model_Settings / Controller_Settings / Controller_Upgrade_Routines / Model_Uninstall / Helper_Misc** — bulk license+update checks, primary-site-only scheduling, network update-cache sharing, upgrade routine clearing the legacy `edd_sl_*` cache and deprecated per-add-on cron, object-cache-safe option deletes, `is_secondary_network_site()`.

## JS
`setupLicenseDeactivation` refinement (ignore repeat clicks while in-flight, unified `postLicenseDeactivation`, `response.extra` sibling teardown, generic error fallback via `GFPDF.licenseDeactivationError`) + a new Jest test.

## Tests (relocated into `tests/phpunit/integration/`)
Moved/adapted from hot-patch's `tests/phpunit/unit-tests/` into development's refactored `integration/` structure (factory + `Integration\TestCase`): `Test_Redact_Processor`, `Test_EDD_SL_Plugin_Updater`, `Test_Controller_Settings`, `Test_Controller_Upgrade_Routines`, `Test_Model_Settings` (development's non-licensing tests preserved), plus the `is_secondary_network_site` tests (`Test_Helper_Misc_Config`) and `remove_plugin_network_options` test (`Test_Uninstaller`).

## Changelog + version
6.16.0 CHANGELOG section added; `pdf.php` bumped to 6.16.0.

## Verification
- ✅ `php -l` on every changed file
- ✅ PHPCS (WordPress standard) clean · PHP 7.3 compatibility clean
- ✅ `yarn lint:js` clean · **full Jest suite 466/466 pass**
- ✅ Plugin loads in the running dev site (HTTP 200)
- ✅ **Multi-agent expert review** of the combine (8 subsystem reviewers → adversarial verify): PHP src merge confirmed correct with zero findings; it caught a JS half-merge (my env-debug `git checkout` had reverted the JS refinement before commit while its test landed) — **now fixed and re-verified**.
- ⚠️ **PHPUnit suite not run live** — the local integration wp-env became unstable during this work (an unchanged clean checkout also fails to run); needs an env reset (`yarn wp-env:integration destroy && start`) then `yarn test:php`. CI will run the full suite.

## Follow-up (needs a working test env)
A few of development's **existing** licensing test files (`Test_Addon`, `Test_Settings`, the license-deactivation AJAX tests) still assert development's pre-merge behaviour and hot-patch added further addon-level tests; reconcile those (drop obsolete assertions, port hot-patch's new addon tests) against a green test env before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)