### PR TITLE
fix: WordPress 7.1 compatibility

### DIFF
--- a/src/Helper/Helper_Abstract_Fields.php
+++ b/src/Helper/Helper_Abstract_Fields.php
@@ -373,7 +373,7 @@ abstract class Helper_Abstract_Fields implements Helper_Interface_Field_Pdf_Conf
 	/**
 	 * Prevent user-data shortcodes from being processed by the PDF templates
 	 *
-	 * @param string $value The text to be converted
+	 * @param string|null $value The text to be converted
 	 *
 	 * @return string
 	 *
@@ -383,7 +383,7 @@ abstract class Helper_Abstract_Fields implements Helper_Interface_Field_Pdf_Conf
 		$find      = [ '[', ']', '{', '}' ];
 		$converted = [ '&#91;', '&#93;', '&#123;', '&#125;' ];
 
-		return str_replace( $find, $converted, $value );
+		return str_replace( $find, $converted, $value ?? '' );
 	}
 
 	/**

--- a/tests/phpunit/integration/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
+++ b/tests/phpunit/integration/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
@@ -929,7 +929,9 @@ class Test_EDD_SL_Plugin_Updater extends TestCase {
 		add_filter( 'pre_site_option_active_sitewide_plugins', $network_filter );
 
 		$method = new \ReflectionMethod( $this->class, 'is_non_active_multisite' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		/* Active on the current site */
 		$active_plugins = [ $plugin ];

--- a/tests/playwright/core/pdf-access/inactive.spec.ts
+++ b/tests/playwright/core/pdf-access/inactive.spec.ts
@@ -58,8 +58,8 @@ test.describe('Advanced Template Checks', () => {
 		const entry = await pdf.createEntry({ form_id: form.id });
 		await pdf.navigateToEntryList(form.id);
 
-		// Entry list selectors might vary, using a common one
-		await page.locator('td.column-primary').first().hover();
+		// WP 7.1 renders the primary column as <th scope="row">; match on the class only
+		await page.locator('.column-primary').first().hover();
 		await expect(
 			page.locator('.gravitypdf-download-link')
 		).not.toBeVisible();
@@ -85,7 +85,7 @@ test.describe('Advanced Template Checks', () => {
 		await pdf.createEntry({ form_id: form.id });
 		await pdf.navigateToEntryList(form.id);
 
-		await page.locator('td.column-primary').first().hover();
+		await page.locator('.column-primary').first().hover();
 		await expect(page.getByText('View PDF')).not.toBeVisible();
 	});
 

--- a/tools/wp-env/e2e.json
+++ b/tools/wp-env/e2e.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.4.zip",
+  "core": "https://wordpress.org/wordpress-7.1-RC3.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/integration.json
+++ b/tools/wp-env/integration.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.4.zip",
+  "core": "https://wordpress.org/wordpress-7.1-RC3.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {


### PR DESCRIPTION
Bumps the integration and e2e wp-env instances to WordPress 7.1-RC3 and fixes what surfaced.

## `WP_List_Table` markup change

WP 7.1 rewrote `WP_List_Table::single_row_columns()` to render the primary column as `<th scope="row">` instead of `<td>` (and flipped the checkbox column the other way, `th` → `td`). Two entry-list assertions in `inactive.spec.ts` matched on `td.column-primary` and stopped resolving. Matching on the class alone works on both 7.0 and 7.1.

This is the only place the change touches us:

- the `.check-column` selectors in `setupAJAXList*.js` and the SCSS are class-only, so they're unaffected
- the plugin's own PDF list is hand-rolled in `src/View/html/FormSettings/list.php` rather than extending `WP_List_Table`

## PHP deprecations

Two unrelated deprecations were being logged on the PHP 8.5 container:

- `Helper_Abstract_Fields::encode_tags()` passes its argument straight to `str_replace()` as the subject, which PHP 8.1+ deprecates when it's null. Coerced with `?? ''` — `str_replace()` already returned `''` for null, so behaviour is unchanged.
- `Test_EDD_SL_Plugin_Updater` called `ReflectionMethod::setAccessible()` without the `PHP_VERSION_ID < 80100` guard that every other call site in the suite uses, which PHP 8.5 deprecates. The call is still needed for the PHP 7.3 floor, so it's guarded rather than removed. This was the multisite suite's only risky test.

## Testing

All green on 7.1-RC3:

| Suite | Result |
|---|---|
| PHPUnit integration | 1569 passed |
| PHPUnit multisite | 1569 passed, no risky tests |
| Playwright e2e | 87 passed |
| Jest | 470 passed |
| PHPCS / ESLint | clean |

## Note on the wp-env core pin

`tools/wp-env/*.json` now point at `wordpress-7.1-RC3.zip`, so CI runs against the RC. This will want re-pinning when 7.1 final ships.

One gotcha for anyone running these suites locally: wp-env's `start` refreshes `~/.wp-env/<hash>/WordPress-PHPUnit/` alongside core. If that directory is left on the old release's test suite, you'll see 11 integration / 12 multisite failures in `Test_Model_Settings` that look exactly like real 7.1 regressions — "Unexpected incorrect usage notice for `WP_Icon_Collections_Registry::register`" on every test that re-fires `do_action( 'init' )`. They're an artifact: WP 7.1's own test suite ships `_unhook_icon_registration()` (`tests/phpunit/includes/functions.php`, hooked to `init` at 1000) for precisely this case. No plugin or test code needed changing for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)