### PR TITLE
chore(deps): weekly bump of WordPress core + Gravity Forms

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1466,10 +1466,10 @@
         },
         {
             "name": "gravity/gravityforms",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.gravity.io/downloads/?plugin=gravityforms&version=3.0.2"
+                "url": "https://composer.gravity.io/downloads/?plugin=gravityforms&version=3.0.3"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/tools/wp-env/development.json
+++ b/tools/wp-env/development.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.0.4.zip",
+  "core": "https://wordpress.org/wordpress-7.1.zip",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {


### PR DESCRIPTION
Automated weekly dependency refresh.

**WordPress core (wp-env configs):** `` → `7.1`

**Composer packages** — `gravity/gravityforms`

| Package | Before | After |
| --- | --- | --- |
| gravity/gravityforms | `3.0.2` | `3.0.3` |