### PR TITLE
chore(deps): weekly bump of WordPress core + Gravity Forms

### DIFF
--- a/api.php
+++ b/api.php
@@ -363,7 +363,7 @@ final class GPDFAPI {
 	 *
 	 * @return string|WP_Error   Return the filename of the PDF, or a WP_Error on failure
 	 *
-	 * @since 7.0
+	 * @since 6.16.0
 	 */
 	public static function get_pdf_filename( $entry_id, $pdf_id, bool $include_extension = false ) {
 		$form_class = self::get_form_class();

--- a/composer.lock
+++ b/composer.lock
@@ -392,16 +392,16 @@
         },
         {
             "name": "masterminds/html5",
-            "version": "2.10.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fd5018f6815fff903946d0564977b44ce8010e29",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29",
                 "shasum": ""
             },
             "require": {
@@ -409,7 +409,7 @@
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
             },
             "type": "library",
             "extra": {
@@ -453,9 +453,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Masterminds/html5-php/issues",
-                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.1"
             },
-            "time": "2025-07-25T09:04:22+00:00"
+            "time": "2026-06-23T18:43:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2557,25 +2557,25 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.34",
+            "version": "9.6.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+                "reference": "abab27ed286d3e1246fbbfe6b56bfd732d945ec9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/abab27ed286d3e1246fbbfe6b56bfd732d945ec9",
+                "reference": "abab27ed286d3e1246fbbfe6b56bfd732d945ec9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -2591,7 +2591,7 @@
                 "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.8",
+                "sebastian/exporter": "^4.0.9",
                 "sebastian/global-state": "^5.0.8",
                 "sebastian/object-enumerator": "^4.0.4",
                 "sebastian/resource-operations": "^3.0.4",
@@ -2640,31 +2640,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.36"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:45:00+00:00"
+            "time": "2026-08-11T06:25:15+00:00"
         },
         {
             "name": "psr/container",
@@ -2720,18 +2704,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "23afac1b181cebf9a272d9cb3423c6c39f3710d9"
+                "reference": "5f250a5db79180182cc85c0ccd80f61e5c1df8f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/23afac1b181cebf9a272d9cb3423c6c39f3710d9",
-                "reference": "23afac1b181cebf9a272d9cb3423c6c39f3710d9",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5f250a5db79180182cc85c0ccd80f61e5c1df8f1",
+                "reference": "5f250a5db79180182cc85c0ccd80f61e5c1df8f1",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adaptcms/adaptcms": "<=1.3",
-                "admidio/admidio": "<=5.0.9",
+                "adawolfa/isdoc": "<1.4.3|>=1.5,<1.5.1|>=1.6,<1.6.1",
+                "admidio/admidio": "<=5.0.11",
                 "adodb/adodb-php": "<=5.22.9",
                 "aheinze/cockpit": "<2.2",
                 "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.07.2",
@@ -2742,6 +2727,7 @@
                 "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-laravel": "==2021.10",
                 "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
+                "aimeos/pagible": "<0.10.4",
                 "airesvsg/acf-to-rest-api": "<=3.1",
                 "akaunting/akaunting": "<2.1.13",
                 "akeneo/pim-community-dev": "<5.0.119|>=6,<6.0.53",
@@ -2764,8 +2750,10 @@
                 "aoe/restler": "<1.7.1",
                 "apache-solr-for-typo3/solr": "<2.8.3",
                 "apereo/phpcas": "<1.6",
-                "api-platform/core": "<3.4.17|>=4,<4.0.22|>=4.1,<4.1.5",
+                "api-platform/core": "<4.1.30|>=4.2,<4.2.26|>=4.3,<4.3.12",
                 "api-platform/graphql": "<3.4.17|>=4,<4.0.22|>=4.1,<4.1.5",
+                "api-platform/hal": ">=4,<4.1.29|>=4.2,<4.2.25|>=4.3,<4.3.8",
+                "api-platform/json-api": ">=4,<4.1.29|>=4.2,<4.2.25|>=4.3,<4.3.8",
                 "appwrite/server-ce": "<=1.2.1",
                 "arc/web": "<3",
                 "area17/twill": "<1.2.5|>=2,<2.5.3",
@@ -2778,7 +2766,7 @@
                 "austintoddj/canvas": "<=3.4.2",
                 "auth0/auth0-php": ">=3.3,<=8.18",
                 "auth0/login": "<=7.20",
-                "auth0/symfony": "<=5.7",
+                "auth0/symfony": "<=5.8",
                 "auth0/wordpress": "<=5.5",
                 "automad/automad": "<=2.0.0.0-beta27",
                 "automattic/jetpack": "<9.8",
@@ -2820,14 +2808,14 @@
                 "brotkrueml/codehighlight": "<2.7",
                 "brotkrueml/schema": "<1.13.1|>=2,<2.5.1",
                 "brotkrueml/typo3-matomo-integration": "<1.3.2",
-                "buddypress/buddypress": "<7.2.1",
+                "buddypress/buddypress": "<14.5",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
                 "bvbmedia/multishop": "<2.0.39",
                 "bytefury/crater": "<6.0.2",
                 "cachethq/cachet": "<2.5.1",
                 "cadmium-org/cadmium-cms": "<=0.4.9",
                 "cakephp/authentication": "<3.3.6|>=4,<4.1.1",
-                "cakephp/cakephp": "<3.10.3|>=4,<4.0.10|>=4.1,<4.1.4|>=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10|>=5.2.10,<5.2.12|==5.3",
+                "cakephp/cakephp": "<4.5.11|>=4.6,<4.6.4|>=5,<5.1.7|>=5.2,<5.2.13|>=5.3,<5.3.6",
                 "cakephp/database": ">=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10",
                 "cardgate/magento2": "<2.0.33",
                 "cardgate/woocommerce": "<=3.1.15",
@@ -2848,24 +2836,24 @@
                 "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
                 "co-stack/fal_sftp": "<0.2.6",
                 "cockpit-hq/cockpit": "<=2.14",
-                "code16/sharp": "<9.22",
+                "code16/sharp": "<9.22.3",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.10",
-                "codeigniter4/framework": "<4.7.2",
+                "codeigniter4/framework": "<4.7.4",
                 "codeigniter4/shield": "<1.0.0.0-beta8",
                 "codiad/codiad": "<=2.8.4",
                 "codingms/additional-tca": ">=1.7,<1.15.17|>=1.16,<1.16.9",
                 "codingms/modules": "<4.3.11|>=5,<5.7.4|>=6,<6.4.2|>=7,<7.5.5",
                 "commerceteam/commerce": ">=0.9.6,<0.9.9",
                 "components/jquery": ">=1.0.3,<3.5",
-                "composer/composer": "<2.2.28|>=2.3,<2.9.8",
-                "concrete5/concrete5": "<9.4.8",
+                "composer/composer": "<2.2.29|>=2.3,<2.10.2",
+                "concrete5/concrete5": "<9.5.2",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
                 "contao/comments-bundle": ">=2,<4.13.40|>=5.0.0.0-RC1-dev,<5.3.4",
-                "contao/contao": ">=3,<3.5.37|>=4,<4.4.56|>=4.5,<4.13.56|>=5,<5.3.38|>=5.4.0.0-RC1-dev,<5.6.1",
+                "contao/contao": ">=3,<3.5.37|>=4,<4.4.56|>=4.5,<5.3.48|>=5.4,<5.7.9",
                 "contao/core": "<3.5.39",
-                "contao/core-bundle": "<4.13.57|>=5,<5.3.42|>=5.4,<5.6.5",
+                "contao/core-bundle": "<5.3.48|>=5.4,<5.7.9",
                 "contao/listing-bundle": ">=3,<=3.5.30|>=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
                 "coreshop/core-shop": "<4.1.9|==5",
@@ -2876,7 +2864,7 @@
                 "cpsit/typo3-mailqueue": "<0.4.5|>=0.5,<0.5.2",
                 "craftcms/aws-s3": ">=2.0.2,<=2.2.4",
                 "craftcms/azure-blob": ">=2.0.0.0-beta1,<=2.1",
-                "craftcms/cms": "<4.18|>=5,<5.10",
+                "craftcms/cms": "<4.18.3|>=5,<5.10.8",
                 "craftcms/commerce": ">=4,<=4.11.1|>=5,<=5.6.4",
                 "craftcms/composer": ">=4.0.0.0-RC1-dev,<=4.10|>=5.0.0.0-RC1-dev,<=5.5.1",
                 "craftcms/craft": ">=3.5,<=4.16.17|>=5.0.0.0-RC1-dev,<=5.8.21",
@@ -2918,7 +2906,7 @@
                 "doctrine/mongodb-odm-bundle": "<3.0.1",
                 "doctrine/orm": ">=1,<1.2.4|>=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
                 "dolibarr/dolibarr": "<=23.0.2",
-                "dompdf/dompdf": "<2.0.4",
+                "dompdf/dompdf": "<3.1.6",
                 "doublethreedigital/guest-entries": "<3.1.2",
                 "dreamfactory/df-core": "<1.0.4",
                 "drupal-pattern-lab/unified-twig-extensions": "<=0.1",
@@ -2959,11 +2947,11 @@
                 "drupal/umami_analytics": "<1.0.1",
                 "duncanmcclean/guest-entries": "<3.1.2",
                 "dweeves/magmi": "<=0.7.24",
-                "easycorp/easyadmin-bundle": ">=4,<4.29.10|>=5,<5.0.13",
+                "easycorp/easyadmin-bundle": ">=4,<4.29.16|>=5,<5.5.1",
                 "ec-cube/ec-cube": "<2.4.4|>=2.11,<=2.17.1|>=3,<=3.0.18.0-patch4|>=4,<=4.3.1",
                 "ecodev/newsletter": "<=4",
                 "ectouch/ectouch": "<=2.7.2",
-                "egroupware/egroupware": "<23.1.20260113|>=26.0.20251208,<26.0.20260113",
+                "egroupware/egroupware": "<23.1.20260601|>=26.0.20251208,<26.5.20260507",
                 "elefant/cms": "<2.0.7",
                 "elgg/elgg": "<3.3.24|>=4,<4.0.5",
                 "elijaa/phpmemcacheadmin": "<=1.3",
@@ -2998,16 +2986,16 @@
                 "ezsystems/repository-forms": ">=2.3,<2.3.2.1-dev|>=2.5,<2.5.15",
                 "ezyang/htmlpurifier": "<=4.2",
                 "facade/ignition": "<1.16.15|>=2,<2.4.2|>=2.5,<2.5.2",
-                "facturascripts/facturascripts": "<=2025.92|>=2026,<=2026.1",
+                "facturascripts/facturascripts": "<=2026.2",
                 "fastly/magento2": "<1.2.26",
                 "feehi/cms": "<=2.1.1",
                 "feehi/feehicms": "<=2.1.1",
                 "fenom/fenom": "<=2.12.1",
                 "filament/actions": ">=3.2,<3.2.123|>=4,<=4.11.3|>=5,<=5.6.3",
-                "filament/filament": ">=4,<4.3.1",
+                "filament/filament": ">=3,<=3.3.51|>=4,<4.11.5|>=5,<5.6.5",
                 "filament/forms": ">=3,<=3.3.52",
-                "filament/infolists": ">=3,<3.2.115",
-                "filament/tables": ">=3,<=3.3.50|>=4,<4.8.5|>=5,<5.3.5",
+                "filament/infolists": ">=3,<3.2.115|>=4,<=4.11.4|>=5,<=5.6.4",
+                "filament/tables": ">=3,<=3.3.50|>=4,<=4.11.4|>=5,<=5.6.4",
                 "filegator/filegator": "<7.8",
                 "filp/whoops": "<2.1.13",
                 "fineuploader/php-traditional-server": "<=1.2.2",
@@ -3073,10 +3061,10 @@
                 "gregwar/rst": "<1.0.3",
                 "grumpydictator/firefly-iii": "<=6.6.2",
                 "gugoan/economizzer": "<=0.9.0.0-beta1",
-                "guzzlehttp/guzzle": "<7.12.1",
+                "guzzlehttp/guzzle": "<7.15.2|>=8,<8.0.1",
                 "guzzlehttp/guzzle-services": "<1.5.4",
                 "guzzlehttp/oauth-subscriber": "<0.8.1",
-                "guzzlehttp/psr7": "<2.12.1",
+                "guzzlehttp/psr7": "<2.12.3",
                 "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
                 "handcraftedinthealps/goodby-csv": "<1.4.3",
                 "harvesthq/chosen": "<1.8.7",
@@ -3158,7 +3146,7 @@
                 "kelvinmo/simplexrd": "<3.1.1",
                 "kevinpapst/kimai2": "<1.16.7",
                 "khodakhah/nodcms": "<=3.4.1",
-                "kimai/kimai": "<=2.55",
+                "kimai/kimai": "<2.59",
                 "kitodo/presentation": "<3.2.3|>=3.3,<3.3.4",
                 "klaviyo/magento2-extension": ">=1,<3",
                 "knplabs/knp-snappy": "<=1.7",
@@ -3185,16 +3173,16 @@
                 "lavalite/cms": "<=10.1",
                 "lavitto/typo3-form-to-database": "<2.2.5|>=3,<3.2.2|>=4,<4.2.3|>=5,<5.0.2",
                 "lcobucci/jwt": ">=3.4,<3.4.6|>=4,<4.0.4|>=4.1,<4.1.5",
-                "league/commonmark": "<=2.8.1",
+                "league/commonmark": "<2.9",
                 "league/flysystem": "<1.1.4|>=2,<2.1.1",
                 "league/oauth2-server": ">=8.3.2,<8.4.2|>=8.5,<8.5.3",
                 "leantime/leantime": "<3.3",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
                 "libreform/libreform": ">=2,<=2.0.8",
-                "librenms/librenms": "<26.3",
+                "librenms/librenms": "<=26.4",
                 "liftkit/database": "<2.13.2",
                 "lightsaml/lightsaml": "<1.3.5",
-                "limesurvey/limesurvey": "<6.15.4",
+                "limesurvey/limesurvey": "<=7.0.0.0-beta1",
                 "livehelperchat/livehelperchat": "<=3.91",
                 "livewire-filemanager/filemanager": "<=1.0.4",
                 "livewire/livewire": "<2.12.7|>=3.0.0.0-beta1,<3.6.4",
@@ -3217,13 +3205,13 @@
                 "maikuolan/phpmussel": ">=1,<1.6",
                 "mainwp/mainwp": "<=4.4.3.3",
                 "manogi/nova-tiptap": "<=3.2.6",
-                "mantisbt/mantisbt": "<2.28.2",
+                "mantisbt/mantisbt": "<=2.28.3",
                 "marcwillmann/turn": "<0.3.3",
                 "markhuot/craftql": "<=1.3.7",
                 "marshmallow/nova-tiptap": "<5.7",
                 "matomo/matomo": "<1.11",
                 "matyhtf/framework": "<3.0.6",
-                "mautic/core": "<5.2.10|>=6,<6.0.8|>=7.0.0.0-alpha,<7.0.1",
+                "mautic/core": "<5.2.11|>=6,<6.0.9|>=7,<7.1.2",
                 "mautic/core-lib": ">=1.0.0.0-beta,<4.4.13|>=5.0.0.0-alpha,<5.1.1",
                 "mautic/grapes-js-builder-bundle": ">=4,<4.4.18|>=5,<5.2.9|>=6,<6.0.7",
                 "maximebf/debugbar": "<1.19",
@@ -3233,6 +3221,7 @@
                 "mediawiki/cargo": "<3.8.3",
                 "mediawiki/core": "<1.39.5|==1.40",
                 "mediawiki/data-transfer": ">=1.39,<1.39.11|>=1.41,<1.41.3|>=1.42,<1.42.2",
+                "mediawiki/maps": "<12.1.3",
                 "mediawiki/matomo": "<2.4.3",
                 "mediawiki/semantic-media-wiki": "<4.0.2",
                 "mehrwert/phpmyadmin": "<3.2",
@@ -3294,11 +3283,11 @@
                 "nilsteampassnet/teampass": "<3.1.3.1-dev",
                 "nitsan/ns-backup": "<13.0.1",
                 "nonfiction/nterchange": "<4.1.1",
-                "notrinos/notrinos-erp": "<=0.7",
+                "notrinos/notrinos-erp": "<=1",
                 "noumo/easyii": "<=0.9",
                 "novaksolutions/infusionsoft-php-sdk": "<1",
                 "novosga/novosga": "<=2.2.12",
-                "nukeviet/nukeviet": "<4.5.02",
+                "nukeviet/nukeviet": "<4.6.00",
                 "nyholm/psr7": "<1.6.1",
                 "nystudio107/craft-seomatic": "<3.4.12",
                 "nzedb/nzedb": "<0.8",
@@ -3326,8 +3315,10 @@
                 "oro/customer-portal": ">=4.1,<=4.1.13|>=4.2,<=4.2.10|>=5,<=5.0.11|>=5.1,<=5.1.3",
                 "oro/platform": ">=1.7,<1.7.4|>=3.1,<3.1.29|>=4.1,<4.1.17|>=4.2,<=4.2.10|>=5,<=5.0.12|>=5.1,<=5.1.3",
                 "oveleon/contao-cookiebar": "<1.16.3|>=2,<2.1.3",
-                "oxid-esales/oxideshop-ce": "<=7.0.5",
+                "oxid-esales/oxideshop-ce": "<4.5|>=6,<6.14.4",
+                "oxid-esales/oxideshop-metapackage-ce": ">=6,<6.5.5",
                 "oxid-esales/paymorrow-module": ">=1,<1.0.2|>=2,<2.0.1",
+                "oxid-esales/smarty-component": "<1.0.1",
                 "packbackbooks/lti-1-3-php-library": "<5",
                 "padraic/humbug_get_contents": "<1.1.2",
                 "pagarme/pagarme-php": "<3",
@@ -3336,7 +3327,7 @@
                 "paragonie/random_compat": "<2",
                 "paragonie/sodium_compat": "<1.24|>=2,<2.5",
                 "passbolt/passbolt_api": "<4.6.2",
-                "paymenter/paymenter": "<1.5",
+                "paymenter/paymenter": "<=1.5.4",
                 "paypal/adaptivepayments-sdk-php": "<=3.9.2",
                 "paypal/invoice-sdk-php": "<=3.9",
                 "paypal/merchant-sdk-php": "<3.12",
@@ -3349,22 +3340,25 @@
                 "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
                 "personnummer/personnummer": "<3.0.2",
                 "ph7software/ph7builder": "<=17.9.1",
-                "phanan/koel": "<=9.3.4",
-                "pheditor/pheditor": ">=2.0.1,<=2.0.3",
+                "phanan/koel": "<=9.7",
+                "pheditor/pheditor": "<2.0.8",
                 "phenx/php-svg-lib": "<0.5.2",
                 "php-censor/php-censor": "<2.0.13|>=2.1,<2.1.5",
                 "php-mod/curl": "<2.3.2",
+                "php-standard-library/h2": ">=6.1,<6.1.2|>=6.2,<6.2.1",
+                "php-standard-library/php-standard-library": ">=6.1,<6.1.2|>=6.2,<6.2.1",
                 "phpbb/phpbb": "<3.3.16|==4.0.0.0-alpha1",
+                "phpcsstandards/phpcsutils": ">=1.0.0.0-alpha1,<1.2.3",
                 "phpems/phpems": ">=6,<=6.1.3",
                 "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
                 "phpmailer/phpmailer": "<6.5",
                 "phpmussel/phpmussel": ">=1,<1.6",
                 "phpmyadmin/phpmyadmin": "<5.2.2",
-                "phpmyfaq/phpmyfaq": "<4.1.3",
+                "phpmyfaq/phpmyfaq": "<4.1.4",
                 "phpoffice/common": "<0.2.9",
                 "phpoffice/math": "<=0.2",
                 "phpoffice/phpexcel": "<=1.8.2",
-                "phpoffice/phpspreadsheet": "<=1.30.4|>=2,<=2.1.15|>=2.2,<=2.4.4|>=3,<=3.10.4|>=4,<=5.6",
+                "phpoffice/phpspreadsheet": "<=1.30.5|>=2,<=2.1.17|>=2.2,<=2.4.6|>=3,<=3.10.6|>=4,<=5.8",
                 "phppgadmin/phppgadmin": "<=7.13",
                 "phpseclib/phpseclib": "<=2.0.54|>=3,<=3.0.53",
                 "phpservermon/phpservermon": "<3.6",
@@ -3375,22 +3369,24 @@
                 "phpxmlrpc/phpxmlrpc": "<4.9.2",
                 "phraseanet/phraseanet": "==4.0.3",
                 "pi/pi": "<=2.5",
-                "pimcore/admin-ui-classic-bundle": "<=2.3.5",
+                "pimcore/admin-ui-classic-bundle": "<1.7.18|>=2.0.0.0-RC1-dev,<=2.3.5",
                 "pimcore/customer-management-framework-bundle": "<4.2.1",
                 "pimcore/data-hub": "<1.2.4",
                 "pimcore/data-importer": "<1.8.9|>=1.9,<1.9.3",
                 "pimcore/demo": "<10.3",
                 "pimcore/ecommerce-framework-bundle": "<1.0.10",
                 "pimcore/perspective-editor": "<1.5.1",
-                "pimcore/pimcore": "<=12.3.8",
+                "pimcore/pimcore": "<12.3.9|>=2026.1,<=2026.1.4",
                 "pimcore/web2print-tools-bundle": "<=5.2.1|>=6.0.0.0-RC1-dev,<=6.1",
                 "piwik/piwik": "<1.11",
                 "pixelfed/pixelfed": "<0.12.5",
+                "plank/laravel-mediable": "<7",
                 "plotly/plotly.js": "<2.25.2",
                 "pocketmine/bedrock-protocol": "<8.0.2",
                 "pocketmine/pocketmine-mp": "<5.42.1",
                 "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
-                "poweradmin/poweradmin": "<4.2.4|>=4.3,<4.3.3",
+                "pontedilana/php-weasyprint": "<=2.5.1",
+                "poweradmin/poweradmin": "<4.2.5|>=4.3,<4.3.4",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
                 "prestashop/blockreassurance": "<=5.1.3",
@@ -3402,14 +3398,14 @@
                 "prestashop/ps_checkout": "<5.3",
                 "prestashop/ps_contactinfo": "<=3.3.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
-                "prestashop/ps_facetedsearch": "<3.4.1",
+                "prestashop/ps_facetedsearch": "<4.0.4",
                 "prestashop/ps_linklist": "<3.1",
                 "privatebin/privatebin": "<1.4|>=1.5,<1.7.4|>=1.7.7,<2.0.3",
                 "processwire/processwire": "<=3.0.255",
                 "propel/propel": ">=2.0.0.0-alpha1,<2.0.0.0-alpha8",
                 "propel/propel1": ">=1,<1.7.2",
                 "psy/psysh": "<=0.11.22|>=0.12,<=0.12.18",
-                "pterodactyl/panel": "<1.12.3",
+                "pterodactyl/panel": "<=1.12.4",
                 "ptheofan/yii2-statemachine": ">=2.0.0.0-RC1-dev,<=2",
                 "ptrofimov/beanstalk_console": "<1.7.14",
                 "pubnub/pubnub": "<6.1",
@@ -3429,7 +3425,7 @@
                 "rap2hpoutre/laravel-log-viewer": "<0.13",
                 "react/http": ">=0.7,<1.9",
                 "really-simple-plugins/complianz-gdpr": "<6.4.2",
-                "redaxo/source": "<5.21",
+                "redaxo/source": "<5.21.1",
                 "remdex/livehelperchat": "<4.29",
                 "renolit/reint-downloadmanager": "<4.0.2|>=5,<5.0.1",
                 "reportico-web/reportico": "<=8.1",
@@ -3468,10 +3464,10 @@
                 "silverstripe-australia/advancedreports": ">=1,<=2",
                 "silverstripe/admin": "<1.13.19|>=2,<2.1.8",
                 "silverstripe/assets": "<2.4.5|>=3,<3.1.3",
-                "silverstripe/cms": "<4.11.3",
+                "silverstripe/cms": "<6.2.1",
                 "silverstripe/comments": ">=1.3,<3.1.1",
                 "silverstripe/forum": "<0.6.2|>=0.7,<0.7.4",
-                "silverstripe/framework": "<5.3.23",
+                "silverstripe/framework": "<6.2.2",
                 "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.8.2|>=4,<4.3.7|>=5,<5.1.3",
                 "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
                 "silverstripe/recipe-cms": ">=4.5,<4.5.3",
@@ -3481,13 +3477,14 @@
                 "silverstripe/silverstripe-omnipay": "<2.5.2|>=3,<3.0.2|>=3.1,<3.1.4|>=3.2,<3.2.1",
                 "silverstripe/subsites": ">=2,<2.6.1",
                 "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
-                "silverstripe/userforms": "<3|>=5,<5.4.2",
+                "silverstripe/userforms": "<6.4.9|>=7,<7.0.7|>=7.1,<7.1.1",
+                "silverstripe/versioned": "<3.2.1",
                 "silverstripe/versioned-admin": ">=1,<1.11.1",
                 "simogeo/filemanager": "<=2.5",
                 "simple-updates/phpwhois": "<=1",
-                "simplesamlphp/saml2": "<=4.16.15|>=5.0.0.0-alpha1,<=5.0.0.0-alpha19",
-                "simplesamlphp/saml2-legacy": "<=4.16.15",
-                "simplesamlphp/simplesamlphp": "<1.18.6",
+                "simplesamlphp/saml2": "<4.19.3|>=4.20,<=4.20.2|>=5,<5.0.6|>=6,<6.2.1",
+                "simplesamlphp/saml2-legacy": "<4.19.3|>=4.20,<=4.20.2",
+                "simplesamlphp/simplesamlphp": "<=2.4.6|>=2.5,<=2.5.1",
                 "simplesamlphp/simplesamlphp-module-casserver": "<=7.0.2",
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "simplesamlphp/simplesamlphp-module-openid": "<1",
@@ -3500,16 +3497,18 @@
                 "sjbr/sr-freecap": "<2.4.6|>=2.5,<2.5.3",
                 "sjbr/static-info-tables": "<2.3.1",
                 "slim/psr7": "<1.4.1|>=1.5,<1.5.1|>=1.6,<1.6.1",
-                "slim/slim": "<2.6",
+                "slim/slim": "<2.6|>=4.4,<=4.15.1",
                 "slub/slub-events": "<3.0.3",
-                "smarty/smarty": "<4.5.3|>=5,<5.1.1",
-                "snipe/snipe-it": "<8.4.1",
+                "smarty/smarty": "<4.5.7|>=5,<5.8.4",
+                "snipe/snipe-it": "<=8.6.1",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
+                "solidinvoice/solidinvoice": "<=2.3.15",
                 "solspace/craft-freeform": "<4.1.29|>=5,<=5.14.6",
                 "soosyze/soosyze": "<=2",
                 "spatie/browsershot": "<5.0.5",
                 "spatie/image-optimizer": "<1.7.3",
+                "spatie/laravel-medialibrary": "<11.23",
                 "spatie/schema-org": ">=3.23.1,<3.23.2|>=4,<4.0.2",
                 "spencer14420/sp-php-email-handler": "<1",
                 "spipu/html2pdf": "<5.2.8",
@@ -3517,13 +3516,13 @@
                 "spomky-labs/otphp": "<11.4.3",
                 "spoon/library": "<1.4.1",
                 "spoonity/tcpdf": "<6.2.22",
-                "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
+                "squizlabs/php_codesniffer": "<3.13.6|>=4,<4.0.2",
                 "ssddanbrown/bookstack": "<24.05.1",
                 "starcitizentools/citizen-skin": ">=1.9.4,<3.9",
                 "starcitizentools/short-description": ">=4,<4.0.1",
                 "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2|>=3,<3.1.1",
                 "starcitizenwiki/embedvideo": "<=4",
-                "statamic/cms": "<5.73.22|>=6,<6.18.1",
+                "statamic/cms": "<5.74.3|>=6,<6.24.2",
                 "stormpath/sdk": "<9.9.99",
                 "studio-42/elfinder": "<=2.1.67",
                 "studiomitte/friendlycaptcha": "<0.1.4",
@@ -3540,9 +3539,11 @@
                 "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
                 "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
                 "sylius/grid-bundle": "<1.10.1",
+                "sylius/mollie-plugin": "<2.2.8|>=3,<3.2.4|>=3.3,<3.3.1",
                 "sylius/paypal-plugin": "<1.6.2|>=1.7,<1.7.2|>=2,<2.0.2",
                 "sylius/resource-bundle": ">=1,<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
-                "sylius/sylius": "<1.9.12|>=1.10,<1.10.16|>=1.11,<1.11.17|>=1.12,<=1.12.22|>=1.13,<=1.13.14|>=1.14,<=1.14.17|>=2,<=2.0.15|>=2.1,<=2.1.11|>=2.2,<=2.2.2",
+                "sylius/sylius": "<1.9.12|>=1.10,<1.10.16|>=1.11,<1.11.17|>=1.12,<=1.12.22|>=1.13,<=1.13.14|>=1.14,<=1.14.17|>=2,<2.0.18|>=2.1,<2.1.15|>=2.2,<2.2.6",
+                "symbiote/silverstripe-advancedworkflow": "<6.4.5|>=7,<7.1.3|>=7.2,<7.2.1",
                 "symbiote/silverstripe-multivaluefield": ">=3,<3.1",
                 "symbiote/silverstripe-queuedjobs": ">=3,<3.0.2|>=3.1,<3.1.4|>=4,<4.0.7|>=4.1,<4.1.2|>=4.2,<4.2.4|>=4.3,<4.3.3|>=4.4,<4.4.3|>=4.5,<4.5.1|>=4.6,<4.6.4",
                 "symbiote/silverstripe-seed": "<6.0.3",
@@ -3607,10 +3608,10 @@
                 "tecnickcom/tcpdf": "<6.8",
                 "terminal42/contao-tablelookupwizard": "<3.3.5",
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-                "thelia/thelia": ">=2.1,<2.1.3",
+                "thelia/thelia": ">=2.0.0.0-beta1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<6.0.8",
-                "thorsten/phpmyfaq": "<4.1.3",
+                "thorsten/phpmyfaq": "<4.2.0.0-alpha",
                 "tikiwiki/tiki-manager": "<=17.1",
                 "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
                 "tinymce/tinymce": "<7.9.3|>=8,<8.5.1",
@@ -3632,19 +3633,19 @@
                 "twig/intl-extra": "<3.26",
                 "twig/markdown-extra": "<3.26",
                 "twig/twig": "<3.27",
-                "typicms/core": "<16.1.7",
+                "typicms/core": "<12.0.5|>=13,<13.0.9|>=14,<14.0.27|>=15,<15.0.29|>=16,<16.1.7",
                 "typo3/cms": "<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
                 "typo3/cms-backend": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-belog": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-beuser": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
-                "typo3/cms-core": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
+                "typo3/cms-core": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.34|>=14,<14.3.6",
                 "typo3/cms-dashboard": ">=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
                 "typo3/cms-extbase": "<6.2.24|>=7,<7.6.8|==8.1.1",
                 "typo3/cms-extensionmanager": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-felogin": ">=4.2,<4.2.3",
                 "typo3/cms-filelist": ">=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
-                "typo3/cms-fluid": "<4.3.4|>=4.4,<4.4.1",
-                "typo3/cms-form": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
+                "typo3/cms-fluid": "<4.3.4|>=4.4,<4.4.1|>=8,<8.7.23|>=9,<9.5.4",
+                "typo3/cms-form": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.5",
                 "typo3/cms-frontend": "<4.3.9|>=4.4,<4.4.5",
                 "typo3/cms-indexed-search": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-install": "<4.1.14|>=4.2,<4.2.16|>=4.3,<4.3.9|>=4.4,<4.4.5|>=12.2,<12.4.8|==13.4.2",
@@ -3674,7 +3675,7 @@
                 "uvdesk/core-framework": "<=1.1.1",
                 "vanilla/safecurl": "<0.9.2",
                 "verbb/comments": "<1.5.5",
-                "verbb/formie": "<2.2.21|>=3,<3.1.26",
+                "verbb/formie": "<3.1.28",
                 "verbb/image-resizer": "<2.0.9",
                 "verbb/knock-knock": "<1.2.8",
                 "verot/class.upload.php": "<=2.1.6",
@@ -3689,11 +3690,12 @@
                 "wanglelecc/laracms": "<=1.0.3",
                 "wapplersystems/a21glossary": "<=0.4.10",
                 "web-auth/webauthn-framework": ">=3.3,<3.3.4|>=4.5,<4.9|>=5.2,<5.2.4|>=5.3,<5.3.1",
-                "web-auth/webauthn-lib": ">=4.5,<4.9|>=5.2,<5.2.4",
-                "web-auth/webauthn-symfony-bundle": ">=5.2,<5.2.4",
+                "web-auth/webauthn-lib": ">=4.5,<5.3.5",
+                "web-auth/webauthn-symfony-bundle": "<5.3.4",
                 "web-feet/coastercms": "==5.5",
-                "web-token/jwt-experimental": "<=4.1.6",
-                "web-token/jwt-framework": "<=4.2.99",
+                "web-token/jwt-bundle": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
+                "web-token/jwt-experimental": "<4.1.7",
+                "web-token/jwt-framework": "<4.1.7",
                 "web-token/jwt-library": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
                 "web-tp3/wec_map": "<3.0.3",
                 "webbuilders-group/silverstripe-kapost-bridge": "<0.4",
@@ -3706,15 +3708,17 @@
                 "wikibase/wikibase": "<=1.39.3",
                 "wikimedia/parsoid": "<0.12.2",
                 "willdurand/js-translation-bundle": "<2.1.1",
-                "winter/wn-backend-module": "<1.2.12",
-                "winter/wn-cms-module": "<=1.2.9",
+                "winter/wn-backend-module": "<1.2.13",
+                "winter/wn-cms-module": "<=1.2.12",
                 "winter/wn-dusk-plugin": "<2.1",
                 "winter/wn-system-module": "<1.2.4",
                 "wintercms/winter": "<=1.2.3",
                 "wireui/wireui": "<1.19.3|>=2,<2.1.3",
+                "wnx/laravel-backup-restore": "<=1.9.3",
                 "woocommerce/woocommerce": "<6.6|>=8.8,<8.8.5|>=8.9,<8.9.3",
                 "wp-cli/wp-cli": ">=0.12,<2.5",
-                "wp-graphql/wp-graphql": "<=1.14.5",
+                "wp-coding-standards/wpcs": ">=0.14.1,<3.4.1",
+                "wp-graphql/wp-graphql": "<=2.6",
                 "wp-premium/gravityforms": "<2.4.21",
                 "wpanel/wpanel4-cms": "<=4.3.1",
                 "wpcloud/wp-stateless": "<3.2",
@@ -3725,7 +3729,7 @@
                 "xpressengine/xpressengine": "<3.0.15",
                 "yab/quarx": "<2.4.5",
                 "yansongda/pay": "<=3.7.19",
-                "yeswiki/yeswiki": "<4.6.4",
+                "yeswiki/yeswiki": "<4.6.6",
                 "yetiforce/yetiforce-crm": "<6.5",
                 "yidashi/yii2cmf": "<=2",
                 "yii2mod/yii2-cms": "<1.9.2",
@@ -3819,7 +3823,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-22T21:03:44+00:00"
+            "time": "2026-08-13T19:02:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4262,16 +4266,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.8",
+            "version": "4.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+                "reference": "4352c1a3df741a7ba9e61af6fed51d1fee41cbf7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/4352c1a3df741a7ba9e61af6fed51d1fee41cbf7",
+                "reference": "4352c1a3df741a7ba9e61af6fed51d1fee41cbf7",
                 "shasum": ""
             },
             "require": {
@@ -4327,7 +4331,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.9"
             },
             "funding": [
                 {
@@ -4347,7 +4351,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:03:27+00:00"
+            "time": "2026-08-11T04:55:59+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -4596,16 +4600,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.6",
+            "version": "4.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+                "reference": "c85be6922b7fd365942b986b9a50397d65407611"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/c85be6922b7fd365942b986b9a50397d65407611",
+                "reference": "c85be6922b7fd365942b986b9a50397d65407611",
                 "shasum": ""
             },
             "require": {
@@ -4647,7 +4651,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.7"
             },
             "funding": [
                 {
@@ -4667,7 +4671,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:57:39+00:00"
+            "time": "2026-08-11T05:25:24+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -4834,16 +4838,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -4909,7 +4913,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/console",
@@ -5726,7 +5730,7 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.9.4",
+            "version": "6.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",

--- a/composer.lock
+++ b/composer.lock
@@ -1540,10 +1540,10 @@
         },
         {
             "name": "gravity/gravityforms",
-            "version": "2.10.5",
+            "version": "3.0.2",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.gravity.io/downloads/?plugin=gravityforms&version=2.10.5"
+                "url": "https://composer.gravity.io/downloads/?plugin=gravityforms&version=3.0.2"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/src/Helper/Fields/Field_Chainedselect.php
+++ b/src/Helper/Fields/Field_Chainedselect.php
@@ -4,7 +4,6 @@ namespace GFPDF\Helper\Fields;
 
 use Exception;
 use GF_Chained_Field_Select;
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Misc;
@@ -63,7 +62,7 @@ class Field_Chainedselect extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );

--- a/src/Helper/Fields/Field_Default.php
+++ b/src/Helper/Fields/Field_Default.php
@@ -2,7 +2,6 @@
 
 namespace GFPDF\Helper\Fields;
 
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 
 /**
@@ -36,7 +35,7 @@ class Field_Default extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );

--- a/src/Helper/Fields/Field_Likert.php
+++ b/src/Helper/Fields/Field_Likert.php
@@ -2,7 +2,6 @@
 
 namespace GFPDF\Helper\Fields;
 
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 
 /**
@@ -84,7 +83,7 @@ class Field_Likert extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );

--- a/src/Helper/Fields/Field_Rank.php
+++ b/src/Helper/Fields/Field_Rank.php
@@ -2,7 +2,6 @@
 
 namespace GFPDF\Helper\Fields;
 
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 
 /**
@@ -53,7 +52,7 @@ class Field_Rank extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );

--- a/src/Helper/Fields/Field_Rating.php
+++ b/src/Helper/Fields/Field_Rating.php
@@ -2,7 +2,6 @@
 
 namespace GFPDF\Helper\Fields;
 
-use GFCommon;
 use GFPDF\Helper\Helper_Abstract_Fields;
 
 /**
@@ -53,7 +52,7 @@ class Field_Rating extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$property = version_compare( \GFForms::$version, '2.9.29', '>=' ) ? $this->entry : $this->entry['currency'];
 
-		$html = GFCommon::get_lead_field_display( $this->field, $this->get_value(), $property );
+		$html = $this->field->get_value_entry_detail( $this->get_value(), $property );
 		$html = apply_filters( 'gform_entry_field_value', $html, $this->field, $this->entry, $this->form );
 
 		return parent::html( $html );

--- a/tests/phpunit/integration/Helper/Test_Addon.php
+++ b/tests/phpunit/integration/Helper/Test_Addon.php
@@ -321,6 +321,38 @@ class Test_Addon extends TestCase {
 	}
 
 	/**
+	 * @since 6.16.0
+	 */
+	public function test_schedule_license_check_skipped_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* A valid key so the check would otherwise build params and POST — proving the gate is what stops it */
+		$this->addon->update_license_info( [ 'license' => 'abc123', 'status' => 'valid' ] );
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP in tests' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		/* Pose as a secondary site with Gravity PDF network-activated; only a network option is read, so no real blog is needed */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		$this->assertFalse( $this->addon->schedule_license_check() );
+		$this->assertFalse( $http_called );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		remove_filter( 'pre_http_request', $spy );
+		$this->addon->delete_license_info();
+	}
+
+	/**
 	 * @since 4.2
 	 */
 	public function test_auto_register_global_fields_fallback() {
@@ -450,6 +482,90 @@ class Test_Addon extends TestCase {
 		$this->assertNotEmpty( $this->addon->get_license_status() );
 	}
 
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_hardcoded_license_retries_after_failed_activation() {
+		set_current_screen( 'index.php' );
+
+		add_filter( 'gfpdf_addon_hardcoded_license_key', function () {
+			return 'abc123';
+		} );
+
+		$http_calls = 0;
+		$ok         = false;
+		$api        = function () use ( &$http_calls, &$ok ) {
+			$http_calls++;
+
+			return $ok
+				? [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid' ] ) ]
+				: new \WP_Error( 'down', 'API unreachable' );
+		};
+
+		add_filter( 'pre_http_request', $api );
+
+		$this->addon->init();
+		$backoff = 'gfpdf_license_activation_' . $this->addon->get_slug();
+
+		/* First attempt: the API is down, so activation fails and isn't stored as active */
+		do_action( 'init' );
+		$this->assertSame( 1, $http_calls );
+		$this->assertNotContains( $this->addon->get_license_status(), [ 'active', 'valid' ] );
+
+		/* Backoff blocks an immediate retry so a bad/unreachable key doesn't POST on every request */
+		do_action( 'init' );
+		$this->assertSame( 1, $http_calls );
+
+		/* Once the backoff elapses the activation is retried — the old key-equality guard never retried */
+		delete_transient( $backoff );
+		$ok = true;
+		do_action( 'init' );
+		$this->assertSame( 2, $http_calls );
+		$this->assertSame( 'valid', $this->addon->get_license_status() );
+
+		remove_all_filters( 'gfpdf_addon_hardcoded_license_key' );
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_hardcoded_license_activation_skipped_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		set_current_screen( 'index.php' );
+
+		add_filter( 'gfpdf_addon_hardcoded_license_key', static function () {
+			return 'abc123';
+		} );
+
+		$http_called = false;
+		$spy         = function () use ( &$http_called ) {
+			$http_called = true;
+			return new \WP_Error( 'blocked', 'no HTTP in tests' );
+		};
+		add_filter( 'pre_http_request', $spy );
+
+		/* Read the license state from the real blog before switching, so the assertions below reflect the gate */
+		$this->addon->init();
+
+		/* Pose as a secondary site with Gravity PDF network-activated; the primary handles activation */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		do_action( 'init' );
+
+		$this->assertFalse( $http_called );
+		$this->assertEmpty( $this->addon->get_license_status() );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		remove_filter( 'pre_http_request', $spy );
+		remove_all_filters( 'gfpdf_addon_hardcoded_license_key' );
+	}
+
 	public function test_get_short_name_strips_gravity_pdf_prefix() {
 		$prefixed = new Addon(
 			'gpdf-sample',
@@ -552,6 +668,35 @@ class Test_Addon extends TestCase {
 		$this->assertStringContainsString( 'download_id=777', $output );
 	}
 
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_license_registration_notice_hidden_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		/* Preconditions that would otherwise render the notice: a known EDD ID and an unregistered license */
+		$this->addon->set_edd_download_id( '123' );
+
+		/* Primary site shows the "Register your copy" prompt */
+		ob_start();
+		$this->addon->license_registration();
+		$this->assertStringContainsString( 'Register your copy', ob_get_clean() );
+
+		/* Pose as a secondary site with Gravity PDF network-activated; the primary handles licensing */
+		$network_plugins = static function () { return [ PDF_PLUGIN_BASENAME => time() ]; };
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		ob_start();
+		$this->addon->license_registration();
+		$this->assertEmpty( ob_get_clean() );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+	}
+
 	public function test_update_license_status_expired_response_includes_date_link() {
 		$this->addon->set_edd_download_id( '777' );
 
@@ -621,6 +766,34 @@ class Test_Addon extends TestCase {
 		$this->addon->update_license_status_from_response( 'abc', $response );
 
 		$this->assertSame( 'rate_limit', $this->addon->get_license_status() );
+	}
+
+	/**
+	 * A store rejection arrives with the key still populated, so the status has to carry the withdrawal end to end.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_rejected_license_response_withdraws_network_package() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		$this->addon->init();
+		do_action( 'init' );
+
+		$updater = $this->addon->get_plugin_updater();
+		$package = (object) [ 'new_version' => '2.0', 'package' => 'https://store.com/download/123' ];
+
+		update_site_option(
+			$updater->get_network_cache_key(),
+			[ 'timeout' => strtotime( '+3 days' ), 'value' => wp_json_encode( $package ), 'blog_id' => get_current_blog_id() ]
+		);
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'expired', 'expires' => '2020-01-01 00:00:00' ] ) ];
+		$this->addon->update_license_status_from_response( 'unchanged-key', $response );
+
+		$this->assertSame( 'expired', $this->addon->get_license_status() );
+		$this->assertFalse( get_site_option( $updater->get_network_cache_key() ) );
 	}
 
 	public function test_activate_license_fires_action_and_returns_license_info() {
@@ -749,6 +922,7 @@ class Test_Addon extends TestCase {
 			new Helper_Notices()
 		);
 		$other->set_edd_download_id( '888' );
+		$other->update_license_info( [ 'license' => 'other-key', 'status' => 'valid', 'message' => '' ] );
 
 		$this->addon->set_edd_download_id( '777' );
 
@@ -760,6 +934,64 @@ class Test_Addon extends TestCase {
 		$this->addon->maybe_auto_activate_license( $response, $other, false );
 
 		$this->assertFalse( $this->addon->has_license_auto_activated() );
+		$this->assertEmpty( $this->addon->get_license_status() );
+	}
+
+	/**
+	 * A plain (non-Access-Pass) activation response has no products array, so nothing is shared.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_activate_license_ignores_non_access_pass_response() {
+		$this->addon->set_edd_download_id( 10 );
+		$this->addon2->set_edd_download_id( 20 );
+		$this->addon->update_license_info( [ 'license' => 'KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid' ] ) ];
+		$this->addon2->maybe_auto_activate_license( $response, $this->addon, false );
+
+		$this->assertFalse( $this->addon2->has_license_auto_activated() );
+
+		$this->addon->delete_license_info();
+	}
+
+	/**
+	 * The gfpdf_addon_post_license_activation action is public: a third-party do_action() may pass a non-addon second
+	 * arg (or omit the third), which must not fatal.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_activate_license_ignores_non_addon_arg() {
+		$this->addon->set_edd_download_id( 10 );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid', 'products' => [ 10 ] ] ) ];
+		$this->addon->maybe_auto_activate_license( $response, 'not-an-addon' );
+
+		$this->assertFalse( $this->addon->has_license_auto_activated() );
+	}
+
+	/**
+	 * The sibling's cached update info was fetched unlicensed (so it holds no package) and must not survive the
+	 * Access Pass adopting a key.
+	 *
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_activate_license_flushes_update_cache() {
+		$this->addon->set_edd_download_id( 10 );
+		$this->addon2->set_edd_download_id( 20 );
+
+		/* Seed first — init() re-reads the license info from the database, overwriting the in-memory copy */
+		$updater = $this->seed_update_cache( $this->addon2 );
+
+		$this->addon->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'valid', 'products' => [ 10, 20 ] ] ) ];
+		$this->addon2->maybe_auto_activate_license( $response, $this->addon, false );
+
+		$this->assertFalse( $updater->get_cached_version_info() );
+
+		$this->addon->delete_license_info();
+		$this->addon2->delete_license_info();
 	}
 
 	public function test_maybe_auto_deactivate_license_when_addon_in_access_pass() {
@@ -779,6 +1011,9 @@ class Test_Addon extends TestCase {
 
 		$this->addon->set_edd_download_id( '777' );
 
+		/* The initiator has already wiped its own license before firing the action, so the sibling's must go too */
+		$this->addon->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
 		$response = [
 			'response' => [ 'code' => 200 ],
 			'body'     => json_encode( [ 'products' => [ 777, 888 ] ] ),
@@ -787,6 +1022,41 @@ class Test_Addon extends TestCase {
 		$this->addon->maybe_auto_deactivate_license( $response, $other );
 
 		$this->assertTrue( $this->addon->has_license_auto_deactivated() );
+		$this->assertEmpty( $this->addon->get_license_status() );
+
+		$this->addon->delete_license_info();
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_deactivate_license_ignores_non_addon_arg() {
+		$this->addon->set_edd_download_id( 10 );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'deactivated', 'products' => [ 10 ] ] ) ];
+		$this->addon->maybe_auto_deactivate_license( $response, 'not-an-addon' );
+
+		$this->assertFalse( $this->addon->has_license_auto_deactivated() );
+	}
+
+	/**
+	 * @since 6.16.0
+	 */
+	public function test_maybe_auto_deactivate_license_flushes_update_cache() {
+		$this->addon->set_edd_download_id( 10 );
+		$this->addon2->set_edd_download_id( 20 );
+		$this->addon->delete_license_info();
+
+		$updater = $this->seed_update_cache( $this->addon2 );
+
+		$this->addon2->update_license_info( [ 'license' => 'AP-KEY', 'status' => 'active', 'message' => 'ok' ] );
+
+		$response = [ 'response' => [ 'code' => 200 ], 'body' => wp_json_encode( [ 'license' => 'deactivated', 'products' => [ 10, 20 ] ] ) ];
+		$this->addon2->maybe_auto_deactivate_license( $response, $this->addon );
+
+		$this->assertFalse( $updater->get_cached_version_info() );
+
+		$this->addon2->delete_license_info();
 	}
 
 	public function test_flush_update_cache_is_noop_without_plugin_updater() {
@@ -803,6 +1073,26 @@ class Test_Addon extends TestCase {
 		$this->addon->flush_update_cache();
 
 		$this->assertEmpty( get_option( $this->addon->get_plugin_updater()->get_cache_key() ) );
+	}
+
+	/**
+	 * Boot the add-on's updater and prime its version-info cache
+	 *
+	 * @param Helper_Abstract_Addon $addon
+	 *
+	 * @return \GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater
+	 */
+	private function seed_update_cache( $addon ) {
+		$addon->init();
+		do_action( 'init' );
+
+		$updater = $addon->get_plugin_updater();
+		update_option(
+			$updater->get_cache_key(),
+			[ 'timeout' => strtotime( '+3 hours' ), 'value' => wp_json_encode( (object) [ 'new_version' => '2.0', 'package' => '' ] ) ]
+		);
+
+		return $updater;
 	}
 }
 

--- a/tests/phpunit/integration/Helper/Test_Form_Data.php
+++ b/tests/phpunit/integration/Helper/Test_Form_Data.php
@@ -1675,8 +1675,6 @@ class Test_Form_Data extends TestCase {
 		$this->assertNotTrue( $repeater->maybe_show_section_title( true, $repeater->field, [ '', '', null ] ) );
 		$this->assertNotTrue( $repeater->maybe_show_section_title( true, $repeater->field, null ) );
 		$this->assertNotTrue( $repeater->maybe_show_section_title( false, $repeater->field, null ) );
-		$this->assertNotTrue( $repeater->maybe_show_section_title( false, $repeater->field, [ false, null ] ) );
-		$this->assertNotTrue( $repeater->maybe_show_section_title( false, $repeater->field, false ) );
 		$this->assertNotTrue( $repeater->maybe_show_section_title( true, $repeater->field, false ) );
 
 

--- a/tests/phpunit/integration/Model/Test_Model_Settings_Ajax.php
+++ b/tests/phpunit/integration/Model/Test_Model_Settings_Ajax.php
@@ -4,7 +4,12 @@ declare( strict_types=1 );
 
 namespace GFPDF\Model;
 
+use GFPDF\Helper\Helper_Abstract_Addon;
+use GFPDF\Helper\Helper_Logger;
+use GFPDF\Helper\Helper_Notices;
+use GFPDF\Helper\Helper_Singleton;
 use GFPDF\Tests\Integration\AjaxTestCase;
+use WP_Error;
 use WPAjaxDieContinueException;
 use WPAjaxDieStopException;
 
@@ -12,6 +17,13 @@ use WPAjaxDieStopException;
  * @group ajax
  */
 class Test_Model_Settings_Ajax extends AjaxTestCase {
+
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		$this->gfpdf()->data->addon = [];
+
+		parent::tear_down();
+	}
 
 	public function test_ajax_process_license_deactivation() {
 		$this->_setRole( 'administrator' );
@@ -32,4 +44,126 @@ class Test_Model_Settings_Ajax extends AjaxTestCase {
 			$this->assertStringContainsString( 'An unknown error occurred', json_decode( $this->_last_response )->error );
 		}
 	}
+
+	/**
+	 * Access Pass keys are site-activated, so deactivating one add-on deactivates every sibling sharing the pass. The
+	 * `extra` array names those siblings and is consumed by assets/js/admin/settings/common/setupLicenseDeactivation.js.
+	 */
+	public function test_ajax_process_license_deactivation_shares_access_pass_siblings() {
+		$this->_setRole( 'administrator' );
+
+		$master  = $this->register_deactivation_addon( 'master-plugin', 'Master', '/master/file.php', 5 );
+		$sibling = $this->register_deactivation_addon( 'sibling-plugin', 'Sibling', '/sibling/file.php', 10 );
+
+		$license = [
+			'license' => 'AP-KEY',
+			'status'  => 'active',
+			'message' => 'ok',
+		];
+
+		$master->update_license_info( $license );
+		$sibling->update_license_info( $license );
+
+		/* The API confirms deactivation and reports the pass products, so the sibling auto-deactivates too */
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode(
+						[
+							'license'  => 'deactivated',
+							'products' => [ 5, 10 ],
+						]
+					),
+				];
+			}
+		);
+
+		$_POST['nonce']      = wp_create_nonce( 'gfpdf_deactivate_license' );
+		$_POST['addon_name'] = 'master-plugin';
+
+		try {
+			$this->_handleAjax( 'gfpdf_deactivate_license' );
+			$this->fail( 'Expected WPAjaxDieContinueException was not thrown.' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			$response = json_decode( $this->_last_response );
+
+			$this->assertSame( 'Access Pass license key deactivated.', $response->success );
+			$this->assertSame( [ 'sibling-plugin' ], $response->extra );
+		}
+
+		/* The sibling is flagged by the Access Pass listener, while the add-on doing the deactivation is skipped */
+		$this->assertTrue( $sibling->has_license_auto_deactivated() );
+		$this->assertFalse( $master->has_license_auto_deactivated() );
+	}
+
+	public function test_ajax_process_license_deactivation_api_failure() {
+		$this->_setRole( 'administrator' );
+
+		$master = $this->register_deactivation_addon( 'master-plugin', 'Master', '/master/file.php', 5 );
+		$master->update_license_info(
+			[
+				'license' => 'KEY',
+				'status'  => 'active',
+				'message' => 'ok',
+			]
+		);
+
+		/* API unreachable → deactivate_license() returns false → the API-error branch responds */
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return new WP_Error( 'down', 'API unreachable' );
+			}
+		);
+
+		$_POST['nonce']      = wp_create_nonce( 'gfpdf_deactivate_license' );
+		$_POST['addon_name'] = 'master-plugin';
+
+		try {
+			$this->_handleAjax( 'gfpdf_deactivate_license' );
+			$this->fail( 'Expected WPAjaxDieContinueException was not thrown.' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			$this->assertStringContainsString( 'An API error occurred', json_decode( $this->_last_response )->error );
+		}
+	}
+
+	/**
+	 * Build and register an add-on for the license-deactivation AJAX tests.
+	 *
+	 * @param string $slug
+	 * @param string $name
+	 * @param string $file
+	 * @param int    $edd_id
+	 *
+	 * @return AjaxDeactivationAddon
+	 */
+	private function register_deactivation_addon( $slug, $name, $file, $edd_id ) {
+		$gfpdf = $this->gfpdf();
+
+		$addon = new AjaxDeactivationAddon(
+			$slug,
+			$name,
+			'Gravity PDF',
+			'1.0',
+			$file,
+			$gfpdf->data,
+			$gfpdf->options,
+			new Helper_Singleton(),
+			new Helper_Logger( $slug, $name ),
+			new Helper_Notices()
+		);
+
+		$addon->set_edd_download_id( $edd_id );
+		$addon->init();
+
+		return $addon;
+	}
+}
+
+/**
+ * Minimal concrete add-on used by the license-deactivation AJAX tests
+ */
+class AjaxDeactivationAddon extends Helper_Abstract_Addon {
 }

--- a/tests/phpunit/integration/Model/Test_Uninstaller.php
+++ b/tests/phpunit/integration/Model/Test_Uninstaller.php
@@ -179,9 +179,7 @@ class Test_Uninstaller extends TestCase {
 
 		$this->model->remove_plugin_options();
 
-		/* flush the options cache so fresh values can be checked from the database */
-		wp_cache_delete( 'alloptions', 'options' );
-
+		/* No cache flush here on purpose — the uninstall must invalidate what it deletes */
 		$this->assertFalse( get_option( 'gfpdf_is_installed' ) );
 		$this->assertFalse( get_option( 'gfpdf_current_version' ) );
 		$this->assertFalse( get_option( 'gfpdf_settings' ) );

--- a/tests/phpunit/integration/View/Test_View_Settings.php
+++ b/tests/phpunit/integration/View/Test_View_Settings.php
@@ -67,6 +67,29 @@ class Test_View_Settings extends TestCase {
 		$this->assertArrayNotHasKey( 20, $tabs );
 	}
 
+	public function test_get_available_tabs_hides_license_tab_on_secondary_network_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests only' );
+		}
+
+		$this->data->add_addon( $this->make_addon( 'addon-a' ) );
+
+		/* Primary site: licensing is managed here, so the tab is present */
+		$this->assertContains( 'license', wp_list_pluck( $this->view->get_available_tabs(), 'id' ) );
+
+		/* Pose as a secondary site with Gravity PDF network-activated; only a network option is read, so no real blog is needed */
+		$network_plugins = static function () {
+			return [ PDF_PLUGIN_BASENAME => time() ];
+		};
+		add_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+		switch_to_blog( PHP_INT_MAX );
+
+		$this->assertNotContains( 'license', wp_list_pluck( $this->view->get_available_tabs(), 'id' ) );
+
+		restore_current_blog();
+		remove_filter( 'pre_site_option_active_sitewide_plugins', $network_plugins );
+	}
+
 	public function test_get_available_tabs_adds_extensions_tab_when_addon_implements_interface() {
 		$this->data->add_addon( $this->make_addon( 'addon-a' ) );
 		$this->data->add_addon( $this->make_extension_addon( 'addon-b' ) );

--- a/tools/wp-env/development.json
+++ b/tools/wp-env/development.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.3.zip",
+  "core": "https://wordpress.org/wordpress-7.0.4.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/development.json
+++ b/tools/wp-env/development.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.2.zip",
+  "core": "https://wordpress.org/wordpress-7.0.3.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/e2e.json
+++ b/tools/wp-env/e2e.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.3.zip",
+  "core": "https://wordpress.org/wordpress-7.0.4.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/e2e.json
+++ b/tools/wp-env/e2e.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.2.zip",
+  "core": "https://wordpress.org/wordpress-7.0.3.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/integration.json
+++ b/tools/wp-env/integration.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.3.zip",
+  "core": "https://wordpress.org/wordpress-7.0.4.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/integration.json
+++ b/tools/wp-env/integration.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.2.zip",
+  "core": "https://wordpress.org/wordpress-7.0.3.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {


### PR DESCRIPTION
Automated weekly dependency refresh.

**WordPress core (wp-env configs):** `7.0.2` → `7.0.3`

**Composer packages** — `gravity/gravityforms`

| Package | Before | After |
| --- | --- | --- |
| gravity/gravityforms | `2.10.5` | `3.0.2` |