### PR TITLE
chore(deps): bump wp-phpunit to 7.0 and refresh composer.lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "phpcompatibility/phpcompatibility-wp": "*",
     "roave/security-advisories": "dev-master",
     "yoast/phpunit-polyfills": "^4.0",
-    "wp-phpunit/wp-phpunit": "^6.4",
+    "wp-phpunit/wp-phpunit": "^7.0",
     "gravity/gravityforms": "*"
   },
   "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45c670075d119a64c3e7b101b78db661",
+    "content-hash": "a9d392aec421b5a279d8935b4eb0fdc2",
     "packages": [
         {
             "name": "gravitypdf/querypath",
@@ -1478,30 +1478,36 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.5",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
-                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PhpParser\\": "lib/PhpParser"
@@ -1523,9 +1529,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.5"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:45:25+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -4782,16 +4788,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.9.5",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0"
+                "reference": "0d17335392d78b12b3e7e6b519cd53db728df52a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/15fd216bf6516670d8d07b938675925bfa5c15b0",
-                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/0d17335392d78b12b3e7e6b519cd53db728df52a",
+                "reference": "0d17335392d78b12b3e7e6b519cd53db728df52a",
                 "shasum": ""
             },
             "type": "library",
@@ -4826,7 +4832,7 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2026-02-04T01:48:23+00:00"
+            "time": "2026-07-10T02:38:55+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",


### PR DESCRIPTION
## Summary

`wp-phpunit/wp-phpunit` was pinned to `^6.4` and resolving to 6.9.5 while every wp-env config now runs WordPress 7.0.4, so the test library was a major version behind the runtime it exercises. This widens the constraint to `^7.0`.

`nikic/php-parser` moves 4.19.5 → 5.8.0 as a side effect. It is a transitive dev dependency of `phpunit/php-code-coverage`, `sebastian/complexity` and `sebastian/lines-of-code`, all of which already allow `^4 || ^5`.

| Package | From | To |
|---|---|---|
| `wp-phpunit/wp-phpunit` | 6.9.5 | 7.0.2 |
| `nikic/php-parser` | v4.19.5 | v5.8.0 |

## What deliberately did not move

- **`roave/security-advisories`** is already locked at the current upstream `master` head (`5f250a5`, verified against `git ls-remote`), and `composer audit` reports no advisories.
- **`squizlabs/php_codesniffer`** 4.0.4 stays out of reach: `wp-coding-standards/wpcs` (`^3.13.5`) and `phpcompatibility/php-compatibility` (`^2.3 || ^3.0.2`) both still cap at PHPCS 3. WPCS 3.4.1 and phpcompatibility-wp 2.1.8 are the newest stable releases of each, so there is no stable path to PHPCS 4 yet.
- **`mpdf/mpdf`** (`dev-development`) — upstream branch has not moved since 2026-06-11.

## php-scoper

`composer prefix` was re-run after the update. This is required after *any* composer operation, since the install reinstates the `vendor/` sources php-scoper strips, leaving prefixed and unprefixed copies of monolog/psr side by side. Output is healthy: 1080 files across the expected nine `vendor_prefixed/` packages.

## Test plan

- [x] `phpunit -c tools/phpunit/config.xml` — 1569 tests, 4921 assertions, 46 skipped, 0 failures
- [x] `phpunit -c tools/phpunit/config-multisite.xml` — 1569 tests, 5017 assertions, 10 skipped, 0 failures, 1 pre-existing risky test (a PHP 8.5 `ReflectionMethod::setAccessible()` deprecation in `Test_EDD_SL_Plugin_Updater`, unrelated to this change)
- [x] `phpcs --standard=./tools/phpcs/config.xml src pdf.php api.php` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)