### PR TITLE
Decouple the localised script data from PDF_TEMPLATE_LOCATION

### DIFF
--- a/src/Helper/Helper_Data.php
+++ b/src/Helper/Helper_Data.php
@@ -206,12 +206,14 @@ class Helper_Data {
 	 *
 	 * @param Helper_Abstract_Options $options
 	 * @param Helper_Abstract_Form    $gform
+	 * @param Helper_Templates        $templates
 	 *
 	 * @return array
 	 *
 	 * @since  4.0
+	 * @since  6.17.0 Added the $templates parameter
 	 */
-	public function get_localised_script_data( Helper_Abstract_Options $options, Helper_Abstract_Form $gform ) {
+	public function get_localised_script_data( Helper_Abstract_Options $options, Helper_Abstract_Form $gform, Helper_Templates $templates ) {
 
 		$custom_fonts      = array_values( $options->get_custom_fonts() );
 		$user_data         = get_userdata( get_current_user_id() );
@@ -228,7 +230,7 @@ class Helper_Data {
 				'restUrl'                              => rest_url( 'gravity-pdf/v1/' ),
 				'restNonce'                            => wp_create_nonce( 'wp_rest' ),
 				'currentVersion'                       => PDF_EXTENDED_VERSION,
-				'pdfWorkingDir'                        => PDF_TEMPLATE_LOCATION,
+				'pdfWorkingDir'                        => $templates->get_template_path(),
 				'pluginUrl'                            => PDF_PLUGIN_URL,
 				'pluginPath'                           => PDF_PLUGIN_DIR,
 				'customFontData'                       => wp_json_encode( $custom_fonts ),

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -446,7 +446,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 			add_filter( 'tiny_mce_before_init', [ $this, 'tinymce_styles' ] );
 
 			/* Localise admin script */
-			$data = $this->data->get_localised_script_data( $this->options, $this->gform );
+			$data = $this->data->get_localised_script_data( $this->options, $this->gform, $this->templates );
 
 			wp_localize_script( 'gfpdf_js_entrypoint', 'GFPDF', $data );
 			wp_localize_script( 'gfpdf_js_settings', 'GFPDF', $data );

--- a/tests/phpunit/integration/Helper/Test_Helper_Data.php
+++ b/tests/phpunit/integration/Helper/Test_Helper_Data.php
@@ -154,7 +154,7 @@ class Test_Helper_Data extends TestCase {
 	public function test_localised_script() {
 		global $gfpdf;
 
-		$localised_data = $this->data->get_localised_script_data( $gfpdf->options, $gfpdf->gform );
+		$localised_data = $this->data->get_localised_script_data( $gfpdf->options, $gfpdf->gform, $gfpdf->templates );
 		$required_keys  = [
 			'ajaxUrl',
 			'ajaxNonce',
@@ -168,6 +168,10 @@ class Test_Helper_Data extends TestCase {
 		foreach ( $required_keys as $key ) {
 			$this->assertArrayHasKey( $key, $localised_data );
 		}
+
+		/* The React Template Manager compares this against each template path to decide if it can be deleted */
+		$working_dir = is_multisite() ? $gfpdf->data->multisite_template_location : $gfpdf->data->template_location;
+		$this->assertSame( $working_dir, $localised_data['pdfWorkingDir'] );
 	}
 
 	public function test_get_conditional_logic_options() {


### PR DESCRIPTION
Phase 1 of the [7.0 deprecated code removal plan](https://github.com/GravityPDF/gravity-pdf/pull/1695) — non-breaking, ships in 6.17.

`Helper_Data::get_localised_script_data()` sourced `pdfWorkingDir` from the v3 `PDF_TEMPLATE_LOCATION` constant, which is defined inside `src/deprecated.php`. That made a file slated for deletion in 7.0 load-bearing for the React Template Manager: `pdfWorkingDir` is what `TemplateFooterActions::notCoreTemplate()` compares each template path against to decide whether the delete button renders.

The constant is defined as `Helper_Templates::get_template_path()`, so the helper is now passed into `get_localised_script_data()` and called directly. The value is byte-identical on both single and multisite, and is no longer frozen at `after_setup_theme`.

`GFPDF_Core::setup_constants()` still defines all four v3 constants for third parties — those go in Phase 2 alongside the rest of `src/deprecated.php`.

### Notes

- `get_localised_script_data()` gains a third required parameter. The only caller is `Router::load_admin_assets()`; add-ons extend this data through the documented `gfpdf_localised_script_array` filter, not by calling the method.
- `PDF_TEMPLATE_LOCATION` now has no remaining consumer in `src/`.

### Testing

- `Test_Helper_Data::test_localised_script` now asserts `pdfWorkingDir` resolves to the working directory (multisite-aware) rather than only checking the key exists.
- Full integration suite green (1569 tests); multisite `Test_Helper_Data` green.
- `TemplateFooterActions` Jest suite green — the JS contract is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)