### PR TITLE
fix: repair the release build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,12 +63,9 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "GFPDF\\Tests\\Concerns\\": "tests/phpunit/Concerns/"
-    },
-    "classmap": [
-      "tests/phpunit/integration/TestCase.php",
-      "tests/phpunit/integration/AjaxTestCase.php"
-    ]
+      "GFPDF\\Tests\\Concerns\\": "tests/phpunit/Concerns/",
+      "GFPDF\\Tests\\Integration\\": "tests/phpunit/integration/"
+    }
   },
   "config": {
     "preferred-install": "dist",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "prebuild:core-fonts": "bash tools/release/json-payload.sh https://api.github.com/repos/GravityPDF/mpdf-core-fonts/contents/ core-fonts.json",
     "i10n": "yarn build && yarn i10n:make-pot && yarn i10n:update-po && yarn i10n:make-mo && yarn i10n:make-json && yarn i10n:make-php",
     "i10n:make-pot": "wp i18n make-pot ./ languages/gravity-pdf.pot --include=pdf.php,api.php,gravity-pdf-updater.php,src,build --exclude=tmp,vendor,vendor_prefixed --domain=gravity-pdf --headers='{\"Report-Msgid-Bugs-To\":\"https://gravitypdf.com\"}'",
-    "i10n:make-json": "wp i18n make-json languages --no-purge",
+    "i10n:make-json": "wp i18n make-json languages",
     "i10n:make-php": "wp i18n make-php languages",
     "i10n:update-po": "wp i18n update-po languages/gravity-pdf.pot languages",
     "i10n:make-mo": "wp i18n make-mo languages",

--- a/tools/release/build.sh
+++ b/tools/release/build.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Abort on the first failure. Without this a broken step (a failed composer install skipping the
+# php-scoper prefix, say) still produced a zip, just one missing half the plugin.
+# No -u: BRANCH is intentionally unset below.
+set -eo pipefail
+
 echo $0 $1
 
 if [ $# -lt 1 ]; then


### PR DESCRIPTION
`tools/release/build.sh` currently produces a broken zip and reports success while doing it. Three separate defects, all pre-existing.

## 1. `composer install` aborts before the php-scoper step

`composer.json`'s `autoload-dev.classmap` points at two files under `tests/`, but `.gitattributes` marks `/tests export-ignore`. The release package is a `git archive`, so those files aren't there:

```
In ClassMapGenerator.php line 136:
  Could not scan for classes inside "tests/phpunit/integration/TestCase.php"
  which does not appear to be a file nor a folder
```

That happens during autoload generation — **before `post-install-cmd`**, so `composer prefix` never runs and `vendor_prefixed/` ships empty. The result is a 1.5MB zip against 4.7MB for a real release, containing a plugin that cannot load mPDF or Monolog.

Both classes are already PSR-4 compliant (`GFPDF\Tests\Integration\` → `tests/phpunit/integration/`), and unlike a classmap a PSR-4 rule tolerates the directory being absent, so the entry moves there.

Introduced by 2228837c (the PHPUnit suite refactor).

## 2. `yarn i10n` fails on `make-json`

`wp i18n make-json languages --no-purge` — WP-CLI no longer accepts `--purge`. It was dropped upstream when `make-json` stopped modifying the source PO files at all, which is exactly what `--no-purge` was asking for. Dropping the flag restores the step; verified the PO files come out byte-identical.

## 3. Neither failure stopped the build

`build.sh` had no `set -e`, so it carried on past both and still zipped an artifact. It has one now. Not `-u` — `BRANCH` is deliberately unset in the `git archive` call on line 23.

## Verification

Before/after against a real `git archive`:

| Base | `composer install` on the archive |
|---|---|
| `development` | fails — `ClassMapGenerator` error above |
| this branch | succeeds, autoloader generated |

A full `build.sh` run with all three fixes applied produces a **5.0MB** zip that passes `unzip -t`, with all 9 scoped packages present, `Mpdf\Tag` correctly prefixed, and no `tools/`, `tests/`, `.github/` or dev dependencies. The complete i18n chain (`make-pot` → `update-po` → `make-mo` → `make-json` → `make-php`) reports success at every step.

That end-to-end run was done with #1696 also applied, because php-scoper 0.15 cannot execute on PHP 8.x — the prefix step can only run locally on PHP 7.4. `deployment.yml` uses PHP 7.4, so the release path is unaffected by that; the two PRs are independent and can merge in either order.

## Note

`yarn i10n` runs without `--cwd`, so it regenerates the *source* repo's `languages/*.po`/`*.mo` rather than the package's, and its output never reaches the archive (already extracted by that point). Left alone here — it changes what ships, so it deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)