### PR TITLE
feat: support GF 3.0 International (formatted) phone numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 6.16.0
 * 🎉 Feature: Gravity Forms 3.0 compatibility
+* 🎉 Feature: Support the Gravity Forms 3.0 International (formatted) phone number format, displayed with the country and dial code in front of the number
 * 🎉 Feature: Auto-activate/deactivate license key for installed Gravity PDF extensions when saving an Access Pass   
 * 🎉 Feature: Support for setting a license key in code using the PHP constant `GPDF_LICENSE_KEY`
 * 🔒 Security: Redact sensitive information from log files
@@ -29,6 +30,7 @@
 * 💻 Developer: Replace `edd_sl_*` hooks with `gpdf_sl_*` hooks
 * 💻 Developer: Add `gfpdf_addon_post_license_activation` and `gfpdf_addon_post_license_deactivation` actions
 * 💻 Developer: Deprecate `Helper_Abstract_Addon::plugin_updater()`, `Helper_Abstract_Addon::schedule_license_check()`, and `Model_Settings::deactivate_license_key()`
+* 💻 Developer: Add `$form_data['phone']` which includes the country, dial code, national, formatted, and E.164 values of an International (formatted) phone number
 
 ### 6.15.0
 * 🎉 Feature: Switch the update/license API server to api.gravitypdf.com

--- a/src/Helper/Fields/Field_Phone.php
+++ b/src/Helper/Fields/Field_Phone.php
@@ -60,15 +60,46 @@ class Field_Phone extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = $this->value();
+		return parent::html( $this->get_display_value() );
+	}
 
-		return parent::html( $value );
+	/**
+	 * Standardised method for returning the field's correct $form_data['field'] keys
+	 *
+	 * The International (formatted) number is also exposed, in its individual parts, under $form_data['phone']
+	 *
+	 * @return array
+	 *
+	 * @since 6.16.0
+	 */
+	public function form_data() {
+		$value    = $this->get_display_value();
+		$label    = $this->get_label();
+		$field_id = (int) $this->field->id;
+
+		$data = [
+			'field' => [
+				$field_id . '.' . $label => $value,
+				$field_id                => $value,
+				$label                   => $value,
+			],
+		];
+
+		$phone = $this->value();
+		if ( is_array( $phone ) ) {
+			$data['phone'][ $field_id ] = $phone;
+		}
+
+		return $data;
 	}
 
 	/**
 	 * Get the standard GF value of this field
 	 *
-	 * @return array
+	 * Returns the individual parts of the number when the entry holds an International (formatted) number, otherwise
+	 * the number is returned as a string
+	 *
+	 * @return string|array
 	 *
 	 * @since 4.0
 	 */
@@ -77,8 +108,100 @@ class Field_Phone extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( esc_html( $this->get_value() ) );
+		$value = $this->get_value();
+		$phone = $this->get_international_phone( $value );
+
+		$this->cache( $phone ?? esc_html( $value ) );
 
 		return $this->cache();
+	}
+
+	/**
+	 * Get the number as it should be displayed in the PDF
+	 *
+	 * International (formatted) numbers are prefixed with the ISO country code, and the dial code when the field's
+	 * "Show country dial code" setting is enabled
+	 *
+	 * @return string
+	 *
+	 * @since 6.16.0
+	 */
+	protected function get_display_value() {
+		$phone = $this->value();
+
+		if ( ! is_array( $phone ) ) {
+			return $phone;
+		}
+
+		$parts = [ $phone['country'] ];
+
+		if ( $this->field->showCountryCode ?? true ) {
+			$parts[] = $phone['dial_code'];
+		}
+
+		$parts[] = $phone['formatted'];
+
+		return implode( ' ', array_filter( $parts ) );
+	}
+
+	/**
+	 * Get the individual parts of a Gravity Forms 3.0 International (formatted) number, which is stored as JSON
+	 *
+	 * The stored value is tested, and not the field's format setting, so entries saved before the format was changed
+	 * still display correctly
+	 *
+	 * @param string $value The raw field value from the entry
+	 *
+	 * @return array|null Null when the value isn't an International (formatted) number
+	 *
+	 * @since 6.16.0
+	 */
+	protected function get_international_phone( $value ) {
+		$phone = is_string( $value ) ? json_decode( $value, true ) : null;
+
+		if ( ! is_array( $phone ) || ( ! isset( $phone['formatted'] ) && ! isset( $phone['e164'] ) ) ) {
+			return null;
+		}
+
+		/* Entries added through the API bypass the Gravity Forms sanitiser, so discard anything that isn't a scalar */
+		$parts = [];
+		foreach ( [ 'country', 'national', 'formatted', 'e164' ] as $key ) {
+			$part          = $phone[ $key ] ?? null;
+			$parts[ $key ] = is_scalar( $part ) ? esc_html( (string) $part ) : '';
+		}
+
+		return [
+			'country'   => strtoupper( $parts['country'] ),
+			'dial_code' => $this->get_dial_code( $parts['e164'], $parts['national'] ),
+			'national'  => $parts['national'],
+			'formatted' => $parts['formatted'],
+			'e164'      => $parts['e164'],
+		];
+	}
+
+	/**
+	 * Derive the country dial code by removing the national number from the tail of the E.164 number
+	 *
+	 * Gravity Forms only ships its dial code list to the browser, so it cannot be looked up in PHP
+	 *
+	 * @param string $e164     The E.164 number, eg. +12015551232
+	 * @param string $national The national number, eg. 2015551232
+	 *
+	 * @return string The dial code, eg. +1, or an empty string when it cannot be derived
+	 *
+	 * @since 6.16.0
+	 */
+	protected function get_dial_code( $e164, $national ) {
+		$e164_digits     = preg_replace( '/\D/', '', $e164 );
+		$national_digits = preg_replace( '/\D/', '', $national );
+		$length          = strlen( $national_digits );
+
+		if ( $length === 0 || substr( $e164_digits, - $length ) !== $national_digits ) {
+			return '';
+		}
+
+		$dial_code = substr( $e164_digits, 0, - $length );
+
+		return $dial_code !== '' ? '+' . $dial_code : '';
 	}
 }

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -1374,6 +1374,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				'misc',
 				'field',
 				'list',
+				'phone',
 				'signature_details_id',
 				'products',
 				'products_totals',

--- a/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Phone.php
+++ b/tests/phpunit/unit-tests/Helper/Fields/Test_Field_Phone.php
@@ -1,0 +1,180 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Fields;
+
+use GF_Field_Phone;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   helper
+ * @group   fields
+ */
+class Test_Field_Phone extends WP_UnitTestCase {
+
+	/**
+	 * A US number in the Gravity Forms 3.0 International (formatted) format
+	 */
+	private const US_NUMBER = '{"country":"US","national":"2015551232","formatted":"(201) 555-1232","e164":"+12015551232"}';
+
+	/**
+	 * Build a Field_Phone holding the passed entry value
+	 *
+	 * @param string $value          The raw value stored in the entry
+	 * @param array  $field_settings Additional GF_Field_Phone settings, eg. phoneFormat or showCountryCode
+	 *
+	 * @return Field_Phone
+	 */
+	protected function get_field( $value, $field_settings = [] ) {
+		$field = new GF_Field_Phone(
+			array_merge(
+				[
+					'id'          => 1,
+					'label'       => 'Phone',
+					'phoneFormat' => 'formatted',
+				],
+				$field_settings
+			)
+		);
+
+		$entry = [
+			'id'      => 0,
+			'form_id' => 0,
+			'1'       => $value,
+		];
+
+		return new Field_Phone( $field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+	}
+
+	/**
+	 * The International (formatted) number is stored as JSON, and is broken into its individual parts
+	 */
+	public function test_value_international() {
+		$field = $this->get_field( self::US_NUMBER );
+
+		$this->assertSame(
+			[
+				'country'   => 'US',
+				'dial_code' => '+1',
+				'national'  => '2015551232',
+				'formatted' => '(201) 555-1232',
+				'e164'      => '+12015551232',
+			],
+			$field->value()
+		);
+	}
+
+	/**
+	 * The dial code isn't available to PHP, so it's derived from the E.164 and national numbers
+	 */
+	public function test_value_international_multi_digit_dial_code() {
+		$field = $this->get_field( '{"country":"gb","national":"2079460958","formatted":"020 7946 0958","e164":"+442079460958"}' );
+
+		$value = $field->value();
+
+		$this->assertSame( 'GB', $value['country'] );
+		$this->assertSame( '+44', $value['dial_code'] );
+	}
+
+	/**
+	 * Entries saved while the field was International (formatted) still display correctly after the field is swapped
+	 * to a format that doesn't store JSON
+	 */
+	public function test_value_international_after_format_swap() {
+		$field = $this->get_field( self::US_NUMBER, [ 'phoneFormat' => 'international' ] );
+
+		$this->assertStringContainsString( '<div class="value">US +1 (201) 555-1232</div>', $field->html() );
+		$this->assertSame( '+12015551232', $field->form_data()['phone'][1]['e164'] );
+	}
+
+	/**
+	 * A number that isn't stored as JSON is passed through as a string
+	 */
+	public function test_value_standard() {
+		$field = $this->get_field( '(555) 678-1210', [ 'phoneFormat' => 'standard' ] );
+
+		$this->assertSame( '(555) 678-1210', $field->value() );
+	}
+
+	/**
+	 * The ISO country code and dial code are shown in front of the number
+	 */
+	public function test_html_shows_country_and_dial_code() {
+		$field = $this->get_field( self::US_NUMBER, [ 'showCountryCode' => true ] );
+
+		$this->assertStringContainsString( '<div class="value">US +1 (201) 555-1232</div>', $field->html() );
+	}
+
+	/**
+	 * Only the ISO country code is shown when the field's dial code setting is disabled
+	 */
+	public function test_html_hides_dial_code() {
+		$field = $this->get_field( self::US_NUMBER, [ 'showCountryCode' => false ] );
+
+		$this->assertStringContainsString( '<div class="value">US (201) 555-1232</div>', $field->html() );
+	}
+
+	/**
+	 * The dial code is shown by default, matching how Gravity Forms renders the field
+	 */
+	public function test_html_shows_dial_code_by_default() {
+		$field = $this->get_field( self::US_NUMBER );
+
+		$this->assertStringContainsString( '<div class="value">US +1 (201) 555-1232</div>', $field->html() );
+	}
+
+	/**
+	 * $form_data['field'] holds the displayed number, and $form_data['phone'] the individual parts
+	 */
+	public function test_form_data_international() {
+		$field = $this->get_field( self::US_NUMBER );
+
+		$form_data = $field->form_data();
+
+		$this->assertSame( 'US +1 (201) 555-1232', $form_data['field'][1] );
+		$this->assertSame( 'US +1 (201) 555-1232', $form_data['field']['1.Phone'] );
+		$this->assertSame( 'US +1 (201) 555-1232', $form_data['field']['Phone'] );
+
+		$this->assertSame( '+12015551232', $form_data['phone'][1]['e164'] );
+		$this->assertSame( 'US', $form_data['phone'][1]['country'] );
+	}
+
+	/**
+	 * The phone key is only added for International (formatted) numbers
+	 */
+	public function test_form_data_standard() {
+		$field = $this->get_field( '(555) 678-1210', [ 'phoneFormat' => 'standard' ] );
+
+		$form_data = $field->form_data();
+
+		$this->assertSame( '(555) 678-1210', $form_data['field'][1] );
+		$this->assertSame( '(555) 678-1210', $form_data['field']['1.Phone'] );
+		$this->assertSame( '(555) 678-1210', $form_data['field']['Phone'] );
+
+		$this->assertArrayNotHasKey( 'phone', $form_data );
+	}
+
+	/**
+	 * JSON that isn't an International (formatted) number is left alone
+	 */
+	public function test_value_unrecognised_json() {
+		$field = $this->get_field( '{"foo":"bar"}' );
+
+		$this->assertSame( '{&quot;foo&quot;:&quot;bar&quot;}', $field->value() );
+	}
+
+	/**
+	 * An empty field is still reported as empty
+	 */
+	public function test_is_empty() {
+		$this->assertTrue( $this->get_field( '' )->is_empty() );
+		$this->assertFalse( $this->get_field( self::US_NUMBER )->is_empty() );
+	}
+}


### PR DESCRIPTION
## What

Gravity Forms 3.0 adds an **International (formatted)** phone format that stores the value as a JSON object in the entry. Gravity PDF had no support for it, so it printed the raw JSON:

```
{"country":"US","national":"2015551232","formatted":"(201) 555-1232","e164":"+12015551232"}
```

`Field_Phone` now renders the ISO country code, the dial code, and the formatted number. The dial code is dropped when the field's **Show country dial code** setting is off, mirroring what the user saw on screen:

| Setting | PDF output |
|---|---|
| Enabled (GF default) | `US +1 (201) 555-1232` |
| Disabled | `US (201) 555-1232` |

Detection keys off **the stored entry value being JSON**, not the field's `phoneFormat` setting. Entries saved while the field was International (formatted) therefore still display correctly after the field is switched to a format that doesn't store JSON — otherwise those existing entries would revert to showing raw JSON.

### Why the dial code is derived rather than looked up

It's obtained by removing the national number from the tail of the E.164 number. Two PHP-side alternatives were checked and rejected:

- `GF_Field_Phone::get_dial_code()` reads `assets/js/src/theme/fields/international-phone/countries.json`. That file **is not in the distributed Gravity Forms zip** (only `assets/js/dist/` ships), so it returns an empty string in a real install. It's also `private static`.
- `E164Validator::validate( $e164, true )` does return the dial code, but it's GF 2.9+ while Gravity PDF supports 2.5+, it's an undocumented internal in the global namespace, and the first call loads a 254 KB rules array.

## `$form_data`

`$form_data['field']` keeps the displayed number as a **string**, so templates that echo it keep working if a site switches an existing phone field to the new format. The parts are exposed under a new `phone` key:

```php
$form_data['field'][14]         // 'US +1 (201) 555-1232'
$form_data['field']['14.Phone'] // 'US +1 (201) 555-1232'
$form_data['field']['Phone']    // 'US +1 (201) 555-1232'

$form_data['phone'][14] => [
    'country'   => 'US',
    'dial_code' => '+1',
    'national'  => '2015551232',
    'formatted' => '(201) 555-1232',
    'e164'      => '+12015551232',
]
```

This follows the `Field_List` / `Field_Signature` precedent of putting structured data under its own top-level key, and `'phone'` was added to `gfpdf_form_data_key_order`.

⚠️ As with the existing `list` and `signature_details_id` keys, **`$form_data['phone']` is not populated for phone fields inside a Repeater**, because `Field_Repeater` merges only the `field` and `html_id` keys from its sub-fields. Worth a docs note.

## Testing

11 new tests in `tests/phpunit/unit-tests/Helper/Fields/Test_Field_Phone.php`, covering the US and multi-digit (GB `+44`) dial-code derivation, both `showCountryCode` states plus the unset default, the format-switch case, non-JSON pass-through, unrecognised JSON, and `$form_data` for both shapes. The fixture is built in memory, so it touches no database.

Full suite run against the branch: **1162 tests, 3602 assertions**. PHPCS and `phpcompat` (PHP 7.3 floor) both clean.

## Notes for review

- Changelog entries are filed under the existing **6.16.0** release, as a 🎉 Feature alongside the existing "Gravity Forms 3.0 compatibility" line.
- Behaviour is unchanged for US Standard and International (unformatted) phone fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)