### PR TITLE
Follow-up: port GF 3.0 International (formatted) phone support from hot-patch-6.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 6.16.0
 * 🎉 Feature: Gravity Forms 3.0 compatibility
+* 🎉 Feature: Support the Gravity Forms 3.0 International (formatted) phone number format, displayed with the country and dial code in front of the number
 * 🎉 Feature: Auto-activate/deactivate license key for installed Gravity PDF extensions when saving an Access Pass
 * 🎉 Feature: Support for setting a license key in code using the PHP constant `GPDF_LICENSE_KEY`
 * 🔒 Security: Redact sensitive information from log files
@@ -29,6 +30,7 @@
 * 💻 Developer: Replace `edd_sl_*` hooks with `gpdf_sl_*` hooks
 * 💻 Developer: Add `gfpdf_addon_post_license_activation` and `gfpdf_addon_post_license_deactivation` actions
 * 💻 Developer: Deprecate `Helper_Abstract_Addon::plugin_updater()`, `Helper_Abstract_Addon::schedule_license_check()`, and `Model_Settings::deactivate_license_key()`
+* 💻 Developer: Add `$form_data['phone']` which includes the country, dial code, national, formatted, and E.164 values of an International (formatted) phone number
 
 ### 6.15.0
 * 🎉 Feature: Switch the update/license API server to api.gravitypdf.com

--- a/src/Helper/Fields/Field_Phone.php
+++ b/src/Helper/Fields/Field_Phone.php
@@ -60,15 +60,46 @@ class Field_Phone extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = $this->value();
+		return parent::html( $this->get_display_value() );
+	}
 
-		return parent::html( $value );
+	/**
+	 * Standardised method for returning the field's correct $form_data['field'] keys
+	 *
+	 * The International (formatted) number is also exposed, in its individual parts, under $form_data['phone']
+	 *
+	 * @return array
+	 *
+	 * @since 6.16.0
+	 */
+	public function form_data() {
+		$value    = $this->get_display_value();
+		$label    = $this->get_label();
+		$field_id = (int) $this->field->id;
+
+		$data = [
+			'field' => [
+				$field_id . '.' . $label => $value,
+				$field_id                => $value,
+				$label                   => $value,
+			],
+		];
+
+		$phone = $this->value();
+		if ( is_array( $phone ) ) {
+			$data['phone'][ $field_id ] = $phone;
+		}
+
+		return $data;
 	}
 
 	/**
 	 * Get the standard GF value of this field
 	 *
-	 * @return array
+	 * Returns the individual parts of the number when the entry holds an International (formatted) number, otherwise
+	 * the number is returned as a string
+	 *
+	 * @return string|array
 	 *
 	 * @since 4.0
 	 */
@@ -77,8 +108,100 @@ class Field_Phone extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( esc_html( $this->get_value() ) );
+		$value = $this->get_value();
+		$phone = $this->get_international_phone( $value );
+
+		$this->cache( $phone ?? esc_html( $value ) );
 
 		return $this->cache();
+	}
+
+	/**
+	 * Get the number as it should be displayed in the PDF
+	 *
+	 * International (formatted) numbers are prefixed with the ISO country code, and the dial code when the field's
+	 * "Show country dial code" setting is enabled
+	 *
+	 * @return string
+	 *
+	 * @since 6.16.0
+	 */
+	protected function get_display_value() {
+		$phone = $this->value();
+
+		if ( ! is_array( $phone ) ) {
+			return $phone;
+		}
+
+		$parts = [ $phone['country'] ];
+
+		if ( $this->field->showCountryCode ?? true ) {
+			$parts[] = $phone['dial_code'];
+		}
+
+		$parts[] = $phone['formatted'];
+
+		return implode( ' ', array_filter( $parts ) );
+	}
+
+	/**
+	 * Get the individual parts of a Gravity Forms 3.0 International (formatted) number, which is stored as JSON
+	 *
+	 * The stored value is tested, and not the field's format setting, so entries saved before the format was changed
+	 * still display correctly
+	 *
+	 * @param string $value The raw field value from the entry
+	 *
+	 * @return array|null Null when the value isn't an International (formatted) number
+	 *
+	 * @since 6.16.0
+	 */
+	protected function get_international_phone( $value ) {
+		$phone = is_string( $value ) ? json_decode( $value, true ) : null;
+
+		if ( ! is_array( $phone ) || ( ! isset( $phone['formatted'] ) && ! isset( $phone['e164'] ) ) ) {
+			return null;
+		}
+
+		/* Entries added through the API bypass the Gravity Forms sanitiser, so discard anything that isn't a scalar */
+		$parts = [];
+		foreach ( [ 'country', 'national', 'formatted', 'e164' ] as $key ) {
+			$part          = $phone[ $key ] ?? null;
+			$parts[ $key ] = is_scalar( $part ) ? esc_html( (string) $part ) : '';
+		}
+
+		return [
+			'country'   => strtoupper( $parts['country'] ),
+			'dial_code' => $this->get_dial_code( $parts['e164'], $parts['national'] ),
+			'national'  => $parts['national'],
+			'formatted' => $parts['formatted'],
+			'e164'      => $parts['e164'],
+		];
+	}
+
+	/**
+	 * Derive the country dial code by removing the national number from the tail of the E.164 number
+	 *
+	 * Gravity Forms only ships its dial code list to the browser, so it cannot be looked up in PHP
+	 *
+	 * @param string $e164     The E.164 number, eg. +12015551232
+	 * @param string $national The national number, eg. 2015551232
+	 *
+	 * @return string The dial code, eg. +1, or an empty string when it cannot be derived
+	 *
+	 * @since 6.16.0
+	 */
+	protected function get_dial_code( $e164, $national ) {
+		$e164_digits     = preg_replace( '/\D/', '', $e164 );
+		$national_digits = preg_replace( '/\D/', '', $national );
+		$length          = strlen( $national_digits );
+
+		if ( $length === 0 || substr( $e164_digits, - $length ) !== $national_digits ) {
+			return '';
+		}
+
+		$dial_code = substr( $e164_digits, 0, - $length );
+
+		return $dial_code !== '' ? '+' . $dial_code : '';
 	}
 }

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -1403,6 +1403,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				'misc',
 				'field',
 				'list',
+				'phone',
 				'signature_details_id',
 				'products',
 				'products_totals',

--- a/tests/phpunit/integration/Helper/Fields/Test_Field_Phone.php
+++ b/tests/phpunit/integration/Helper/Fields/Test_Field_Phone.php
@@ -13,11 +13,44 @@ use GFPDF\Tests\Integration\TestCase;
  */
 class Test_Field_Phone extends TestCase {
 
+	/**
+	 * A US number in the Gravity Forms 3.0 International (formatted) format
+	 */
+	private const US_NUMBER = '{"country":"US","national":"2015551232","formatted":"(201) 555-1232","e164":"+12015551232"}';
+
 	public static function set_up_before_class(): void {
 		parent::set_up_before_class();
 		static::load_fixtures( [ 'all-form-fields' ], [ 'all-form-fields' ] );
 	}
 
+	/**
+	 * Build a Field_Phone holding the passed entry value
+	 *
+	 * @param string $value          The raw value stored in the entry
+	 * @param array  $field_settings Additional GF_Field_Phone settings, eg. phoneFormat or showCountryCode
+	 *
+	 * @return Field_Phone
+	 */
+	protected function get_field( $value, $field_settings = [] ) {
+		$field = new GF_Field_Phone(
+			array_merge(
+				[
+					'id'          => 1,
+					'label'       => 'Phone',
+					'phoneFormat' => 'formatted',
+				],
+				$field_settings
+			)
+		);
+
+		$entry = [
+			'id'      => 0,
+			'form_id' => 0,
+			'1'       => $value,
+		];
+
+		return new Field_Phone( $field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
+	}
 
 	public function test_html_contains_phone_number() {
 		$entry    = $this->entry( 'all-form-fields' );
@@ -46,5 +79,130 @@ class Test_Field_Phone extends TestCase {
 		$pdf_field = new Field_Phone( $gf_field, $entry, \GPDFAPI::get_form_class(), \GPDFAPI::get_misc_class() );
 
 		$this->assertSame( '', $pdf_field->value() );
+	}
+
+	/**
+	 * The International (formatted) number is stored as JSON, and is broken into its individual parts
+	 */
+	public function test_value_international() {
+		$field = $this->get_field( self::US_NUMBER );
+
+		$this->assertSame(
+			[
+				'country'   => 'US',
+				'dial_code' => '+1',
+				'national'  => '2015551232',
+				'formatted' => '(201) 555-1232',
+				'e164'      => '+12015551232',
+			],
+			$field->value()
+		);
+	}
+
+	/**
+	 * The dial code isn't available to PHP, so it's derived from the E.164 and national numbers
+	 */
+	public function test_value_international_multi_digit_dial_code() {
+		$field = $this->get_field( '{"country":"gb","national":"2079460958","formatted":"020 7946 0958","e164":"+442079460958"}' );
+
+		$value = $field->value();
+
+		$this->assertSame( 'GB', $value['country'] );
+		$this->assertSame( '+44', $value['dial_code'] );
+	}
+
+	/**
+	 * Entries saved while the field was International (formatted) still display correctly after the field is swapped
+	 * to a format that doesn't store JSON
+	 */
+	public function test_value_international_after_format_swap() {
+		$field = $this->get_field( self::US_NUMBER, [ 'phoneFormat' => 'international' ] );
+
+		$this->assertStringContainsString( '<div class="value">US +1 (201) 555-1232</div>', $field->html() );
+		$this->assertSame( '+12015551232', $field->form_data()['phone'][1]['e164'] );
+	}
+
+	/**
+	 * A number that isn't stored as JSON is passed through as a string
+	 */
+	public function test_value_standard() {
+		$field = $this->get_field( '(555) 678-1210', [ 'phoneFormat' => 'standard' ] );
+
+		$this->assertSame( '(555) 678-1210', $field->value() );
+	}
+
+	/**
+	 * The ISO country code and dial code are shown in front of the number
+	 */
+	public function test_html_shows_country_and_dial_code() {
+		$field = $this->get_field( self::US_NUMBER, [ 'showCountryCode' => true ] );
+
+		$this->assertStringContainsString( '<div class="value">US +1 (201) 555-1232</div>', $field->html() );
+	}
+
+	/**
+	 * Only the ISO country code is shown when the field's dial code setting is disabled
+	 */
+	public function test_html_hides_dial_code() {
+		$field = $this->get_field( self::US_NUMBER, [ 'showCountryCode' => false ] );
+
+		$this->assertStringContainsString( '<div class="value">US (201) 555-1232</div>', $field->html() );
+	}
+
+	/**
+	 * The dial code is shown by default, matching how Gravity Forms renders the field
+	 */
+	public function test_html_shows_dial_code_by_default() {
+		$field = $this->get_field( self::US_NUMBER );
+
+		$this->assertStringContainsString( '<div class="value">US +1 (201) 555-1232</div>', $field->html() );
+	}
+
+	/**
+	 * $form_data['field'] holds the displayed number, and $form_data['phone'] the individual parts
+	 */
+	public function test_form_data_international() {
+		$field = $this->get_field( self::US_NUMBER );
+
+		$form_data = $field->form_data();
+
+		$this->assertSame( 'US +1 (201) 555-1232', $form_data['field'][1] );
+		$this->assertSame( 'US +1 (201) 555-1232', $form_data['field']['1.Phone'] );
+		$this->assertSame( 'US +1 (201) 555-1232', $form_data['field']['Phone'] );
+
+		$this->assertSame( '+12015551232', $form_data['phone'][1]['e164'] );
+		$this->assertSame( 'US', $form_data['phone'][1]['country'] );
+	}
+
+	/**
+	 * The phone key is only added for International (formatted) numbers
+	 */
+	public function test_form_data_standard() {
+		$field = $this->get_field( '(555) 678-1210', [ 'phoneFormat' => 'standard' ] );
+
+		$form_data = $field->form_data();
+
+		$this->assertSame( '(555) 678-1210', $form_data['field'][1] );
+		$this->assertSame( '(555) 678-1210', $form_data['field']['1.Phone'] );
+		$this->assertSame( '(555) 678-1210', $form_data['field']['Phone'] );
+
+		$this->assertArrayNotHasKey( 'phone', $form_data );
+	}
+
+	/**
+	 * JSON that isn't an International (formatted) number is left alone
+	 */
+	public function test_value_unrecognised_json() {
+		$field = $this->get_field( '{"foo":"bar"}' );
+
+		$this->assertSame( '{&quot;foo&quot;:&quot;bar&quot;}', $field->value() );
+	}
+
+	/**
+	 * An empty field is still reported as empty
+	 */
+	public function test_is_empty() {
+		$this->assertTrue( $this->get_field( '' )->is_empty() );
+		$this->assertFalse( $this->get_field( self::US_NUMBER )->is_empty() );
 	}
 }


### PR DESCRIPTION
Follow-up to #1687. `hot-patch-6.16.0` gained one commit after that merge was authored — 2e666a65 (#1689, _feat: support GF 3.0 International (formatted) phone numbers_). Everything else on `hot-patch-6.16.0` is already in `development`.

## What's ported

Gravity Forms 3.0 adds an International (formatted) phone format that stores the entry value as JSON, so PDFs printed the raw object:

```
{"country":"US","national":"2015551232","formatted":"(201) 555-1232","e164":"+12015551232"}
```

`Field_Phone` now renders `US +1 (201) 555-1232`, dropping the dial code when the field's "Show country dial code" setting is off. Detection is based on the stored value being JSON rather than on `phoneFormat`, so entries saved under the old format still display correctly after the field is switched. The individual parts are exposed under a new `$form_data['phone']` key.

## Differences from the upstream commit

- `src/` is byte-identical to `hot-patch-6.16.0`.
- The upstream commit added a new `tests/phpunit/unit-tests/Helper/Fields/Test_Field_Phone.php` extending `WP_UnitTestCase`. `development` already has `tests/phpunit/integration/Helper/Fields/Test_Field_Phone.php`, so the 11 new cases are folded into that file and it extends the integration `TestCase`. Its three existing fixture-based tests are unchanged.
- The CHANGELOG entries merged cleanly (the only conflict was trailing whitespace on an unrelated line).

## Verification

- `Test_Field_Phone`: 14 tests, 24 assertions — OK.
- Full PHPUnit suite on `wp-env:integration`: **1558 tests, 4894 assertions, 41 skipped — OK**, no failures.
- PHPCS (`tools/phpcs/config.xml`) and PHP 7.3 compatibility clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)